### PR TITLE
Fix/sinclair tweak

### DIFF
--- a/backend/dbtools/sortgender.go
+++ b/backend/dbtools/sortgender.go
@@ -14,12 +14,12 @@ func SortGender(bigData [][]string) (male []structs.Entry, female []structs.Entr
 		gender := setGender(&dataStruct)
 		switch gender {
 		case enum.Male:
-			if dataStruct.Total > 0 && dataStruct.Bodyweight > 0 {
+			if dataStruct.Total > 0 && dataStruct.Total < enum.MaxTotal && dataStruct.Bodyweight > enum.MinimumBodyweight {
 				sinclair.CalcSinclair(&dataStruct, true)
 			}
 			male = append(male, dataStruct)
 		case enum.Female:
-			if dataStruct.Total > 0 && dataStruct.Bodyweight > 0 {
+			if dataStruct.Total > 0 && dataStruct.Total < enum.MaxTotal && dataStruct.Bodyweight > enum.MinimumBodyweight {
 				sinclair.CalcSinclair(&dataStruct, false)
 			}
 			female = append(female, dataStruct)

--- a/backend/dbtools/sortgender.go
+++ b/backend/dbtools/sortgender.go
@@ -5,7 +5,6 @@ import (
 	"backend/sinclair"
 	"backend/structs"
 	"regexp"
-	"strconv"
 )
 
 // SortGender Splits results into 3 categories, male, female, and unknown.
@@ -54,23 +53,21 @@ func regGenderCheck(entry *structs.Entry) (gender string) {
 }
 
 func assignStruct(line []string) (lineStruct structs.Entry) {
-	floatTotal, _ := strconv.ParseFloat(line[13], 32)
-	floatBodyweight, _ := strconv.ParseFloat(line[4], 32)
 	lineStruct = structs.Entry{
 		Event:      line[0],
 		Date:       line[1],
 		Gender:     line[2],
 		Name:       line[3],
-		Bodyweight: float32(floatBodyweight),
-		Sn1:        line[5],
-		Sn2:        line[6],
-		Sn3:        line[7],
-		CJ1:        line[8],
-		CJ2:        line[9],
-		CJ3:        line[10],
-		BestSn:     line[11],
-		BestCJ:     line[12],
-		Total:      float32(floatTotal),
+		Bodyweight: Float(line[4]),
+		Sn1:        Float(line[5]),
+		Sn2:        Float(line[6]),
+		Sn3:        Float(line[7]),
+		CJ1:        Float(line[8]),
+		CJ2:        Float(line[9]),
+		CJ3:        Float(line[10]),
+		BestSn:     Float(line[11]),
+		BestCJ:     Float(line[12]),
+		Total:      Float(line[13]),
 		Sinclair:   0.0,
 		Federation: line[14],
 	}

--- a/backend/dbtools/utilities.go
+++ b/backend/dbtools/utilities.go
@@ -6,8 +6,17 @@ import (
 	"log"
 	"os"
 	"path"
+	"strconv"
 )
 
+//Float - Converts a string containing a float32 to exactly that
+func Float(preFloatStr string) (retFloat float32) {
+	convFloat, _ := strconv.ParseFloat(preFloatStr, 32)
+	retFloat = float32(convFloat)
+	return
+}
+
+//Contains - Returns true if a substring within a string exists
 func Contains(sl []string, name string) bool {
 	for _, value := range sl {
 		if value == name {

--- a/backend/enum/enums.go
+++ b/backend/enum/enums.go
@@ -1,9 +1,11 @@
 package enum
 
 const (
-	Male     string = "male"
-	Female   string = "female"
-	Unknown  string = "unknown"
-	Total    string = "total"
-	Sinclair string = "sinclair"
+	Male              string  = "male"
+	Female            string  = "female"
+	Unknown           string  = "unknown"
+	Total             string  = "total"
+	Sinclair          string  = "sinclair"
+	MaxTotal          float32 = 510
+	MinimumBodyweight float32 = 20
 )

--- a/backend/sinclair/sinclair.go
+++ b/backend/sinclair/sinclair.go
@@ -7,10 +7,12 @@ import (
 
 // Coefficient numbers
 const (
-	aMale   = 0.751945030
-	bMale   = 175.508
-	aFemale = 0.783497476
-	bFemale = 153.655
+	aMale        = 0.751945030
+	bMale        = 175.508
+	aFemale      = 0.783497476
+	bFemale      = 153.655
+	naimSinclair = 505 + 1 // The extra 1 is for rounding etc.
+	minBW        = 20      // KG, nobody is breaking records at that weight
 )
 
 // CalcSinclair Calculates the sinclair of a result passed to it. We are using ONLY the Senior coefficient because
@@ -23,13 +25,16 @@ func CalcSinclair(result *structs.Entry, male bool) {
 		coEffA = aFemale
 		coEffB = bFemale
 	}
-	if result.Total != 0 && result.Bodyweight >= 0 {
+	if result.Total != 0 && result.Bodyweight > minBW {
 		if float64(result.Bodyweight) <= coEffB {
 			var X = math.Log10(float64(result.Bodyweight) / coEffB)
 			var expX = math.Pow(X, 2)
 			var coEffExp = coEffA * expX
 			var expSum = math.Pow(10, coEffExp)
-			result.Sinclair = float32(float64(result.Total) * expSum)
+			var sinclair = float32(float64(result.Total) * expSum)
+			if sinclair <= naimSinclair {
+				result.Sinclair = sinclair
+			}
 		} else {
 			result.Sinclair = result.Total
 		}

--- a/backend/structs/structs.go
+++ b/backend/structs/structs.go
@@ -22,14 +22,14 @@ type Entry struct {
 	Gender     string  `json:"gender"`
 	Name       string  `json:"lifter_name"`
 	Bodyweight float32 `json:"bodyweight"`
-	Sn1        string  `json:"snatch_1"`
-	Sn2        string  `json:"snatch_2"`
-	Sn3        string  `json:"snatch_3"`
-	CJ1        string  `json:"cj_1"`
-	CJ2        string  `json:"cj_2"`
-	CJ3        string  `json:"cj_3"`
-	BestSn     string  `json:"best_snatch"`
-	BestCJ     string  `json:"best_cj"`
+	Sn1        float32 `json:"snatch_1"`
+	Sn2        float32 `json:"snatch_2"`
+	Sn3        float32 `json:"snatch_3"`
+	CJ1        float32 `json:"cj_1"`
+	CJ2        float32 `json:"cj_2"`
+	CJ3        float32 `json:"cj_3"`
+	BestSn     float32 `json:"best_snatch"`
+	BestCJ     float32 `json:"best_cj"`
 	Total      float32 `json:"total"`
 	Sinclair   float32 `json:"sinclair"`
 	Federation string  `json:"country"`


### PR DESCRIPTION
Due to a lot of bogus data entry by event organisers, there's a few impossible scores slipping through into both the sinclair and total leaderboards.

This PR is to discard those scores on generation instead of altering those events manually.