### PR TITLE
Added minimum character limit

### DIFF
--- a/backend/serverMain.go
+++ b/backend/serverMain.go
@@ -23,10 +23,12 @@ func getTest(c *gin.Context) {
 }
 
 func getSearchName(c *gin.Context) {
-	search := structs.NameSearch{NameStr: c.Query("name")}
-	suggestions := lifter.NameSearch(search.NameStr, &processedLeaderboard.AllNames)
-	results := structs.NameSearchResults{Names: processedLeaderboard.FetchNames(suggestions)}
-	c.JSON(http.StatusOK, results)
+	if len(c.Query("name")) >= 3 {
+		search := structs.NameSearch{NameStr: c.Query("name")}
+		suggestions := lifter.NameSearch(search.NameStr, &processedLeaderboard.AllNames)
+		results := structs.NameSearchResults{Names: processedLeaderboard.FetchNames(suggestions)}
+		c.JSON(http.StatusOK, results)
+	}
 }
 
 func postLifterRecord(c *gin.Context) {


### PR DESCRIPTION
Lifter name search endpoint didn't have a name limit so it would result in spamming the endpoint initially.

This imposes a 3 character limit to the endpoint.