### PR TITLE
fix: disambiguate two distinct "Jake Anderson" lifters in US data

### DIFF
--- a/event_data/US/1347.csv
+++ b/event_data/US/1347.csv
@@ -1,6 +1,6 @@
 meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
 Blaze High School Open,2014-02-08,Open Men's+105 kg,Adam Mehr,114.6,100,-103,-103,128,130,132,100,132,232
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Jake Anderson,98.18,92,-95,95,116,120,125,95,125,220
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Jake Anderson #1,98.18,92,-95,95,116,120,125,95,125,220
 Blaze High School Open,2014-02-08,Open Men's+105 kg,Michael Trettel,107.8,88,91,93,116,119,123,93,123,216
 Blaze High School Open,2014-02-08,Open Men's 85 kg,Gerrit Olsen,83.29,91,-94,-95,-114,115,116,91,116,207
 Blaze High School Open,2014-02-08,Open Men's 105 kg,Joseph Splettstoeser,102.85,86,89,91,-115,115,-120,91,115,206

--- a/event_data/US/1377.csv
+++ b/event_data/US/1377.csv
@@ -4,7 +4,7 @@ Rosemont High School Open,2014-01-18,Open Men's 69 kg,Nate Oelke,68.65,90,94,95,
 Rosemont High School Open,2014-01-18,Open Men's 105 kg,Tramail Peterson,104.4,85,89,95,120,126,130,95,130,225
 Rosemont High School Open,2014-01-18,Open Men's 94 kg,Gabriel Ehlers,92.55,85,90,95,115,120,125,95,125,220
 Rosemont High School Open,2014-01-18,Open Men's+105 kg,Jacob Koestler,114.2,84,87,90,121,126,130,90,130,220
-Rosemont High School Open,2014-01-18,Open Men's 105 kg,Jake Anderson,99.45,86,90,94,116,116,120,94,120,214
+Rosemont High School Open,2014-01-18,Open Men's 105 kg,Jake Anderson #1,99.45,86,90,94,116,116,120,94,120,214
 Rosemont High School Open,2014-01-18,Open Men's+105 kg,Michael Trettel,108,86,90,92,116,120,120,92,120,212
 Rosemont High School Open,2014-01-18,Open Men's+105 kg,Joseph Splettstoeser,107.5,83,83,86,105,110,115,86,115,201
 Rosemont High School Open,2014-01-18,Open Men's 94 kg,William O'Connell,92,80,85,87,102,109,112,87,112,199

--- a/event_data/US/1384.csv
+++ b/event_data/US/1384.csv
@@ -1,6 +1,6 @@
 meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
 MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Preston Anderson,92.4,115,-123,-131,130,-140,-145,115,130,245
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Jake Anderson,96.6,95,100,105,125,130,140,105,140,245
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Jake Anderson #1,96.6,95,100,105,125,130,140,105,140,245
 MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Connor Rousemiller,96.5,105,110,-115,130,-140,-140,110,130,240
 MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Jacob Koestler,110.7,93,97,100,132,137,-141,100,137,237
 MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Tramail Peterson,104.3,95,100,-103,-135,135,-139,100,135,235

--- a/event_data/US/1640.csv
+++ b/event_data/US/1640.csv
@@ -14,7 +14,7 @@ National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg
 National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Chayce Dement,112.9,95,100,105,127,132,136,105,136,241
 National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Cody Wilson,73.8,98,-104,-104,140,-146,-146,98,140,238
 National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Daniel Vaden,75.64,107,-111,-111,-130,-131,131,107,131,238
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Jake Anderson,102.38,-100,103,-107,-125,125,135,103,135,238
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Jake Anderson #1,102.38,-100,103,-107,-125,125,135,103,135,238
 National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Tramail Peterson,109.32,97,101,-104,-135,-137,137,101,137,238
 National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Harrison Maurus,68.17,100,105,105,125,129,132,105,132,237
 National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Sam Ernst,81.87,99,104,105,120,125,130,105,130,235

--- a/event_data/US/267.csv
+++ b/event_data/US/267.csv
@@ -1,5 +1,5 @@
 meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-Brian Trussell,2015-01-17,Open Men's+105 kg,Jake Anderson,108.4,90,95,100,130,135,143,100,143,243
+Brian Trussell,2015-01-17,Open Men's+105 kg,Jake Anderson #1,108.4,90,95,100,130,135,143,100,143,243
 Brian Trussell,2015-01-17,Open Men's+105 kg,Tramail Peterson,108.2,95,100,103,130,133,138,103,138,241
 Brian Trussell,2015-01-17,Open Men's 105 kg,Logan Bruce,100.3,88,95,97,105,114,120,97,120,217
 Brian Trussell,2015-01-17,Open Men's 94 kg,Gabe Hall,92.45,84,86,86,121,126,130,86,130,216

--- a/event_data/US/271.csv
+++ b/event_data/US/271.csv
@@ -1,7 +1,7 @@
 meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
 Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Nate Oelke,76.6,112,116,-120,147,151,-155,116,151,267
 Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Michael Schiller,79,-110,110,-112,145,148,-150,110,148,258
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Jake Anderson,107.7,110,115,-123,135,140,-145,115,140,255
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Jake Anderson #1,107.7,110,115,-123,135,140,-145,115,140,255
 Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Eric Rousemiller,135.8,105,-110,-110,130,-135,-135,105,130,235
 Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Connor Rousemiller,101.1,-110,110,-121,120,-151,-151,110,120,230
 Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Gabe Hall,92,93,97,-100,-126,126,131,97,131,228

--- a/event_data/US/702.csv
+++ b/event_data/US/702.csv
@@ -4,7 +4,7 @@ North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Jalen Wu
 North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Nate Oelke,68.35,88,-93,93,118,122,124,93,124,217
 North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Adam Mehr,110,-96,-96,96,116,120,-124,96,120,216
 North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Michael Schiller,73.7,88,90,-92,-123,-123,123,90,123,213
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Jake Anderson,106.2,80,88,93,105,115,-125,93,115,208
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Jake Anderson #1,106.2,80,88,93,105,115,-125,93,115,208
 North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Douglas Molde,84.7,85,-88,-88,115,-116,116,85,116,201
 North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Michael Trettel,102,74,81,86,100,108,113,86,113,199
 North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,William Staska,94.1,80,85,-88,100,105,113,85,113,198


### PR DESCRIPTION
## Summary
The "Jake Anderson" record in US event data conflates two distinct lifters:

- **Minnesota high-school-era lifter** — 2013-12 → 2015-03, 7 meets, body weight 96–108 kg, totals 208–255
- **+109 kg lifter** — 2022-04 → 2026-03, 12 meets, body weight 122–137 kg, totals 255–320

7-year gap, ~25 kg body-weight delta, no overlap. Almost certainly different people.

This PR renames the older lifter's 7 historical entries to `Jake Anderson #1` (OpenPowerlifting convention). The newer lifter's records are unchanged.

## Notes
- Disclosure: I am the newer lifter.
- This is a one-time fix for historical CSVs. New meets scraped for either name will land as plain "Jake Anderson" and re-conflate. A general aliasing layer would be a separate, larger change — happy to file an issue if useful.
- `make check_db` passes (run via `python3 scripts/check_db.py`).

## Test plan
- [x] `python3 scripts/check_db.py` reports `TEST PASSED`
- [x] All 7 older entries now read `Jake Anderson #1`
- [x] All 12 newer entries unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)