### PR TITLE
fix/nvf scraper fails

### DIFF
--- a/event_data/NVF/641.csv
+++ b/event_data/NVF/641.csv
@@ -1,0 +1,15 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 49Kg,Emine Tefre Grønnevik,49,-35,35,37,-47,47,52,37,52,89
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 49Kg,Heidi Nævdal,49,40,-43,-43,46,49,51,40,51,91
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 45Kg,Ingrid Emilie Haugland,45,23,25,27,27,29,-32,27,29,56
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 45Kg,Ingrid Skag Skjefstad,45,28,-30,30,35,38,-40,30,38,68
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 59Kg,Lea Berge Jensen,59,-56,57,-59,69,-73,-73,57,69,126
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 59Kg,Lilje Kristine M. Røyseth,59,45,48,-50,63,-66,66,48,66,114
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 17 55Kg,Mathea Dypvik Kvaale,55,33,35,37,43,45,47,37,47,84
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 17 55Kg,Monika Øvrebø,55,33,36,-38,-37,37,42,36,42,78
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 59Kg,Nora Kristine Haugland,59,-40,40,43,48,51,53,43,53,96
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Junior Under 20 55Kg,Ronja Lenvik,55,74,76,78,90,-92,-92,78,90,168
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Junior Under 20 59Kg,Sandra Nævdal,59,67,-70,70,80,84,87,70,87,157
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 59Kg,Sandra Viktoria N. Amundsen,59,57,60,64,70,-73,75,64,75,139
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 15 59Kg,Veslemøy Susort Toskedal,59,-38,-38,38,50,-54,55,38,55,93
+Hitra VK Norgesmesterskap Junior,2024-04-20,Women's Youth Under 17 55Kg,Vilma Kornelie Hetle,55,41,43,45,54,57,60,45,60,105

--- a/event_data/NVF/642.csv
+++ b/event_data/NVF/642.csv
@@ -1,0 +1,4 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Oslo AK Seriestevne,2024-04-24,Men's Masters (55-59) 96Kg,Lars-Thomas Grønlien,96,70,75,-80,85,90,95,75,95,170
+Oslo AK Seriestevne,2024-04-24,Men's Masters (50-54) +109kg,Cornelius Wiedswang,109,-50,50,55,70,75,-80,55,75,130
+Oslo AK Seriestevne,2024-04-24,Women's Masters (40-44) 71Kg,Aurora Foss,71,37,39,41,50,54,-57,41,54,95

--- a/event_data/NVF/643.csv
+++ b/event_data/NVF/643.csv
@@ -1,0 +1,9 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Hitra VK Seriestevne,2024-04-24,Women's Youth Under 15 45Kg,Solveig Olsen,45,21,23,25,28,30,-32,25,30,55
+Hitra VK Seriestevne,2024-04-24,Men's Youth Under 17 67Kg,Martin Christoffer Nordgård,67,32,35,37,37,41,45,37,45,82
+Hitra VK Seriestevne,2024-04-24,Men's Youth Under 15 49Kg,Steffen Svebak Mastad,49,15,17,-19,20,22,23,17,23,40
+Hitra VK Seriestevne,2024-04-24,Men's Youth Under 17 67Kg,Henrik Eskerod,67,27,30,-32,-32,34,36,30,36,66
+Hitra VK Seriestevne,2024-04-24,Men's Youth Under 15 61Kg,Theo Svankild Darell,61,23,25,27,27,30,32,27,32,59
+Hitra VK Seriestevne,2024-04-24,Men's Youth Under 15 55Kg,Emil Røvik,55,29,32,-35,32,35,38,32,38,70
+Hitra VK Seriestevne,2024-04-24,Women's Youth Under 15 45Kg,Natali Siska,45,-16,16,-19,24,26,28,16,28,44
+Hitra VK Seriestevne,2024-04-24,Men's Youth Under 17 67Kg,Lennart Hafsmo Vitsø,67,27,31,35,37,41,45,35,45,80

--- a/event_data/NVF/644.csv
+++ b/event_data/NVF/644.csv
@@ -1,0 +1,7 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Vigrestad IK Seriestevne,2024-04-24,Men's Senior 109+Kg,Hans Gunnar Kvadsheim,999,120,125,-130,150,-156,-156,125,150,275
+Vigrestad IK Seriestevne,2024-04-24,Men's Youth Under 17 81Kg,Sondre K. Friestad,81,64,67,-70,75,80,-82,67,80,147
+Vigrestad IK Seriestevne,2024-04-24,Men's Masters (65-69) 89Kg,Vidar Sæland,89,-66,66,-72,85,92,-100,66,92,158
+Vigrestad IK Seriestevne,2024-04-24,Men's Youth Under 17 102+Kg,Oliver Andre Håland Stokkeland,998,55,-60,-60,55,-60,-60,55,55,110
+Vigrestad IK Seriestevne,2024-04-24,Men's Youth Under 17 81Kg,Nawat Mangmee,81,70,75,-80,90,93,-95,75,93,168
+Vigrestad IK Seriestevne,2024-04-24,Men's Youth Under 17 102+Kg,Kåre Jan Hansen,102,-45,50,-55,-60,-60,60,50,60,110

--- a/event_data/NVF/645.csv
+++ b/event_data/NVF/645.csv
@@ -1,0 +1,4 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Stavanger AK Seriestevne,2024-04-25,Men's Masters (55-59) 89Kg,Dag A Klinkenberg,89,70,-75,75,85,90,-93,75,90,165
+Stavanger AK Seriestevne,2024-04-25,Men's Masters (65-69) 109+Kg,Bernt Petter Andersen,109,60,65,-70,80,85,90,65,90,155
+Stavanger AK Seriestevne,2024-04-25,Men's Senior 89Kg,Sondre Andersen Gysland,89,95,-100,100,120,125,-127,100,125,225

--- a/event_data/NVF/646.csv
+++ b/event_data/NVF/646.csv
@@ -1,0 +1,9 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Trondheim AK Seriestevne,2024-04-27,Women's Senior 64Kg,Hanna Økland,64,50,52,54,60,63,65,54,65,119
+Trondheim AK Seriestevne,2024-04-27,Men's Masters (40-44) 102Kg,Magnus Mikalsen,102,70,75,78,90,95,100,78,100,178
+Trondheim AK Seriestevne,2024-04-27,Men's Senior 89Kg,Torbjørn Øverås,89,90,95,100,115,120,125,100,125,225
+Trondheim AK Seriestevne,2024-04-27,Men's Masters (75-79) 96kg,Reidar Vårvik,96,35,40,45,45,50,-55,45,50,95
+Trondheim AK Seriestevne,2024-04-27,Women's Senior 81Kg,Sarah Mari Sande,81,59,-61,-61,76,79,-81,59,79,138
+Trondheim AK Seriestevne,2024-04-27,Men's Masters (80+) 109Kg,Jan Olav Nystrøm,109,43,45,-46,64,66,-68,45,66,111
+Trondheim AK Seriestevne,2024-04-27,Men's Youth Under 15 61Kg,Hauk Gulbrandsen,61,35,38,-40,47,-50,52,38,52,90
+Trondheim AK Seriestevne,2024-04-27,Men's Youth Under 15 49Kg,Marlon Gulbrandsen,49,22,24,-26,28,30,32,24,32,56

--- a/event_data/NVF/647.csv
+++ b/event_data/NVF/647.csv
@@ -1,0 +1,3 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Spydeberg Atletene Seriestevne,2024-04-27,Men's Masters (55-59) 96Kg,Lars-Thomas Grønlien,96,75,80,0,95,100,0,80,100,180
+Spydeberg Atletene Seriestevne,2024-04-27,Men's Masters (70-74) 96kg,Johan Thonerud,96,60,0,0,78,0,0,60,78,138

--- a/event_data/NVF/648.csv
+++ b/event_data/NVF/648.csv
@@ -1,0 +1,12 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Stavanger AK Seriestevne,2024-04-27,Men's Senior 96Kg,Lars Espedal,96,99,102,-105,-120,120,-126,102,120,222
+Stavanger AK Seriestevne,2024-04-27,Women's Masters (50-54) 64Kg,Anita Kristoffersen,64,37,-41,-41,45,49,-50,37,49,86
+Stavanger AK Seriestevne,2024-04-27,Women's Masters (40-44) 71Kg,Anna Szigeti,71,60,62,64,68,70,-73,64,70,134
+Stavanger AK Seriestevne,2024-04-27,Women's Masters (50-54) 64Kg,Jorunn Alvilde Meling,64,25,27,-28,-35,-35,-35,27,0.0,0.0
+Stavanger AK Seriestevne,2024-04-27,Men's Masters (45-49) 89Kg,Yngve Sundt,89,65,70,75,95,100,-105,75,100,175
+Stavanger AK Seriestevne,2024-04-27,Women's Youth Under 15 64Kg,Mia Wensberg,64,42,44,-46,52,-54,54,44,54,98
+Stavanger AK Seriestevne,2024-04-27,Women's Masters (45-49) 76Kg,Andrea Wensberg,76,-35,37,-41,50,52,54,37,54,91
+Stavanger AK Seriestevne,2024-04-27,Men's Masters (55-59) 89Kg,Jan Gunnar Reke,89,50,55,58,65,70,75,58,75,133
+Stavanger AK Seriestevne,2024-04-27,Men's Youth Under 15 49Kg,Marius Blålid,49,-15,15,17,15,17,23,17,23,40
+Stavanger AK Seriestevne,2024-04-27,Women's Youth Under 15 64Kg,Lilli Wensberg,64,15,17,19,15,17,23,19,23,42
+Stavanger AK Seriestevne,2024-04-27,Men's Youth Under 17 81Kg,Jakub Ragnar Szigeti,81,37,40,45,68,75,80,45,80,125

--- a/event_data/NVF/649.csv
+++ b/event_data/NVF/649.csv
@@ -1,0 +1,8 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Christiania AK Seriestevne,2024-04-28,Men's Senior 96Kg,Emil André Sætran,96,71,74,-76,89,93,-95,74,93,167
+Christiania AK Seriestevne,2024-04-28,Men's Masters (35-39) 73Kg,Mauricio Kjeldner,73,-87,-92,-92,110,-115,-115,0.0,110,0.0
+Christiania AK Seriestevne,2024-04-28,Women's Senior 59Kg,Evelina Galaibo,59,56,59,-62,73,76,-80,59,76,135
+Christiania AK Seriestevne,2024-04-28,Women's Masters (55-59) +87kg,Rita Alnes,87,-48,50,53,60,-66,66,53,66,119
+Christiania AK Seriestevne,2024-04-28,Women's Masters (40-44) 64Kg,Camilla Pedersen,64,46,48,50,60,-65,-66,50,60,110
+Christiania AK Seriestevne,2024-04-28,Men's Senior 96Kg,Julius Ellertsson,96,117,-121,-121,147,-152,152,117,152,269
+Christiania AK Seriestevne,2024-04-28,Women's Masters (40-44) 71Kg,Mirjana Milosevic,71,31,-33,-33,36,39,41,31,41,72

--- a/event_data/NVF/650.csv
+++ b/event_data/NVF/650.csv
@@ -1,0 +1,4 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Vigrestad IK Seriestevne,2024-04-28,Men's Senior 109+Kg,Tord Gravdal,999,121,-127,-127,151,-156,-156,121,151,272
+Vigrestad IK Seriestevne,2024-04-28,Women's Youth Under 17 71Kg,Ingeborg Liland,71,46,48,50,58,61,64,50,64,114
+Vigrestad IK Seriestevne,2024-04-28,Women's Masters (40-44) 76Kg,Cecilie Waland,76,52,56,-60,78,80,-82,56,80,136

--- a/event_data/NVF/651.csv
+++ b/event_data/NVF/651.csv
@@ -1,0 +1,4 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Spydeberg Atletene Seriestevne,2024-04-28,Men's Senior 81Kg,Simen Nerkvern,81,45,55,0,75,85,95,55,95,150
+Spydeberg Atletene Seriestevne,2024-04-28,Men's Senior 102Kg,Mikael Kristiansen,102,75,-81,81,-105,105,111,81,111,192
+Spydeberg Atletene Seriestevne,2024-04-28,Men's Masters (35-39) 109+Kg,John Anders Terland,999,95,100,108,120,125,-130,108,125,233

--- a/event_data/NVF/654.csv
+++ b/event_data/NVF/654.csv
@@ -1,0 +1,13 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Junior Under 20 81Kg,Aksel Lykkebø Svorstøl,81,90,-95,-95,115,122,125,90,125,215
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Masters (60-64) 89Kg,Jørn Helgheim,89,50,53,56,60,65,70,56,70,126
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Masters (50-54) 89Kg,Odd Gunnar Røyseth,89,80,85,90,100,105,0,90,105,195
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Youth Under 17 67Kg,Erik Orasmäe,67,73,76,78,85,90,-93,78,90,168
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Youth Under 17 81Kg,Andreas Kvamsås Savland,81,-72,72,-75,81,85,-89,72,85,157
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Youth Under 17 96Kg,Mathias Birkeland,96,55,-60,60,77,82,86,60,86,146
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Youth Under 17 89Kg,Olai Slagstad Aamot,89,77,81,-85,107,-112,-115,81,107,188
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Junior Under 20 96Kg,Jakub Karol Kudyba,96,90,-94,94,115,-120,-122,94,115,209
+Tambarskjelvar IL Seriestevne,2024-04-25,Women's Youth Under 15 49Kg,Live Thune Vaulen,49,22,25,-26,32,36,-39,25,36,61
+Tambarskjelvar IL Seriestevne,2024-04-25,Women's Youth Under 15 40Kg,Tina Sægrov,40,21,-23,-23,24,26,28,21,28,49
+Tambarskjelvar IL Seriestevne,2024-04-25,Men's Youth Under 17 73Kg,Lyder Slagstad Aamot,73,-58,58,-61,68,-72,-72,58,68,126
+Tambarskjelvar IL Seriestevne,2024-04-25,Women's Youth Under 15 49Kg,Emine Tefre Grønnevik,49,-38,38,40,49,-52,-52,40,49,89

--- a/event_data/NVF/655.csv
+++ b/event_data/NVF/655.csv
@@ -1,0 +1,2 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Namsos VK Seriestevne,2024-04-25,Men's Masters (50-54) 89Kg,Bjørn Tore Wiik,89,84,-88,-91,100,105,-109,84,105,189

--- a/event_data/NVF/656.csv
+++ b/event_data/NVF/656.csv
@@ -1,0 +1,5 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Grenland Atletklubb Seriestevne,2024-04-29,Women's Youth Under 15 59Kg,Ingvild Holm,59,45,-48,48,53,-57,-57,48,53,101
+Grenland Atletklubb Seriestevne,2024-04-29,Men's Senior 96Kg,Mats Olsen,96,113,116,-120,140,-145,145,116,145,261
+Grenland Atletklubb Seriestevne,2024-04-29,Women's Senior 76Kg,Lotte Marie Gule Andervik,76,52,55,57,68,72,-75,57,72,129
+Grenland Atletklubb Seriestevne,2024-04-29,Women's Senior 55Kg,Susanne Arntsen Christoffersen,55,50,-53,-53,63,65,0,50,65,115

--- a/event_data/NVF/657.csv
+++ b/event_data/NVF/657.csv
@@ -1,0 +1,5 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Tønsberg-Kam. Seriestevne,2024-04-26,Women's Senior 87+Kg,Heidi Johansen,997,65,-68,-69,83,-87,-88,65,83,148
+Tønsberg-Kam. Seriestevne,2024-04-26,Women's Masters (35-39) 55Kg,Vibeke Carlsen,55,53,56,58,65,68,70,58,70,128
+Tønsberg-Kam. Seriestevne,2024-04-26,Men's Senior 102Kg,Tarjei Breivik,102,115,-119,-120,110,0,0,115,110,225
+Tønsberg-Kam. Seriestevne,2024-04-26,Women's Senior 64Kg,Oda Wiig,64,63,65,68,83,85,-88,68,85,153

--- a/event_data/NVF/658.csv
+++ b/event_data/NVF/658.csv
@@ -1,0 +1,2 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Nidelv IL Seriestevne,2024-04-29,Men's Masters (80+) 81kg,Kåre Sagmyr,81,38,-43,-43,45,48,-50,38,48,86

--- a/event_data/NVF/659.csv
+++ b/event_data/NVF/659.csv
@@ -1,0 +1,5 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Tromsø AK Seriestevne,2024-05-12,Women's Masters (45-49) 87+Kg,Maria Israelsson,997,40,44,-48,-52,53,-55,44,53,97
+Tromsø AK Seriestevne,2024-05-12,Women's Masters (45-49) 87+Kg,Ingvild Bratterud,87,50,53,56,70,73,-75,56,73,129
+Tromsø AK Seriestevne,2024-05-12,Women's Masters (55-59) 55Kg,Eva Bjørkeng,59,44,47,50,54,57,60,50,60,110
+Tromsø AK Seriestevne,2024-05-12,Men's Senior 96Kg,Thomas Nilsen,96,63,66,-69,78,82,-86,66,82,148

--- a/event_data/NVF/660.csv
+++ b/event_data/NVF/660.csv
@@ -1,0 +1,9 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+T&IL National Seriestevne,2024-05-13,Men's Youth Under 15 61Kg,Marius Karagiannis,61,50,-53,-53,-62,62,-66,50,62,112
+T&IL National Seriestevne,2024-05-13,Men's Senior 109+Kg,Steinar A. Aas,999,78,82,85,112,116,120,85,120,205
+T&IL National Seriestevne,2024-05-13,Men's Masters (35-39) 89Kg,Leik Simon Aas,89,75,80,83,90,100,-110,83,100,183
+T&IL National Seriestevne,2024-05-13,Men's Youth Under 15 61Kg,Cornelis Belsby,61,25,27,30,36,38,40,30,40,70
+T&IL National Seriestevne,2024-05-13,Men's Youth Under 15 61Kg,Jørgen Bysveen,61,56,60,-63,74,77,80,60,80,140
+T&IL National Seriestevne,2024-05-13,Women's Youth Under 17 55Kg,Luna Wangberg Møgster,55,15,-17,19,22,25,27,19,27,46
+T&IL National Seriestevne,2024-05-13,Men's Masters (50-54) 67kg,Roy Arne Bysveen,67,40,44,46,58,60,62,46,62,108
+T&IL National Seriestevne,2024-05-13,Men's Youth Under 15 49Kg,Darian D. Amundsen,49,12,14,15,20,22,23,15,23,38

--- a/event_data/NVF/661.csv
+++ b/event_data/NVF/661.csv
@@ -1,0 +1,11 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+AK Bjørgvin Seriestevne,2024-05-15,Women's Senior 55Kg,Sarah Hovden Øvsthus,55,74,76,-77,91,94,-97,76,94,170
+AK Bjørgvin Seriestevne,2024-05-15,Men's Masters (45-49) 109Kg,Børge Aadland,109,100,-103,0,135,141,-146,100,141,241
+AK Bjørgvin Seriestevne,2024-05-15,Women's Youth Under 15 40Kg,Ingrid Skag Skjefstad,40,27,-30,-32,-38,38,-40,27,38,65
+AK Bjørgvin Seriestevne,2024-05-15,Men's Masters (50-54) 96Kg,Endre Dolata Gundersen,96,80,90,-92,100,-105,107,90,107,197
+AK Bjørgvin Seriestevne,2024-05-15,Men's Senior 89Kg,Bent André Midtbø,89,-108,-108,108,135,140,145,108,145,253
+AK Bjørgvin Seriestevne,2024-05-15,Women's Youth Under 17 55Kg,Heidi Nævdal,55,40,43,-45,50,52,-54,43,52,95
+AK Bjørgvin Seriestevne,2024-05-15,Men's Youth Under 17 96Kg,Nikolai K. Aadland,96,100,-105,-105,130,135,-141,100,135,235
+AK Bjørgvin Seriestevne,2024-05-15,Men's Masters (35-39) 89Kg,Patricio Yanez,89,82,86,-90,105,110,-115,86,110,196
+AK Bjørgvin Seriestevne,2024-05-15,Men's Masters (60-64) 102kg,Petter N. Sæterdal,102,70,75,-80,90,95,100,75,100,175
+AK Bjørgvin Seriestevne,2024-05-15,Men's Senior 109Kg,Sindre K. Nesheim,109,120,125,-130,-157,157,-163,125,157,282

--- a/event_data/NVF/662.csv
+++ b/event_data/NVF/662.csv
@@ -1,0 +1,2 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Spydeberg Atletene Seriestevne,2024-05-18,Men's Masters (35-39) 109+Kg,John Anders Terland,999,100,106,110,110,120,-140,110,120,230

--- a/event_data/NVF/663.csv
+++ b/event_data/NVF/663.csv
@@ -1,0 +1,4 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Stavanger AK Seriestevne,2024-05-25,Men's Senior 89Kg,Andreas Klinkenberg,89,93,97,-101,125,130,-135,97,130,227
+Stavanger AK Seriestevne,2024-05-25,Women's Masters (50-54) 59Kg,Anita Kristoffersen,59,35,38,40,45,48,50,40,50,90
+Stavanger AK Seriestevne,2024-05-25,Women's Masters (50-54) 59Kg,Jorunn Alvilde Meling,59,20,23,-25,30,-33,34,23,34,57

--- a/event_data/NVF/664.csv
+++ b/event_data/NVF/664.csv
@@ -1,0 +1,6 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Spydeberg Atletene Seriestevne,2024-05-25,Women's Senior 87+Kg,Maren Matsson,997,68,71,-73,90,-95,-95,71,90,161
+Spydeberg Atletene Seriestevne,2024-05-25,Women's Senior 71Kg,Ina-Kristin Aasvang,71,62,-64,-64,85,89,-92,62,89,151
+Spydeberg Atletene Seriestevne,2024-05-25,Men's Senior 109+Kg,Jørgen Kjellevand,999,120,125,0,140,150,0,125,150,275
+Spydeberg Atletene Seriestevne,2024-05-25,Junior Women's 87+kg,Maria-Isabel Velasquez Lie,997,60,-65,-65,75,-81,0,60,75,135
+Spydeberg Atletene Seriestevne,2024-05-25,Men's Senior 102Kg,Mikael Kristiansen,102,83,86,-88,0,0,0,86,0.0,0.0

--- a/event_data/NVF/665.csv
+++ b/event_data/NVF/665.csv
@@ -1,0 +1,8 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Elverum AK Seriestevne 5-kamp,2024-05-26,Women's Youth Under 15 40Kg,Lina Bjørnstad,40,15,16,17,21,22,24,17,24,41
+Elverum AK Seriestevne 5-kamp,2024-05-26,Women's Youth Under 15 59Kg,Sara K. Olsen,59,35,39,40,45,48,50,40,50,90
+Elverum AK Seriestevne 5-kamp,2024-05-26,Women's Masters (40-44) 59Kg,Anne Mari Knarvik,59,52,-55,-56,72,-76,0,52,72,124
+Elverum AK Seriestevne 5-kamp,2024-05-26,Women's Masters (35-39) 87+Kg,Pernille L. Bjørnstad,87,45,47,50,55,60,-65,50,60,110
+Elverum AK Seriestevne 5-kamp,2024-05-26,Women's Masters (50-54) 87+Kg,Lena Haugseth,997,35,39,-45,45,-48,50,39,50,89
+Elverum AK Seriestevne 5-kamp,2024-05-26,Men's Masters (35-39) 81Kg,Ivar B. Bjørnstad,81,53,55,57,65,68,71,57,71,128
+Elverum AK Seriestevne 5-kamp,2024-05-26,Women's Youth Under 15 45Kg,Mille Amalie S. Norum,45,10,12,13,13,14,15,13,15,28

--- a/event_data/NVF/666.csv
+++ b/event_data/NVF/666.csv
@@ -1,0 +1,8 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Men's Youth Under 17 81Kg,Sondre Elias Fredriksen,81,69,73,-75,83,-86,86,73,86,159
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Men's Youth Under 15 61Kg,Alexander Stormoen Bruun,61,-34,36,38,43,47,49,38,49,87
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Women's Masters (35-39) 81Kg,Elisabeth Settem,81,66,69,-72,84,87,-90,69,87,156
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Men's Youth Under 15 55Kg,Kevin Moe-Akselsen,55,16,18,19,20,23,25,19,25,44
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Men's Youth Under 15 49Kg,Casper Moe-Akselsen,49,12,14,-15,16,18,20,14,20,34
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Men's Youth Under 15 55Kg,Markus Emil Brennvik,55,35,38,41,43,-47,47,41,47,88
+Nidelv IL Seriestevne 5-kamp,2024-05-22,Women's Youth Under 15 40Kg,Anine Sofie Fritz Almås,40,15,17,19,15,17,19,19,19,38

--- a/event_data/NVF/667.csv
+++ b/event_data/NVF/667.csv
@@ -1,0 +1,8 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Larvik AK Klubbmesterskap,2024-05-25,Women's Senior 59Kg,Rebekka Tao Jacobsen,59,73,76,78,97,102,-104,78,102,180
+Larvik AK Klubbmesterskap,2024-05-25,Men's Youth Under 15 55Kg,Jacob T. Sverdrup,55,39,41,43,45,48,51,43,51,94
+Larvik AK Klubbmesterskap,2024-05-25,Women's Senior 76Kg,Mia Mundal,76,75,-78,-83,100,105,110,75,110,185
+Larvik AK Klubbmesterskap,2024-05-25,Men's Youth Under 15 55Kg,Mikkel Lynum Refsdal,55,30,32,-35,40,42,45,32,45,77
+Larvik AK Klubbmesterskap,2024-05-25,Men's Youth Under 17 89Kg,Leonardo Løvenfalck,89,45,48,51,52,55,58,51,58,109
+Larvik AK Klubbmesterskap,2024-05-25,Women's Masters (35-39) 55Kg,Vibeke Carlsen,55,-54,-55,56,67,70,-72,56,70,126
+Larvik AK Klubbmesterskap,2024-05-25,Men's Youth Under 15 49Kg,Sjur Almquist Grimstad,49,20,-25,-25,30,35,37,20,37,57

--- a/event_data/NVF/668.csv
+++ b/event_data/NVF/668.csv
@@ -1,0 +1,11 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Trondheim AK Seriestevne,2024-05-29,Men's Senior 96Kg,Lukas Baldauf,96,-90,90,-96,110,115,-120,90,115,205
+Trondheim AK Seriestevne,2024-05-29,Men's Senior 89Kg,Torbjørn Øverås,89,103,106,-108,123,-128,-128,106,123,229
+Trondheim AK Seriestevne,2024-05-29,Women's Senior 81Kg,Sarah Mari Sande,81,-58,58,60,76,80,-82,60,80,140
+Trondheim AK Seriestevne,2024-05-29,Men's Masters (80+) 109Kg,Jan Olav Nystrøm,109,43,-45,45,60,64,65,45,65,110
+Trondheim AK Seriestevne,2024-05-29,Men's Masters (35-39) 89Kg,Magnus German Hove,89,87,95,103,-120,-125,-125,103,0.0,0.0
+Trondheim AK Seriestevne,2024-05-29,Women's Youth Under 15 59Kg,Vilma Kornelie Hetle,59,-44,44,47,54,57,-60,47,57,104
+Trondheim AK Seriestevne,2024-05-29,Men's Masters (50-54) 89Kg,Jonny Block,89,82,87,90,102,107,-110,90,107,197
+Trondheim AK Seriestevne,2024-05-29,Men's Youth Under 15 61Kg,Hauk Gulbrandsen,61,35,38,42,0,0,0,42,0.0,0.0
+Trondheim AK Seriestevne,2024-05-29,Men's Youth Under 15 49Kg,Marlon Gulbrandsen,49,20,23,-25,0,0,0,23,0.0,0.0
+Trondheim AK Seriestevne,2024-05-29,Men's Senior 67Kg,Daniel Long,67,45,49,52,60,65,-70,52,65,117

--- a/event_data/NVF/669.csv
+++ b/event_data/NVF/669.csv
@@ -1,0 +1,10 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Tysvær VK Seriestevne,2024-05-29,Women's Masters (45-49) 87+Kg,Monika Zakrzewska,87,44,46,48,60,64,-67,48,64,112
+Tysvær VK Seriestevne,2024-05-29,Men's Masters (40-44) 89Kg,Ørjan Østhus,89,105,110,-115,128,133,-138,110,133,243
+Tysvær VK Seriestevne,2024-05-29,Men's Youth Under 17 81Kg,William Kyvik,81,-70,70,78,-87,92,-95,78,92,170
+Tysvær VK Seriestevne,2024-05-29,Men's Masters (55-59) 109Kg,Dag Rønnevik,109,75,-80,-83,-100,100,-108,75,100,175
+Tysvær VK Seriestevne,2024-05-29,Women's Masters (40-44) 76Kg,Merete Ree,76,45,50,-53,55,65,-68,50,65,115
+Tysvær VK Seriestevne,2024-05-29,Women's Youth Under 17 76Kg,Emma Aurora Hansen,76,-58,60,-62,75,77,-80,60,77,137
+Tysvær VK Seriestevne,2024-05-29,Women's Masters (45-49) 87+Kg,Christine Berge Christiansen,87,-30,35,36,40,45,50,36,50,86
+Tysvær VK Seriestevne,2024-05-29,Women's Youth Under 15 59Kg,Veslemøy Susort Toskedal,59,-40,40,43,55,57,-60,43,57,100
+Tysvær VK Seriestevne,2024-05-29,Women's Youth Under 15 64Kg,Martine Nordal Hetland,64,20,22,24,28,30,-34,24,30,54

--- a/event_data/NVF/670.csv
+++ b/event_data/NVF/670.csv
@@ -1,0 +1,9 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+AK Bjørgvin Seriestevne,2024-05-30,Women's Senior 64Kg,Iselin Hatlenes,64,67,70,-72,82,-85,0,70,82,152
+AK Bjørgvin Seriestevne,2024-05-30,Women's Masters (60-64) 76Kg,Margit Skjervheim,76,45,-48,48,56,59,-60,48,59,107
+AK Bjørgvin Seriestevne,2024-05-30,Women's Masters (50-54) 64Kg,Line Søfteland,64,40,42,-45,55,58,-60,42,58,100
+AK Bjørgvin Seriestevne,2024-05-30,Women's Youth Under 17 71Kg,Andrea Gimmestad Eik,71,25,27,29,35,39,-41,29,39,68
+AK Bjørgvin Seriestevne,2024-05-30,Women's Youth Under 15 40Kg,Oline Mella,40,18,-20,-20,19,21,23,18,23,41
+AK Bjørgvin Seriestevne,2024-05-30,Women's Junior Under 20 76Kg,Laila Therese K. Bjørnarheim,76,-70,72,75,90,94,96,75,96,171
+AK Bjørgvin Seriestevne,2024-05-30,Women's Masters (40-44) 71Kg,Marianne Erdal Holm,71,-58,-58,58,-75,75,79,58,79,137
+AK Bjørgvin Seriestevne,2024-05-30,Women's Youth Under 15 45Kg,Astrid Hermansen,45,13,15,-17,17,19,-21,15,19,34

--- a/event_data/NVF/671.csv
+++ b/event_data/NVF/671.csv
@@ -1,0 +1,4 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Stavanger AK Seriestevne,2024-05-30,Women's Masters (40-44) 64Kg,Nhu Tran,64,50,55,-57,70,-73,73,55,73,128
+Stavanger AK Seriestevne,2024-05-30,Women's Youth Under 15 64Kg,Mia Wensberg,64,40,-43,43,50,-53,-53,43,50,93
+Stavanger AK Seriestevne,2024-05-30,Women's Masters (45-49) 71Kg,Andrea Wensberg,71,37,40,-43,50,53,-55,40,53,93

--- a/event_data/NVF/672.csv
+++ b/event_data/NVF/672.csv
@@ -1,0 +1,6 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Hitra VK Klubbmesterskap,2024-05-25,Women's Youth Under 15 45Kg,Solveig Olsen,45,23,25,27,28,30,32,27,32,59
+Hitra VK Klubbmesterskap,2024-05-25,Men's Youth Under 17 67Kg,Martin Christoffer Nordgård,67,34,38,-40,43,47,50,38,50,88
+Hitra VK Klubbmesterskap,2024-05-25,Men's Youth Under 15 49Kg,Steffen Svebak Mastad,49,15,17,18,20,22,24,18,24,42
+Hitra VK Klubbmesterskap,2024-05-25,Men's Youth Under 15 55Kg,Emil Røvik,55,28,30,33,35,38,40,33,40,73
+Hitra VK Klubbmesterskap,2024-05-25,Women's Youth Under 15 45Kg,Natali Siska,45,15,18,-20,25,-28,28,18,28,46

--- a/event_data/NVF/673.csv
+++ b/event_data/NVF/673.csv
@@ -1,0 +1,7 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Tønsberg-Kam. Seriestevne,2024-05-31,Men's Youth Under 17 81Kg,Oliver Mitseim-Haugan,81,80,-85,85,95,100,-110,85,100,185
+Tønsberg-Kam. Seriestevne,2024-05-31,Men's Senior 89Kg,Emil Strandskog,89,77,82,-86,101,106,-111,82,106,188
+Tønsberg-Kam. Seriestevne,2024-05-31,Women's Senior 87Kg,Heidi Johansen,87,63,-65,-65,84,88,0,63,88,151
+Tønsberg-Kam. Seriestevne,2024-05-31,Men's Youth Under 17 73Kg,René Myhre,73,40,45,50,50,0,0,50,50,100
+Tønsberg-Kam. Seriestevne,2024-05-31,Women's Masters (40-44) 76Kg,Ruth Kasirye,76,65,0,0,85,0,0,65,85,150
+Tønsberg-Kam. Seriestevne,2024-05-31,Men's Masters (50-54) 89Kg,Leiv Jørund Myhre,89,40,45,0,65,70,0,45,70,115

--- a/event_data/NVF/674.csv
+++ b/event_data/NVF/674.csv
@@ -1,0 +1,5 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+Oslo AK Seriestevne,2024-06-05,Women's Masters (35-39) 71Kg,Karoline Merli,71,-60,60,-63,60,0,0,60,60,120
+Oslo AK Seriestevne,2024-06-05,Men's Masters (40-44) 96Kg,Andreas Nordmo Skauen,96,75,78,81,92,97,102,81,102,183
+Oslo AK Seriestevne,2024-06-05,Men's Masters (55-59) 96Kg,Lars-Thomas Grønlien,96,-75,75,80,95,100,0,80,100,180
+Oslo AK Seriestevne,2024-06-05,Women's Senior 76Kg,Asta Rønning Fjærli,76,60,63,65,76,79,82,65,82,147

--- a/event_data/NVF/675.csv
+++ b/event_data/NVF/675.csv
@@ -1,0 +1,5 @@
+event,date,category,lifter_name,bodyweight,snatch_1,snatch_2,snatch_3,cj_1,cj_2,cj_3,best_snatch,best_cj,total
+T&IL National Seriestevne,2024-06-06,Men's Senior 109+Kg,Steinar A. Aas,999,82,86,90,-118,-118,120,90,120,210
+T&IL National Seriestevne,2024-06-06,Women's Youth Under 17 55Kg,Luna Wangberg Møgster,55,15,17,20,22,25,-27,20,25,45
+T&IL National Seriestevne,2024-06-06,Women's Youth Under 15 64Kg,Arwen Olea D. Ravneng,64,20,23,-25,26,28,30,23,30,53
+T&IL National Seriestevne,2024-06-06,Men's Youth Under 15 49Kg,Darian D. Amundsen,49,12,14,16,21,23,25,16,25,41

--- a/python_tools/database_handler/result_dataclasses.py
+++ b/python_tools/database_handler/result_dataclasses.py
@@ -57,6 +57,7 @@ class Result:
     total: float = 0.0
 
     def __post_init__(self):
+        self.__catch_nones()
         self.best_snatch = self.__best_snatch()
         self.best_cj = self.__best_cj()
         self.total = self.__total()
@@ -71,3 +72,9 @@ class Result:
         if self.best_snatch == 0.0 or self.best_cj == 0.0:
             return 0.0
         return self.best_snatch + self.best_cj
+
+    def __catch_nones(self):
+        for key, value in self.__dict__.items():
+            if value is None:
+                if key in ['snatch_1', 'snatch_2', 'snatch_3', 'cj_1', 'cj_2', 'cj_3']:
+                    setattr(self, key, 0)


### PR DESCRIPTION
None value was stored / passed directly from the NVF results server in the JSON. Added a simple / lazy / dumb function post-init of the dataclass to catch if a None value is passed into the lift attempts.

closes #355