### PR TITLE
Feature/add total results

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -110,7 +110,7 @@ func postLeaderboard(c *gin.Context) {
 	}
 
 	leaderboardData := processedLeaderboard.Select(body.SortBy) // Selects either total or sinclair sorted leaderboard
-	fedData := dbtools.Filter(*leaderboardData, body, dbtools.WeightClassList[body.WeightClass], &QueryCache)
+	fedData := dbtools.FilterLifts(*leaderboardData, body, dbtools.WeightClassList[body.WeightClass], &QueryCache)
 	c.JSON(http.StatusOK, fedData)
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -22,6 +22,8 @@ var processedLeaderboard structs.LeaderboardData
 
 var lifterData = lifter.Build()
 
+var QueryCache dbtools.QueryCache
+
 func getTest(c *gin.Context) {
 	hour, min, sec := time.Now().Clock()
 	retStruct := structs.TestPayload{Hour: hour, Min: min, Sec: sec}
@@ -108,7 +110,7 @@ func postLeaderboard(c *gin.Context) {
 	}
 
 	leaderboardData := processedLeaderboard.Select(body.SortBy) // Selects either total or sinclair sorted leaderboard
-	fedData := dbtools.Filter(*leaderboardData, body, dbtools.WeightClassList[body.WeightClass], *lifterData)
+	fedData := dbtools.Filter(*leaderboardData, body, dbtools.WeightClassList[body.WeightClass], &QueryCache)
 	c.JSON(http.StatusOK, fedData)
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -25,8 +25,8 @@ var processedLeaderboard structs.LeaderboardData
 var QueryCache dbtools.QueryCache
 
 func getTest(c *gin.Context) {
-	hour, min, sec := time.Now().Clock()
-	retStruct := structs.TestPayload{Hour: hour, Min: min, Sec: sec}
+	hour, mins, sec := time.Now().Clock()
+	retStruct := structs.TestPayload{Hour: hour, Min: mins, Sec: sec}
 	c.JSON(http.StatusOK, retStruct)
 }
 

--- a/backend/dbtools/cache_handler.go
+++ b/backend/dbtools/cache_handler.go
@@ -1,33 +1,26 @@
 package dbtools
 
+import "backend/structs"
+
 type QueryCache struct {
 	Store []Query
 }
 
 type Query struct {
-	Filter        StrippedPayload
+	Filter        structs.LeaderboardPayload
 	DataPositions []int
 }
 
-type StrippedPayload struct {
-	SortBy      string
-	Federation  string
-	WeightClass string
-	Year        int
-	StartDate   string
-	EndDate     string
-}
-
 // AddQuery - Adds a query to the cache.
-func (q *QueryCache) AddQuery(query StrippedPayload, dataPositions []int) {
+func (q *QueryCache) AddQuery(query structs.LeaderboardPayload, dataPositions []int) {
 	q.Store = append(q.Store, Query{Filter: query, DataPositions: dataPositions})
 }
 
 // CheckQuery - Checks if the query has been run before, if so, return the data positions.
-func (q *QueryCache) CheckQuery(query StrippedPayload) (bool, []int) {
-	for _, c := range q.Store {
-		if c.Filter == query {
-			return true, c.DataPositions
+func (q *QueryCache) CheckQuery(query structs.LeaderboardPayload) (bool, []int) {
+	for _, cacheQuery := range q.Store {
+		if cacheQuery.Filter.SortBy == query.SortBy && cacheQuery.Filter.Federation == query.Federation && cacheQuery.Filter.WeightClass == query.WeightClass && cacheQuery.Filter.StartDate == query.StartDate && cacheQuery.Filter.EndDate == query.EndDate {
+			return true, cacheQuery.DataPositions
 		}
 	}
 	return false, nil

--- a/backend/dbtools/cache_handler.go
+++ b/backend/dbtools/cache_handler.go
@@ -1,6 +1,8 @@
 package dbtools
 
-import "backend/structs"
+import (
+	"backend/structs"
+)
 
 type QueryCache struct {
 	Store []Query

--- a/backend/dbtools/cache_handler.go
+++ b/backend/dbtools/cache_handler.go
@@ -1,0 +1,34 @@
+package dbtools
+
+type QueryCache struct {
+	Store []Query
+}
+
+type Query struct {
+	Filter        StrippedPayload
+	DataPositions []int
+}
+
+type StrippedPayload struct {
+	SortBy      string
+	Federation  string
+	WeightClass string
+	Year        int
+	StartDate   string
+	EndDate     string
+}
+
+// AddQuery - Adds a query to the cache.
+func (q *QueryCache) AddQuery(query StrippedPayload, dataPositions []int) {
+	q.Store = append(q.Store, Query{Filter: query, DataPositions: dataPositions})
+}
+
+// CheckQuery - Checks if the query has been run before, if so, return the data positions.
+func (q *QueryCache) CheckQuery(query StrippedPayload) (bool, []int) {
+	for _, c := range q.Store {
+		if c.Filter == query {
+			return true, c.DataPositions
+		}
+	}
+	return false, nil
+}

--- a/backend/dbtools/cache_handler_test.go
+++ b/backend/dbtools/cache_handler_test.go
@@ -1,17 +1,63 @@
 package dbtools
 
-import "testing"
+import (
+	"backend/structs"
+	"testing"
+)
 
-func TestCompareStructs(t *testing.T) {
-	type TestOne struct {
-		One int
-		Two string
+func TestQueryCache_AddQuery(t *testing.T) {
+	type fields struct {
+		Store []Query
 	}
+	type args struct {
+		query         structs.LeaderboardPayload
+		dataPositions []int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{"AddQuery", fields{Store: []Query{}}, args{query: structs.LeaderboardPayload{}, dataPositions: []int{1}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &QueryCache{
+				Store: tt.fields.Store,
+			}
+			q.AddQuery(tt.args.query, tt.args.dataPositions)
+		})
+	}
+}
 
-	testOne := TestOne{One: 1, Two: "two"}
-	testTwo := TestOne{One: 1, Two: "two"}
-
-	if testOne != testTwo {
-		t.Errorf("Structs are not equal")
+func TestQueryCache_CheckQuery(t *testing.T) {
+	type fields struct {
+		Store []Query
+	}
+	type args struct {
+		query structs.LeaderboardPayload
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+		want1  []int
+	}{
+		{"CheckQuery", fields{Store: []Query{{Filter: structs.LeaderboardPayload{SortBy: "total", Federation: "IPF", WeightClass: "93", StartDate: "2018-01-01", EndDate: "2018-01-01"}, DataPositions: []int{1}}}}, args{query: structs.LeaderboardPayload{SortBy: "total", Federation: "IPF", WeightClass: "93", StartDate: "2018-01-01", EndDate: "2018-01-01"}}, true, []int{1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &QueryCache{
+				Store: tt.fields.Store,
+			}
+			got, got1 := q.CheckQuery(tt.args.query)
+			if got != tt.want {
+				t.Errorf("QueryCache.CheckQuery() got = %v, want %v", got, tt.want)
+			}
+			if len(got1) != len(tt.want1) {
+				t.Errorf("QueryCache.CheckQuery() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
 	}
 }

--- a/backend/dbtools/cache_handler_test.go
+++ b/backend/dbtools/cache_handler_test.go
@@ -1,0 +1,17 @@
+package dbtools
+
+import "testing"
+
+func TestCompareStructs(t *testing.T) {
+	type TestOne struct {
+		One int
+		Two string
+	}
+
+	testOne := TestOne{One: 1, Two: "two"}
+	testTwo := TestOne{One: 1, Two: "two"}
+
+	if testOne != testTwo {
+		t.Errorf("Structs are not equal")
+	}
+}

--- a/backend/dbtools/dbtools_test.go
+++ b/backend/dbtools/dbtools_test.go
@@ -42,22 +42,41 @@ func TestCollateAll(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	type args struct {
-		bigData        []structs.Entry
-		filterQuery    structs.LeaderboardPayload
-		weightCat      structs.WeightClass
-		lifterProfiles map[string]string
+		bigData     []structs.Entry
+		filterQuery structs.LeaderboardPayload
+		weightCat   string
 	}
 	tests := []struct {
 		name             string
 		args             args
-		wantFilteredData []structs.Entry
+		wantFilteredData structs.LeaderboardResponse
 	}{
-		// todo: Add test cases.
-		{},
+		{
+			name: "FilterByFederation",
+			args: args{
+				bigData: []structs.Entry{{Date: "2023-06-01", Name: "John Smith", Total: 100, Federation: "BWL", Gender: enum.Male, Bodyweight: 109.00}, {Date: "2023-06-01", Name: "Dave Smith", Total: 200, Federation: "BWL", Gender: enum.Male, Bodyweight: 109.00}, {Date: "2023-06-01", Name: "Ethan Smith", Total: 300, Federation: "BWL", Gender: enum.Male, Bodyweight: 109.00}},
+				filterQuery: structs.LeaderboardPayload{
+					Start:       0,
+					Stop:        10,
+					SortBy:      enum.Total,
+					Federation:  enum.ALLFEDS,
+					WeightClass: "MALL",
+					Year:        69,
+					StartDate:   "2023-01-01",
+					EndDate:     "2024-01-01",
+				},
+				weightCat: "MALL",
+			},
+			wantFilteredData: structs.LeaderboardResponse{
+				Size: 3,
+				Data: []structs.Entry{{Date: "2023-06-01", Name: "John Smith", Total: 100, Federation: "BWL", Gender: enum.Male, Bodyweight: 109.00}, {Date: "2023-06-01", Name: "Dave Smith", Total: 200, Federation: "BWL", Gender: enum.Male, Bodyweight: 109.00}, {Date: "2023-06-01", Name: "Ethan Smith", Total: 300, Federation: "BWL", Gender: enum.Male, Bodyweight: 109.00}},
+			},
+		},
 	}
+	var cache QueryCache
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotFilteredData := Filter(tt.args.bigData, tt.args.filterQuery, tt.args.weightCat, tt.args.lifterProfiles); !reflect.DeepEqual(gotFilteredData, tt.wantFilteredData) {
+			if gotFilteredData := Filter(tt.args.bigData, tt.args.filterQuery, WeightClassList[tt.args.weightCat], &cache); !reflect.DeepEqual(gotFilteredData, tt.wantFilteredData) {
 				t.Errorf("Filter() = %v, want %v", gotFilteredData, tt.wantFilteredData)
 			}
 		})
@@ -268,26 +287,6 @@ func Test_loadAllFedEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if gotAllEvents := loadAllFedEvents(tt.args.federation); !reflect.DeepEqual(reflect.TypeOf(gotAllEvents), reflect.TypeOf(tt.wantAllEvents)) {
 				t.Errorf("loadAllFedEvents() = %v, want %v", gotAllEvents, reflect.TypeOf(tt.wantAllEvents))
-			}
-		})
-	}
-}
-
-func Test_removeFollowingLifts(t *testing.T) {
-	type args struct {
-		bigData []structs.Entry
-	}
-	tests := []struct {
-		name             string
-		args             args
-		wantFilteredData []structs.Entry
-	}{
-		{name: "RemoveFollowingLifts", args: args{bigData: []structs.Entry{{Name: "John Smith", Total: 100}, {Name: "John Smith", Total: 200}, {Name: "John Smith", Total: 300}}}, wantFilteredData: []structs.Entry{{Name: "John Smith", Total: 100}}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotFilteredData := removeFollowingLifts(tt.args.bigData); !reflect.DeepEqual(gotFilteredData, tt.wantFilteredData) {
-				t.Errorf("removeFollowingLifts() = %v, want %v", gotFilteredData, tt.wantFilteredData)
 			}
 		})
 	}

--- a/backend/dbtools/dbtools_test.go
+++ b/backend/dbtools/dbtools_test.go
@@ -76,8 +76,8 @@ func TestFilter(t *testing.T) {
 	var cache QueryCache
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotFilteredData := Filter(tt.args.bigData, tt.args.filterQuery, WeightClassList[tt.args.weightCat], &cache); !reflect.DeepEqual(gotFilteredData, tt.wantFilteredData) {
-				t.Errorf("Filter() = %v, want %v", gotFilteredData, tt.wantFilteredData)
+			if gotFilteredData := FilterLifts(tt.args.bigData, tt.args.filterQuery, WeightClassList[tt.args.weightCat], &cache); !reflect.DeepEqual(gotFilteredData, tt.wantFilteredData) {
+				t.Errorf("FilterLifts() = %v, want %v", gotFilteredData, tt.wantFilteredData)
 			}
 		})
 	}

--- a/backend/dbtools/precache.go
+++ b/backend/dbtools/precache.go
@@ -1,0 +1,38 @@
+package dbtools
+
+import (
+	"backend/enum"
+	"backend/structs"
+)
+
+// PreCacheQuery - Queries to pre-cache on startup.
+var PreCacheQuery = []structs.LeaderboardPayload{
+	{
+		SortBy:      "total",
+		Federation:  "allfeds",
+		WeightClass: "MALL",
+		StartDate:   enum.ZeroDate,
+		EndDate:     enum.MaxDate,
+	},
+	{
+		SortBy:      "total",
+		Federation:  "allfeds",
+		WeightClass: "FALL",
+		StartDate:   enum.ZeroDate,
+		EndDate:     enum.MaxDate,
+	},
+	{
+		SortBy:      "sinclair",
+		Federation:  "allfeds",
+		WeightClass: "MALL",
+		StartDate:   enum.ZeroDate,
+		EndDate:     enum.MaxDate,
+	},
+	{
+		SortBy:      "sinclair",
+		Federation:  "allfeds",
+		WeightClass: "FALL",
+		StartDate:   enum.ZeroDate,
+		EndDate:     enum.MaxDate,
+	},
+}

--- a/backend/dbtools/sortby.go
+++ b/backend/dbtools/sortby.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-// Filter - Returns a slice of structs relating to the selected filter selection
-func Filter(bigData []structs.Entry, filterQuery structs.LeaderboardPayload, weightCat structs.WeightClass, cache *QueryCache) (filteredData structs.LeaderboardResponse) {
+// FilterLifts - Returns a slice of structs relating to the selected filter selection
+func FilterLifts(bigData []structs.Entry, filterQuery structs.LeaderboardPayload, weightCat structs.WeightClass, cache *QueryCache) (filteredData structs.LeaderboardResponse) {
 	exists, positions := cache.CheckQuery(filterQuery)
 
 	if exists {

--- a/backend/dbtools/sortby.go
+++ b/backend/dbtools/sortby.go
@@ -26,17 +26,10 @@ func removeFollowingLifts(bigData []structs.Entry) (filteredData []structs.Entry
 
 // Filter - Returns a slice of structs relating to the selected filter selection
 func Filter(bigData []structs.Entry, filterQuery structs.LeaderboardPayload, weightCat structs.WeightClass, cache *QueryCache) (filteredData structs.LeaderboardResponse) {
-	exists, liftPositions := cache.CheckQuery(StrippedPayload{
-		SortBy:      filterQuery.SortBy,
-		Federation:  filterQuery.Federation,
-		WeightClass: filterQuery.WeightClass,
-		Year:        filterQuery.Year,
-		StartDate:   filterQuery.StartDate,
-		EndDate:     filterQuery.EndDate,
-	})
+	exists, liftPositions := cache.CheckQuery(filterQuery)
 
 	if exists {
-		log.Println("Cache hit!")
+		log.Println("Cache hit")
 		filteredData.Data, filteredData.Size = fetchLifts(&bigData, liftPositions, filterQuery.Start, filterQuery.Stop)
 		return
 	}
@@ -51,14 +44,7 @@ func Filter(bigData []structs.Entry, filterQuery structs.LeaderboardPayload, wei
 		}
 	}
 
-	cache.AddQuery(StrippedPayload{
-		SortBy:      filterQuery.SortBy,
-		Federation:  filterQuery.Federation,
-		WeightClass: filterQuery.WeightClass,
-		Year:        filterQuery.Year,
-		StartDate:   filterQuery.StartDate,
-		EndDate:     filterQuery.EndDate,
-	}, liftPostions)
+	cache.AddQuery(filterQuery, liftPostions)
 
 	filteredData.Data, filteredData.Size = fetchLifts(&bigData, liftPostions, filterQuery.Start, filterQuery.Stop)
 	return
@@ -66,9 +52,11 @@ func Filter(bigData []structs.Entry, filterQuery structs.LeaderboardPayload, wei
 
 // fetchLifts - Returns a slice of structs relating to the selected filter selection, it will also remove any duplicate entries.
 func fetchLifts(bigData *[]structs.Entry, pos []int, start int, stop int) (lifts []structs.Entry, size int) {
+	log.Println("Fetching...")
 	for _, p := range pos {
 		lifts = append(lifts, (*bigData)[p])
 	}
+	log.Println("Removing dupies")
 	lifts = removeFollowingLifts(lifts)
 
 	if stop > len(lifts) {
@@ -81,7 +69,7 @@ func fetchLifts(bigData *[]structs.Entry, pos []int, start int, stop int) (lifts
 
 	size = len(lifts)
 	lifts = lifts[start:stop]
-
+	log.Println("Fetched")
 	return
 }
 

--- a/backend/dbtools/sortby.go
+++ b/backend/dbtools/sortby.go
@@ -8,22 +8,6 @@ import (
 	"time"
 )
 
-func removeFollowingLifts(bigData []structs.Entry, pos *[]int) (filteredData []structs.Entry) {
-	var names []string
-	var position []int
-	// todo: refactor this so it's faster / more efficient
-	for i, d := range bigData {
-		if !utilities.Contains(names, d.Name) {
-			position = append(position, i)
-			names = append(names, d.Name)
-		}
-	}
-	for _, posInt := range position {
-		filteredData = append(filteredData, bigData[posInt])
-	}
-	return
-}
-
 // Filter - Returns a slice of structs relating to the selected filter selection
 func Filter(bigData []structs.Entry, filterQuery structs.LeaderboardPayload, weightCat structs.WeightClass, cache *QueryCache) (filteredData structs.LeaderboardResponse) {
 	exists, positions := cache.CheckQuery(filterQuery)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module backend
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gin-contrib/cors v1.4.0

--- a/backend/structs/structs.go
+++ b/backend/structs/structs.go
@@ -77,3 +77,8 @@ type Entry struct {
 	Federation string  `json:"country"`
 	Instagram  string  `json:"instagram"`
 }
+
+type LeaderboardResponse struct {
+	Size int     `json:"size"`
+	Data []Entry `json:"data"`
+}


### PR DESCRIPTION
Major breaking change to the leaderboard API endpoint to allow for the total amount of lifters to be known in a filter query.

Schema:
```
{
    "size": int,
    "data": [{lift_data_1}, {lift_data_2}, {lift_data_etc}],
}
```