### PR TITLE
fix(frontend): Correct link to Raw Data on the Events page

### DIFF
--- a/frontend/components/molecules/eventsTable.tsx
+++ b/frontend/components/molecules/eventsTable.tsx
@@ -27,7 +27,7 @@ export const EventsListTable = ({
                 <Link href={event_page}>{name}</Link>
               </TableCell>
               <TableCell>
-                <Link href={`https://github.com/euanwm/OpenWeightlifting/tree/development/backend/event_data/${federation}/${id}`}>Data</Link>
+                <Link href={`https://github.com/euanwm/OpenWeightlifting/tree/development/event_data/${federation}/${id}`}>Data</Link>
               </TableCell>
             </TableRow>
           )


### PR DESCRIPTION
The PR #366 moved ./backend/event_data to ./event_data, but the Events page links referencing that folder were not updated.