### PR TITLE
Add floor of 0.0 for best_snatch, best_cj, and total

### DIFF
--- a/python_tools/database_handler/norway.py
+++ b/python_tools/database_handler/norway.py
@@ -117,17 +117,20 @@ class Norway:
     @staticmethod
     def __best_snatch(result: Result) -> float:
         """ Returns the best snatch """
-        return max(result.snatch_1, result.snatch_2, result.snatch_3)
+        return max(0.0, result.snatch_1, result.snatch_2, result.snatch_3)
 
     @staticmethod
     def __best_cj(result: Result) -> float:
         """ Returns the best cj """
-        return max(result.cj_1, result.cj_2, result.cj_3)
+        return max(0.0, result.cj_1, result.cj_2, result.cj_3)
 
     @staticmethod
     def __calc_total(result: Result) -> float:
         """ Returns the total """
-        return result.best_snatch + result.best_cj
+        if result.best_snatch == 0 or result.best_cj == 0:
+            return 0.0
+        else:
+            return result.best_snatch + result.best_cj
 
     @staticmethod
     def __todays_date():


### PR DESCRIPTION
Added a floor of 0.0 for best_snatch and best_cj properties. Also added a conditional to the total that returns either 1) 0.0 if either best_snatch or best_cj are 0.0, or 2) the sum of best_snatch and best_cj. Pulled event 444 and confirmed that it matches the data on the NVF website (https://resultater.vektlofting.no/stevner/444) 