### PR TITLE
fix: correct Jake Anderson's lifts at 2022 AO Series 2

### DIFF
--- a/event_data/US/5500.csv
+++ b/event_data/US/5500.csv
@@ -1,5 +1,5 @@
 meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-The Nike 2022 North American Open Series 2 powered by Rogue,2022-09-18,Open Men's +109kg,Jake Anderson,122.5,118,123,143,135,-140,161,143,161,304
+The Nike 2022 North American Open Series 2 powered by Rogue,2022-09-18,Open Men's +109kg,Jake Anderson,122.5,118,123,-127,135,-140,143,123,143,266
 The Nike 2022 North American Open Series 2 powered by Rogue,2022-09-17,Open Men's 89kg,Kenta Dooley,83.79,110,115,120,150,155,160,120,160,280
 The Nike 2022 North American Open Series 2 powered by Rogue,2022-09-18,Open Men's 102kg,Pedro Hernandez,98.75,118,-122,125,143,150,155,125,155,280
 The Nike 2022 North American Open Series 2 powered by Rogue,2022-09-18,Open Men's 102kg,Alec Olson,100.55,115,120,123,147,153,157,123,157,280


### PR DESCRIPTION
## Summary
The recorded snatch #3 (143) and clean & jerk #3 (161) for Jake Anderson at The Nike 2022 North American Open Series 2 (event 5500, 2022-09-18) are administrative imputations made by USAW to grant AO Finals registration via the AO-podium-bypass rule. They do not reflect lifts that occurred on the platform.

Disclosure: I am the lifter.

Actual performance (video evidence: https://www.instagram.com/reel/CirKV35DlaD/):
- snatch_3 — missed at 127 (now `-127`)
- c&j_3 — successful at 143 (now `143`)

Recomputed: `best_snatch` 143 → 123, `best_c&j` 161 → 143, `total` 304 → 266.

## Test plan
- [x] `python3 scripts/check_db.py` reports `TEST PASSED`
- [x] Diff is the single row in `event_data/US/5500.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)