### PR TITLE
Quick fix for U10/U13 athletes best lifts in France Db

### DIFF
--- a/python_tools/database_handler/france.py
+++ b/python_tools/database_handler/france.py
@@ -303,8 +303,8 @@ class FranceInterface(DBInterface):
             cj_1=float(result.cj_1),
             cj_2=float(result.cj_2),
             cj_3=float(result.cj_3),
-            best_snatch=float(result.best_snatch),
-            best_cj=float(result.best_cj),
+            best_snatch=max(float(result.snatch_1), float(result.snatch_2), float(result.snatch_3)),
+            best_cj=max(float(result.cj_1), float(result.cj_2), float(result.cj_3)),
             total=float(result.total),
         )
         return amal_data


### PR DESCRIPTION
In France, for U10/U13 athletes, Snatch or C&J is calculated with the sum of the 2 heaviest made attempts (it's also considered a bomb out when they make 1/3). Therefore total and Sinclair is calculated on the sum of 2+2 lifts for them.

![image](https://github.com/euanwm/OpenWeightlifting/assets/127698154/4d2973ea-9641-4361-b460-083be5825051)

![image](https://github.com/euanwm/OpenWeightlifting/assets/127698154/27f2ec7d-0393-465c-9c83-b4aaaf37c3a0)

This fix recalculates every athletes best snatch / clean & jerk with the actual heaviest made attempt.