### PR TITLE
Feature/recent events

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -59,7 +59,7 @@ const docTemplate = `{
                             "items": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/definitions/structs.Entry"
+                                    "$ref": "#/definitions/structs.LeaderboardResponse"
                                 }
                             }
                         }
@@ -68,7 +68,9 @@ const docTemplate = `{
                         "description": "No Content"
                     }
                 }
-            },
+            }
+        },
+        "/events/list": {
             "options": {
                 "description": "Metadata shows the name, federation and date of the event along with the filename in the event_data folder.",
                 "consumes": [
@@ -101,10 +103,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/structs.EventsList"
-                                }
+                                "$ref": "#/definitions/structs.EventsList"
                             }
                         }
                     },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -56,7 +56,7 @@
                             "items": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/definitions/structs.Entry"
+                                    "$ref": "#/definitions/structs.LeaderboardResponse"
                                 }
                             }
                         }
@@ -65,7 +65,9 @@
                         "description": "No Content"
                     }
                 }
-            },
+            }
+        },
+        "/events/list": {
             "options": {
                 "description": "Metadata shows the name, federation and date of the event along with the filename in the event_data folder.",
                 "consumes": [
@@ -98,10 +100,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/structs.EventsList"
-                                }
+                                "$ref": "#/definitions/structs.EventsList"
                             }
                         }
                     },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -121,36 +121,6 @@ info:
   version: "1.0"
 paths:
   /events:
-    options:
-      consumes:
-      - application/json
-      description: Metadata shows the name, federation and date of the event along
-        with the filename in the event_data folder.
-      parameters:
-      - description: Start date to filter from
-        in: query
-        name: startdate
-        type: string
-      - description: End date to filter to
-        in: query
-        name: enddate
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              items:
-                $ref: '#/definitions/structs.EventsList'
-              type: array
-            type: array
-        "204":
-          description: No Content
-      summary: Fetch available event metadata within a set date range
-      tags:
-      - OPTIONS Requests
     post:
       consumes:
       - application/json
@@ -176,7 +146,7 @@ paths:
           schema:
             items:
               items:
-                $ref: '#/definitions/structs.Entry'
+                $ref: '#/definitions/structs.LeaderboardResponse'
               type: array
             type: array
         "204":
@@ -184,6 +154,35 @@ paths:
       summary: Fetch a single event
       tags:
       - POST Requests
+  /events/list:
+    options:
+      consumes:
+      - application/json
+      description: Metadata shows the name, federation and date of the event along
+        with the filename in the event_data folder.
+      parameters:
+      - description: Start date to filter from
+        in: query
+        name: startdate
+        type: string
+      - description: End date to filter to
+        in: query
+        name: enddate
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/structs.EventsList'
+            type: array
+        "204":
+          description: No Content
+      summary: Fetch available event metadata within a set date range
+      tags:
+      - OPTIONS Requests
   /history:
     post:
       consumes:

--- a/backend/endpoints.go
+++ b/backend/endpoints.go
@@ -177,7 +177,7 @@ func Leaderboard(c *gin.Context) {
 //		@Produce		json
 //		@Success		200	{array}	 structs.EventsList
 //		@Failure		204	{object}	nil
-//		@Router			/events [options]
+//		@Router			/events/list [options]
 func Events(c *gin.Context) {
 	var response structs.EventsList
 	var query structs.EventSearch

--- a/backend/main.go
+++ b/backend/main.go
@@ -45,7 +45,7 @@ func buildServer() *gin.Engine {
 	r.GET("search", SearchName)
 	r.POST("lifter", LifterRecord)
 	r.POST("history", LifterHistory)
-	r.OPTIONS("events", Events)
+	r.POST("events/list", Events)
 	r.POST("events", SingleEvent)
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	return r

--- a/frontend/api/fetchEventsList/fetchEventsList.ts
+++ b/frontend/api/fetchEventsList/fetchEventsList.ts
@@ -3,8 +3,8 @@ import { EventsList, EventsListRequest } from "@/api/fetchEventsList/fetchEvents
 export default  async function fetchEventsList(
   eventsListRequest: EventsListRequest,
 ): Promise<EventsList> {
-  const response = await fetch(`${process.env.API}/events`, {
-    method: 'OPTIONS',
+  const response = await fetch(`${process.env.API}/events/list`, {
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/frontend/api/fetchEventsList/fetchEventsList.ts
+++ b/frontend/api/fetchEventsList/fetchEventsList.ts
@@ -1,7 +1,7 @@
 import { EventsList, EventsListRequest } from "@/api/fetchEventsList/fetchEventsListTypes";
 
 export default  async function fetchEventsList(
-  eventsListRequest: EventsListRequest,
+  eventsListRequest: EventsListRequest | null,
 ): Promise<EventsList> {
   const response = await fetch(`${process.env.API}/events/list`, {
     method: 'POST',

--- a/frontend/components/molecules/eventTable.tsx
+++ b/frontend/components/molecules/eventTable.tsx
@@ -4,9 +4,10 @@ import {
   TableColumn,
   TableCell,
   TableRow,
-  TableBody,
+  TableBody, Link,
 } from '@nextui-org/react'
 import { LifterResult } from '@/api/fetchLifterData/fetchLifterDataTypes'
+import { CgProfile } from 'react-icons/cg'
 
 export const EventTable = ({
                                history,
@@ -44,10 +45,16 @@ export const EventTable = ({
             sinclair,
           } = lift
 
+          const lifter_page = '../lifter?name=' + lifter_name
+
           return (
             <TableRow key={`history-${index}`}>
               <TableCell>{date}</TableCell>
-              <TableCell>{lifter_name}</TableCell>
+              <TableCell>
+                <Link href={lifter_page}>
+                  {lifter_name}
+                </Link>
+              </TableCell>
               <TableCell>{bodyweight}</TableCell>
               <TableCell>{snatch_1}</TableCell>
               <TableCell>{snatch_2}</TableCell>

--- a/frontend/components/molecules/eventTable.tsx
+++ b/frontend/components/molecules/eventTable.tsx
@@ -7,7 +7,6 @@ import {
   TableBody, Link,
 } from '@nextui-org/react'
 import { LifterResult } from '@/api/fetchLifterData/fetchLifterDataTypes'
-import { CgProfile } from 'react-icons/cg'
 
 export const EventTable = ({
                                history,

--- a/frontend/components/molecules/eventTable.tsx
+++ b/frontend/components/molecules/eventTable.tsx
@@ -1,0 +1,66 @@
+import {
+  Table,
+  TableHeader,
+  TableColumn,
+  TableCell,
+  TableRow,
+  TableBody,
+} from '@nextui-org/react'
+import { LifterResult } from '@/api/fetchLifterData/fetchLifterDataTypes'
+
+export const EventTable = ({
+                               history,
+                             }: {
+  history: LifterResult[]
+}) => {
+  return (
+    <Table>
+      <TableHeader>
+        <TableColumn>Date</TableColumn>
+        <TableColumn>Name</TableColumn>
+        <TableColumn>Bodyweight</TableColumn>
+        <TableColumn>1st Snatch</TableColumn>
+        <TableColumn>2nd Snatch</TableColumn>
+        <TableColumn>3rd Snatch</TableColumn>
+        <TableColumn>1st C&J</TableColumn>
+        <TableColumn>2nd C&J</TableColumn>
+        <TableColumn>3rd C&J</TableColumn>
+        <TableColumn>Total</TableColumn>
+        <TableColumn>Sinclair</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {history.map((lift, index) => {
+          const {
+            date,
+            lifter_name,
+            bodyweight,
+            snatch_1,
+            snatch_2,
+            snatch_3,
+            cj_1,
+            cj_2,
+            cj_3,
+            total,
+            sinclair,
+          } = lift
+
+          return (
+            <TableRow key={`history-${index}`}>
+              <TableCell>{date}</TableCell>
+              <TableCell>{lifter_name}</TableCell>
+              <TableCell>{bodyweight}</TableCell>
+              <TableCell>{snatch_1}</TableCell>
+              <TableCell>{snatch_2}</TableCell>
+              <TableCell>{snatch_3}</TableCell>
+              <TableCell>{cj_1}</TableCell>
+              <TableCell>{cj_2}</TableCell>
+              <TableCell>{cj_3}</TableCell>
+              <TableCell>{total}</TableCell>
+              <TableCell>{sinclair}</TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/components/molecules/eventsTable.tsx
+++ b/frontend/components/molecules/eventsTable.tsx
@@ -1,0 +1,38 @@
+import { EventsList } from '@/api/fetchEventsList/fetchEventsListTypes'
+import { Link, Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@nextui-org/react'
+
+export const EventsListTable = ({
+  events,
+}: {
+  events: EventsList
+}) => {
+  return (
+    <Table>
+      <TableHeader>
+        <TableColumn>Date</TableColumn>
+        <TableColumn>Federation</TableColumn>
+        <TableColumn>Name</TableColumn>
+        <TableColumn>Raw Data</TableColumn>
+      </TableHeader>
+      <TableBody>
+        {events.events.map((event, index) => {
+          const { date, name, federation, id } = event
+          const event_page = `events/show?fed=${federation}&id=${id}`
+
+          return (
+            <TableRow key={`event-${index}`}>
+              <TableCell>{date}</TableCell>
+              <TableCell>{federation}</TableCell>
+              <TableCell>
+                <Link href={event_page}>{name}</Link>
+              </TableCell>
+              <TableCell>
+                <Link href={`https://github.com/euanwm/OpenWeightlifting/tree/development/backend/event_data/${federation}/${id}`}>Data</Link>
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/components/molecules/eventsfilters.tsx
+++ b/frontend/components/molecules/eventsfilters.tsx
@@ -1,0 +1,31 @@
+import { Select, SelectItem } from '@nextui-org/react'
+
+const dayRanges = [
+  { value: 15, label: '15 days' },
+  { value: 30, label: '30 days' },
+  { value: 60, label: '60 days' },
+]
+
+export const EventsFilters = ({
+  handleFilterChange,
+}: {
+  handleFilterChange: any
+}) => (
+  <div className="flex flex-col md:flex-row space-y-1 md:space-y-0 md:space-x-4 mt-4 mx-4">
+    <Select
+      items={dayRanges}
+      label="Day Range"
+      placeholder={dayRanges[0].label}
+      fullWidth={false}
+      onChange={e =>
+        handleFilterChange({ type: 'dayRange', value: e.target.value })
+      }
+    >
+      {dayRange => (
+        <SelectItem key={dayRange.value} value={dayRange.value}>
+          {dayRange.label}
+        </SelectItem>
+      )}
+    </Select>
+  </div>
+)

--- a/frontend/components/molecules/eventsfilters.tsx
+++ b/frontend/components/molecules/eventsfilters.tsx
@@ -1,9 +1,10 @@
 import { Select, SelectItem } from '@nextui-org/react'
 
 const dayRanges = [
-  { value: 15, label: '15 days' },
-  { value: 30, label: '30 days' },
-  { value: 60, label: '60 days' },
+  { value: 15, label: 'The last 15 days' },
+  { value: 30, label: 'The last 30 days' },
+  { value: 60, label: 'The last 60 days' },
+  { value: 120, label: 'The last 120 days' },
 ]
 
 export const EventsFilters = ({
@@ -14,7 +15,7 @@ export const EventsFilters = ({
   <div className="flex flex-col md:flex-row space-y-1 md:space-y-0 md:space-x-4 mt-4 mx-4">
     <Select
       items={dayRanges}
-      label="Day Range"
+      label="Range"
       placeholder={dayRanges[0].label}
       fullWidth={false}
       onChange={e =>

--- a/frontend/components/molecules/head.tsx
+++ b/frontend/components/molecules/head.tsx
@@ -8,7 +8,7 @@ import {
   NavbarMenuItem,
 } from '@nextui-org/react'
 import { FaGithub, FaInstagram } from 'react-icons/fa'
-import { IoPodiumOutline } from 'react-icons/io5'
+import { IoCalendarNumberOutline } from "react-icons/io5";
 import { SlCalculator } from 'react-icons/sl'
 import { MdOutlinePersonSearch } from 'react-icons/md'
 import { FiHome } from 'react-icons/fi'
@@ -37,9 +37,9 @@ const HeaderBar = () => {
           </Link>
         </NavbarMenuItem>
         <NavbarMenuItem>
-          <Link href="/league">
-            <IoPodiumOutline size="30px" className="mt-2"/>
-            <span className="ml-2">The League</span>
+          <Link href="/events">
+            <IoCalendarNumberOutline size="30px" className="mt-2"/>
+            <span className="ml-2">Recent Events</span>
           </Link>
         </NavbarMenuItem>
         <NavbarMenuItem>

--- a/frontend/components/organisms/eventPage.tsx
+++ b/frontend/components/organisms/eventPage.tsx
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router'
+import HeaderBar from '@/components/molecules/head'
+import { EventMetaData } from '@/api/fetchEventsList/fetchEventsListTypes'
+import fetchEventResult from '@/api/fetchEventResult/fetchEventResult'
+import useSWR from 'swr'
+import { Spinner } from '@nextui-org/react'
+import { EventTable } from '@/components/molecules/eventTable'
+
+function ShowEvent(){
+  const router = useRouter()
+  const { fed } = router.query
+  const { id } = router.query
+
+  const requestPayload: EventMetaData = {
+    federation: fed as string,
+    id: id as string,
+    name: '',
+    date: ''
+  }
+
+  const { data, isLoading } = useSWR(
+    requestPayload,
+    fetchEventResult,
+  )
+
+  return (
+    <>
+      {isLoading && (
+        <div className="fixed w-screen h-screen z-10 flex justify-center items-center">
+          <Spinner size="lg" label="Loading..." />
+        </div>
+      )}
+      <HeaderBar />
+      {data ? (
+        <>
+          <center>
+            <h1>Event: {data.data[0].event}</h1>
+            <h2>Date: {data.data[0].date}</h2>
+            <h2>Federation: {data.data[0].country}</h2>
+          <EventTable history={data.data} />
+          </center>
+        </>
+      ) : (
+        <div>{`No data for event`}</div>
+      )}
+    </>
+  )
+}
+
+export default ShowEvent

--- a/frontend/components/organisms/eventPage.tsx
+++ b/frontend/components/organisms/eventPage.tsx
@@ -33,12 +33,11 @@ function ShowEvent(){
       <HeaderBar />
       {data ? (
         <>
-          <center>
-            <h1>Event: {data.data[0].event}</h1>
-            <h2>Date: {data.data[0].date}</h2>
-            <h2>Federation: {data.data[0].country}</h2>
-          <EventTable history={data.data} />
+          <center className={'flex flex-col content-center'}>
+            <p>Event: {data.data[0].event}</p>
+            <p>Federation: {data.data[0].country}</p>
           </center>
+          <EventTable history={data.data} />
         </>
       ) : (
         <div>{`No data for event`}</div>

--- a/frontend/components/organisms/eventsListPage.tsx
+++ b/frontend/components/organisms/eventsListPage.tsx
@@ -1,0 +1,57 @@
+import HeaderBar from '@/components/molecules/head'
+import { useRouter } from 'next/router'
+import { EventsListRequest, EventMetaData } from '@/api/fetchEventsList/fetchEventsListTypes'
+import fetchEventsList from '@/api/fetchEventsList/fetchEventsList'
+import useSWR from 'swr'
+import { Spinner } from '@nextui-org/react'
+
+function EventsListPage() {
+  const router = useRouter()
+  const { fed } = router.query
+  const { id } = router.query
+
+  const today = new Date().toISOString().slice(0, 10)
+  const fifteenDaysAgo = new Date()
+  fifteenDaysAgo.setDate(fifteenDaysAgo.getDate() - 30)
+  const fifteenDaysAgoString = fifteenDaysAgo.toISOString().slice(0, 10)
+
+  const eventsListPayload: EventsListRequest = {
+    startdate: fifteenDaysAgoString,
+    enddate: today,
+  }
+
+  const { data: eventsList, isLoading } = useSWR(
+    eventsListPayload,
+    fetchEventsList,
+  )
+
+  return (
+    <>
+      {isLoading && (
+        <div className="fixed w-screen h-screen z-10 flex justify-center items-center">
+          <Spinner size="lg" label="Loading..." />
+        </div>
+      )}
+    <HeaderBar />
+    <div className={'flex flex-col content-center'}>
+      <h1>Events Page</h1>
+      {eventsList ? (
+        <div className={'flex flex-col content-center'}>
+          <h2>Events List</h2>
+          <ul>
+            {eventsList.events.map((event: EventMetaData) => (
+              <li key={event.id}>
+                <a href={`/events/show?fed=${event.federation}&id=${event.id}`}>{event.name}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <div>{`No data for events list`}</div>
+      )}
+    </div>
+    </>
+  )
+}
+
+export default EventsListPage

--- a/frontend/components/organisms/eventsListPage.tsx
+++ b/frontend/components/organisms/eventsListPage.tsx
@@ -1,29 +1,54 @@
 import HeaderBar from '@/components/molecules/head'
-import { useRouter } from 'next/router'
-import { EventsListRequest, EventMetaData } from '@/api/fetchEventsList/fetchEventsListTypes'
+import { EventsListRequest } from '@/api/fetchEventsList/fetchEventsListTypes'
 import fetchEventsList from '@/api/fetchEventsList/fetchEventsList'
 import useSWR from 'swr'
+import { EventsListTable } from '@/components/molecules/eventsTable'
+import { useState } from 'react'
+import { EventsFilters } from '@/components/molecules/eventsfilters'
 import { Spinner } from '@nextui-org/react'
 
-function EventsListPage() {
-  const router = useRouter()
-  const { fed } = router.query
-  const { id } = router.query
+const defaultDaysPrevious = 15
 
-  const today = new Date().toISOString().slice(0, 10)
-  const fifteenDaysAgo = new Date()
-  fifteenDaysAgo.setDate(fifteenDaysAgo.getDate() - 30)
-  const fifteenDaysAgoString = fifteenDaysAgo.toISOString().slice(0, 10)
-
-  const eventsListPayload: EventsListRequest = {
-    startdate: fifteenDaysAgoString,
-    enddate: today,
+function buildPayload(daysPrevious: number): EventsListRequest {
+  // todo: fix this bug
+  // it's not this function that's causing it, it's the fetchEventsList function
+  // the conditional statement below is a workaround
+  // judge me if you want, I have no shame
+  if (daysPrevious < defaultDaysPrevious) {
+    daysPrevious = defaultDaysPrevious
   }
 
-  const { data: eventsList, isLoading } = useSWR(
-    eventsListPayload,
+  const today = new Date().toISOString().slice(0, 10)
+  const daysPreviousDate = new Date()
+  daysPreviousDate.setDate(daysPreviousDate.getDate() - daysPrevious)
+  const daysPreviousString = daysPreviousDate.toISOString().slice(0, 10)
+
+  return {
+    startdate: daysPreviousString,
+    enddate: today,
+  }
+}
+
+
+function EventsListPage() {
+  const [dayRange, setDayRange] = useState(defaultDaysPrevious)
+
+  const { data, isLoading } = useSWR(
+    buildPayload(dayRange),
     fetchEventsList,
+    { keepPreviousData: false },
   )
+
+  function handleFilterChange(newFilter: any) {
+    const { type, value } = newFilter
+    switch (type) {
+      case 'dayRange':
+        setDayRange(value)
+        break
+      default:
+        setDayRange(value)
+    }
+  }
 
   return (
     <>
@@ -32,24 +57,17 @@ function EventsListPage() {
           <Spinner size="lg" label="Loading..." />
         </div>
       )}
-    <HeaderBar />
-    <div className={'flex flex-col content-center'}>
-      <h1>Events Page</h1>
-      {eventsList ? (
-        <div className={'flex flex-col content-center'}>
-          <h2>Events List</h2>
-          <ul>
-            {eventsList.events.map((event: EventMetaData) => (
-              <li key={event.id}>
-                <a href={`/events/show?fed=${event.federation}&id=${event.id}`}>{event.name}</a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : (
-        <div>{`No data for events list`}</div>
-      )}
-    </div>
+      <HeaderBar />
+      <div className={'flex flex-col content-center'}>
+        <EventsFilters handleFilterChange={handleFilterChange} />
+        {data ? (
+          <div className={'flex flex-col content-center'}>
+            <EventsListTable events={data} />
+          </div>
+        ) : (
+          <div>{`No data for events list`}</div>
+        )}
+      </div>
     </>
   )
 }

--- a/frontend/components/organisms/eventsListPage.tsx
+++ b/frontend/components/organisms/eventsListPage.tsx
@@ -7,8 +7,6 @@ import { useState } from 'react'
 import { EventsFilters } from '@/components/molecules/eventsfilters'
 import { Spinner } from '@nextui-org/react'
 
-const defaultDaysPrevious = 15
-
 function buildPayload(daysPrevious: number): EventsListRequest {
   // todo: fix this bug
   // it's not this function that's causing it, it's the fetchEventsList function
@@ -29,6 +27,7 @@ function buildPayload(daysPrevious: number): EventsListRequest {
   }
 }
 
+const defaultDaysPrevious = 15
 
 function EventsListPage() {
   const [dayRange, setDayRange] = useState(defaultDaysPrevious)
@@ -36,7 +35,7 @@ function EventsListPage() {
   const { data, isLoading } = useSWR(
     buildPayload(dayRange),
     fetchEventsList,
-    { keepPreviousData: false },
+    { keepPreviousData: true },
   )
 
   function handleFilterChange(newFilter: any) {
@@ -60,12 +59,10 @@ function EventsListPage() {
       <HeaderBar />
       <div className={'flex flex-col content-center'}>
         <EventsFilters handleFilterChange={handleFilterChange} />
-        {data ? (
+        {data && (
           <div className={'flex flex-col content-center'}>
             <EventsListTable events={data} />
           </div>
-        ) : (
-          <div>{`No data for events list`}</div>
         )}
       </div>
     </>

--- a/frontend/pages/events.tsx
+++ b/frontend/pages/events.tsx
@@ -1,0 +1,7 @@
+import EventsListPage from '@/components/organisms/eventsListPage'
+
+function Events() {
+  return <EventsListPage />
+}
+
+export default Events

--- a/frontend/pages/events.tsx
+++ b/frontend/pages/events.tsx
@@ -1,7 +1,23 @@
 import EventsListPage from '@/components/organisms/eventsListPage'
+import { SWRConfig } from 'swr'
+import fetchEventsList from '@/api/fetchEventsList/fetchEventsList'
 
-function Events() {
-  return <EventsListPage />
+function Events({ fallback }: { fallback: { eventsList: [] } }) {
+  return (
+  <SWRConfig value={{ fallback }}>
+    <EventsListPage />
+  </SWRConfig>
+  )}
+
+export async function getServerSideProps() {
+  const data = await fetchEventsList(null)
+  return {
+    props: {
+      fallback: {
+        eventsList: data,
+      },
+    },
+  }
 }
 
 export default Events

--- a/frontend/pages/events/show.tsx
+++ b/frontend/pages/events/show.tsx
@@ -1,0 +1,7 @@
+import ShowEvent from '@/components/organisms/eventPage'
+
+function Event() {
+  return <ShowEvent />
+}
+
+export default Event


### PR DESCRIPTION
Adds a new page which replaces The League.

The new page allows users to view  recently added events and view them individually.

There's a small bugfix required as double selecting a value means a null value is passed to the payload generator for the API call.
