### PR TITLE
implemented filtering by date range

### DIFF
--- a/backend/endpoints.go
+++ b/backend/endpoints.go
@@ -175,23 +175,65 @@ func LifterHistory(c *gin.Context) {
 //		@Success		200	{object}	structs.LeaderboardResponse
 //		@Router			/leaderboard [post]
 func Leaderboard(c *gin.Context) {
+	// There are 2 sorted leaderboards currently, sinclair and total. We default to total.
 	sortby, exists := c.GetQuery("sortBy")
 	if !exists {
 		sortby = "total"
 	}
+
+	// If no federation is selected then we assume all federations
 	federation, exists := c.GetQuery("federation")
 	if !exists {
 		federation = enum.ALLFEDS
 	}
+
+	// If no weight category is selected then we default to everyone
 	weightclass, exists := c.GetQuery("weightclass")
 	if !exists {
 		weightclass = "MALL"
 	}
-	year, exists := c.GetQuery("year")
-	if !exists {
-		year = strconv.Itoa(enum.AllYears)
+
+	// Filter by year or within a certain range of dates
+	year, yearExists := c.GetQuery("year") // todo: fix frontend filters and remove the 69 enum for all years
+	if len(year) == 2 {
+		year = ""
+		yearExists = false
 	}
 
+	startDate, startDateExists := c.GetQuery("startdate")
+	if !startDateExists {
+		if !yearExists {
+			startDate = enum.ZeroDate
+		}
+	}
+
+	if startDateExists && yearExists {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Year and date ranges are exclusive"})
+		return
+	}
+
+	endDate, endDateExists := c.GetQuery("enddate")
+	if !endDateExists {
+		if !yearExists {
+			endDate = enum.MaxDate
+		}
+	}
+
+	if endDateExists && yearExists {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Year and date ranges are exclusive"})
+		return
+	}
+
+	if yearExists && !startDateExists && !endDateExists {
+		oneYear, err := strconv.Atoi(year)
+		if err != nil {
+			panic(err)
+		}
+		startDate = year + "-01-01"
+		endDate = strconv.Itoa(oneYear+1) + "-01-01"
+	}
+
+	// Amount of results and positions to start at in the leaderboard
 	start, exists := c.GetQuery("start")
 	if !exists {
 		start = "0"
@@ -216,20 +258,8 @@ func Leaderboard(c *gin.Context) {
 		Federation:  federation,
 		WeightClass: weightclass,
 		Year:        year,
-	}
-
-	// todo: remove this once the frontend filters have been updated to suit
-	switch body.Year {
-	case strconv.Itoa(enum.AllYears):
-		body.StartDate = enum.ZeroDate
-		body.EndDate = enum.MaxDate
-	default:
-		body.StartDate = body.Year + "-01-01"
-		oneYear, err := strconv.Atoi(body.Year)
-		if err != nil {
-			panic(err)
-		}
-		body.EndDate = strconv.Itoa(oneYear+1) + "-01-01"
+		StartDate:   startDate,
+		EndDate:     endDate,
 	}
 
 	leaderboardData := LeaderboardData.Select(body.SortBy) // Selects either total or sinclair sorted leaderboard


### PR DESCRIPTION
@ochsnerd so you're aware, additional filtering is now available by passing a startdate and enddate query parameter to the leaderboard endpoint. These are exclusive to the year parameter and should throw a message if you add them both.

Date format is YYYY-MM-DD