### PR TITLE
Feat/age disambiguation

### DIFF
--- a/backend/dbtools/build.go
+++ b/backend/dbtools/build.go
@@ -9,8 +9,7 @@ import (
 func BuildDatabase(leaderboardTotal *structs.LeaderboardData, eventmetadata *structs.EventsData, lifterRoster *structs.LifterRoster) {
 	log.Println("buildDatabase called...")
 	allLifts := CollateAll(eventmetadata, lifterRoster)
-	// allLifts, badLifts := ParseData(bigData)
-	// log.Println("Unable to parse ", len(badLifts.Lifts), " lifts")
+	lifterRoster.AssignDisambiguation()
 	*leaderboardTotal = structs.LeaderboardData{
 		AllTotals:    SortLiftsBy(allLifts.Lifts, enum.Total),
 		AllSinclairs: SortLiftsBy(allLifts.Lifts, enum.Sinclair),

--- a/backend/dbtools/collate.go
+++ b/backend/dbtools/collate.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log"
 	"path"
+	"strconv"
 )
 
 func CollateAll(eventsData *structs.EventsData, lifterRoster *structs.LifterRoster) (allLifts structs.AllLifts) {
@@ -36,6 +37,7 @@ var columnAliases = [][]string{
 	{"best_snatch"},                        // 11: BestSn
 	{"best_c&j", "best_cj"},                // 12: BestCJ
 	{"total"},                              // 13: Total
+	{"age_on_day"},                         // 14: AgeOnDay
 }
 
 // normalizeColumns reorders rows to match columnAliases order using the CSV header,
@@ -129,6 +131,16 @@ func createSingleEvent(federation, filename string, eventsData *structs.EventsDa
 		if !rules.PassesRules(lift) {
 			continue
 		}
+
+		if len(row[14]) > 0 {
+			ageOnDay, err := strconv.Atoi(row[14])
+			if err != nil {
+				log.Println("err checking age", err)
+				ageOnDay = 0
+			}
+			lift.SetAgeOnDay(ageOnDay)
+		}
+
 		lift.Lifter = lifterRoster.Add(row[3], row[2], federation, lift)
 		sinclair.CalcSinclair(lift)
 		liftPtrSlice = append(liftPtrSlice, lift)

--- a/backend/endpoints.go
+++ b/backend/endpoints.go
@@ -90,15 +90,26 @@ func SearchName(c *gin.Context) {
 //		@Tags			GET Requests
 //	 @Param name query string true "Name of the lifter, must be an exact match"
 //	 @Param federation query string false "Federation to filter lifts by"
+//	 @Param disamb query int false "Disambiguation index from the search endpoint, for names shared by multiple lifters"
 //		@Accept			json
 //		@Produce		json
 //		@Success		200	{object}	structs.LifterHistory
 //	 @Failure		204	{object}	nil
+//	 @Failure		400	{object}	nil
 //		@Router			/history [get]
 func LifterHistory(c *gin.Context) {
 	name := c.Query("name")
 	federation := c.Query("federation")
 	lifterSearch := structs.NameSearch{NameStr: name, Federation: federation}
+
+	if disambStr := c.Query("disamb"); disambStr != "" {
+		disamb, err := strconv.Atoi(disambStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "disamb must be an integer"})
+			return
+		}
+		lifterSearch.Disambiguation = &disamb
+	}
 
 	lifterDetails := lifter.FetchLifts(lifterSearch, &LeaderboardData)
 

--- a/backend/lifter/search.go
+++ b/backend/lifter/search.go
@@ -95,13 +95,20 @@ func Rivals(nameStr string, bigData []*structs.Lift) (rivalResults structs.Rival
 	return
 }
 
-// FetchLifts should use the exact string provided (case-sensitive) by NameSearch
+// FetchLifts should use the exact string provided (case-sensitive) by NameSearch.
+// If name.Disambiguation is set, only the matching lifter (by that stable index,
+// see LifterRoster.AssignDisambiguation) is returned rather than every lifter
+// who ever shared this name.
 func FetchLifts(name structs.NameSearch, leaderboard *structs.LeaderboardData) (lifterData structs.LifterHistory) {
 	lifterData.NameStr = name.NameStr
 	for _, lift := range leaderboard.AllTotals {
-		if lift.Lifter.Name == name.NameStr {
-			lifterData.Lifts = append(lifterData.Lifts, lift)
+		if lift.Lifter.Name != name.NameStr {
+			continue
 		}
+		if name.Disambiguation != nil && lift.Lifter.Disambiguation != *name.Disambiguation {
+			continue
+		}
+		lifterData.Lifts = append(lifterData.Lifts, lift)
 	}
 	return
 }

--- a/backend/lifter/search_test.go
+++ b/backend/lifter/search_test.go
@@ -59,6 +59,7 @@ func TestFetchLifts(t *testing.T) {
 }
 
 func TestNameSearch(t *testing.T) {
+	zero := 0
 	type args struct {
 		nameStr string
 		roster  structs.LifterRoster
@@ -77,7 +78,7 @@ func TestNameSearch(t *testing.T) {
 				{Name: "maybe john smith"},
 			}}},
 			want: structs.NameSearchResults{
-				Names: []structs.NameSearch{{NameStr: "Dave Smith"}},
+				Names: []structs.NameSearch{{NameStr: "Dave Smith", Disambiguation: &zero}},
 				Total: 1,
 			},
 		},
@@ -90,7 +91,7 @@ func TestNameSearch(t *testing.T) {
 				{Name: "john Smith"},
 			}}},
 			want: structs.NameSearchResults{
-				Names: []structs.NameSearch{{NameStr: "john smith"}, {NameStr: "John Smith"}, {NameStr: "john Smith"}},
+				Names: []structs.NameSearch{{NameStr: "john smith", Disambiguation: &zero}, {NameStr: "John Smith", Disambiguation: &zero}, {NameStr: "john Smith", Disambiguation: &zero}},
 				Total: 3,
 			},
 		},

--- a/backend/structs/struct_funcs.go
+++ b/backend/structs/struct_funcs.go
@@ -215,10 +215,17 @@ func (e Lifter) IsMale() bool {
 	return e.Gender == enum.Male
 }
 
+func (e Lifter) LastEventDate() string {
+	if len(e.Lifts) == 0 {
+		return ""
+	}
+	return e.Lifts[len(e.Lifts)-1].Event.Date
+}
+
 func (e LifterRoster) Search(nameStr string) (lifters NameSearchResults) {
 	for _, lifter := range e.Lifters {
 		if strings.Contains(strings.ToLower(lifter.Name), strings.ToLower(nameStr)) {
-			lifters.Names = append(lifters.Names, NameSearch{NameStr: lifter.Name, Gender: lifter.Gender, CurrentAge: lifter.CurrentAge, Federation: lifter.PrimaryFederation})
+			lifters.Names = append(lifters.Names, NameSearch{NameStr: lifter.Name, Gender: lifter.Gender, LastActive: lifter.LastEventDate(), Federation: lifter.PrimaryFederation})
 			lifters.Total++
 		}
 	}

--- a/backend/structs/struct_funcs.go
+++ b/backend/structs/struct_funcs.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -25,9 +26,21 @@ func (e Lift) WithinYear(year int) bool {
 	if year == enum.AllYears {
 		return true
 	}
+	return e.Year() == year
+}
+
+func (e Lift) Year() int {
 	datetime, _ := utilities.StringToDate(e.Event.Date)
 	eventYear, _, _ := datetime.Date()
-	return eventYear == year
+	return eventYear
+}
+
+func (e Lift) CurrentAge() int {
+	if e.ageOnDay == 0 {
+		return 0
+	}
+	currentYear := time.Now().Year()
+	return currentYear - e.Year() + e.ageOnDay
 }
 
 func (e Lift) WithinDates(startDate, endDate string) bool {
@@ -41,6 +54,10 @@ func (e Lift) WithinDates(startDate, endDate string) bool {
 		return true
 	}
 	return false
+}
+
+func (e *Lift) SetAgeOnDay(ageOnDay int) {
+	e.ageOnDay = ageOnDay
 }
 
 func (e Event) SelectedFederation(federation string) bool {
@@ -177,7 +194,7 @@ func (e *LifterRoster) Add(name, category, federation string, lift *Lift) *Lifte
 		e.index = make(map[string]*Lifter)
 	}
 	gender := enum.ClassifyGender(category)
-	key := name + "|" + gender + "|" + federation
+	key := name + "|" + gender + "|" + federation + "|" + strconv.Itoa(lift.CurrentAge())
 	if lifter, ok := e.index[key]; ok {
 		lifter.Lifts = append(lifter.Lifts, lift)
 		return lifter
@@ -185,6 +202,7 @@ func (e *LifterRoster) Add(name, category, federation string, lift *Lift) *Lifte
 	lifter := &Lifter{
 		Name:              name,
 		Gender:            gender,
+		CurrentAge:        lift.CurrentAge(),
 		PrimaryFederation: federation,
 		Lifts:             []*Lift{lift},
 	}
@@ -200,7 +218,7 @@ func (e Lifter) IsMale() bool {
 func (e LifterRoster) Search(nameStr string) (lifters NameSearchResults) {
 	for _, lifter := range e.Lifters {
 		if strings.Contains(strings.ToLower(lifter.Name), strings.ToLower(nameStr)) {
-			lifters.Names = append(lifters.Names, NameSearch{NameStr: lifter.Name, Gender: lifter.Gender, Federation: lifter.PrimaryFederation})
+			lifters.Names = append(lifters.Names, NameSearch{NameStr: lifter.Name, Gender: lifter.Gender, CurrentAge: lifter.CurrentAge, Federation: lifter.PrimaryFederation})
 			lifters.Total++
 		}
 	}

--- a/backend/structs/struct_funcs.go
+++ b/backend/structs/struct_funcs.go
@@ -5,6 +5,7 @@ import (
 	"backend/utilities"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -202,10 +203,10 @@ func (e *LifterRoster) Add(name, category, federation string, lift *Lift) *Lifte
 	lifter := &Lifter{
 		Name:              name,
 		Gender:            gender,
-		CurrentAge:        lift.CurrentAge(),
 		PrimaryFederation: federation,
 		Lifts:             []*Lift{lift},
 	}
+	lifter.SetAge(lift.CurrentAge())
 	e.index[key] = lifter
 	e.Lifters = append(e.Lifters, lifter)
 	return lifter
@@ -215,17 +216,65 @@ func (e Lifter) IsMale() bool {
 	return e.Gender == enum.Male
 }
 
+func (e *Lifter) SetAge(age int) {
+	e.currentAge = age
+}
+
 func (e Lifter) LastEventDate() string {
 	if len(e.Lifts) == 0 {
 		return ""
 	}
-	return e.Lifts[len(e.Lifts)-1].Event.Date
+	latest := e.Lifts[0].Event.Date
+	for _, lift := range e.Lifts[1:] {
+		if lift.Event.Date > latest {
+			latest = lift.Event.Date
+		}
+	}
+	return latest
+}
+
+func (e Lifter) FirstEventDate() string {
+	if len(e.Lifts) == 0 {
+		return ""
+	}
+	earliest := e.Lifts[0].Event.Date
+	for _, lift := range e.Lifts[1:] {
+		if lift.Event.Date < earliest {
+			earliest = lift.Event.Date
+		}
+	}
+	return earliest
+}
+
+func (e *Lifter) SetDisambiguation(disambiguation int) {
+	e.Disambiguation = disambiguation
+}
+
+// AssignDisambiguation stamps each Lifter with a stable index among others
+// sharing its name/gender/federation, ordered by earliest competition date
+// (0 = earliest). Must run once after the roster is fully built, since it
+// needs every Lifter's complete Lifts slice to order groups correctly.
+func (e *LifterRoster) AssignDisambiguation() {
+	groups := make(map[string][]*Lifter)
+	for _, lifter := range e.Lifters {
+		key := lifter.Name + "|" + lifter.Gender + "|" + lifter.PrimaryFederation
+		groups[key] = append(groups[key], lifter)
+	}
+	for _, group := range groups {
+		sort.SliceStable(group, func(i, j int) bool {
+			return group[i].FirstEventDate() < group[j].FirstEventDate()
+		})
+		for i, lifter := range group {
+			lifter.SetDisambiguation(i)
+		}
+	}
 }
 
 func (e LifterRoster) Search(nameStr string) (lifters NameSearchResults) {
 	for _, lifter := range e.Lifters {
 		if strings.Contains(strings.ToLower(lifter.Name), strings.ToLower(nameStr)) {
-			lifters.Names = append(lifters.Names, NameSearch{NameStr: lifter.Name, Gender: lifter.Gender, LastActive: lifter.LastEventDate(), Federation: lifter.PrimaryFederation})
+			disambiguation := lifter.Disambiguation
+			lifters.Names = append(lifters.Names, NameSearch{NameStr: lifter.Name, Gender: lifter.Gender, LastActive: lifter.LastEventDate(), Federation: lifter.PrimaryFederation, Disambiguation: &disambiguation})
 			lifters.Total++
 		}
 	}

--- a/backend/structs/structs.go
+++ b/backend/structs/structs.go
@@ -49,10 +49,11 @@ type RivalsCombined struct {
 }
 
 type NameSearch struct {
-	NameStr    string `json:"name"`
-	Gender     string `json:"gender"`
-	Federation string `json:"federation"`
-	LastActive string `json:"last_active"`
+	NameStr        string `json:"name"`
+	Gender         string `json:"gender"`
+	Federation     string `json:"federation"`
+	LastActive     string `json:"last_active"`
+	Disambiguation *int   `json:"disambiguation,omitempty"`
 }
 
 type LifterHistory struct {
@@ -116,7 +117,8 @@ type LifterRoster struct {
 type Lifter struct {
 	Gender            string `json:"gender"`
 	Name              string `json:"name"`
-	CurrentAge        int
+	currentAge        int
+	Disambiguation    int     `json:"disambiguation"`
 	PrimaryFederation string  `json:"federation"`
 	Lifts             []*Lift `json:"-"` // back-reference; would cycle through Lift.Lifter
 }
@@ -126,9 +128,9 @@ type AllLifts struct {
 }
 
 type Lift struct {
-	Event      *Event     `json:"event"` // parent; already the context when nested under Event.Results/EventResponse
-	Lifter     *Lifter    `json:"lifter"`
-	ageOnDay   int        //nolint:unused // todo: implement age calculation & linking
+	Event      *Event  `json:"event"` // parent; already the context when nested under Event.Results/EventResponse
+	Lifter     *Lifter `json:"lifter"`
+	ageOnDay   int
 	Category   string     `json:"category"`
 	Bodyweight FixedFloat `json:"bodyweight"`
 	Sn1        FixedFloat `json:"snatch_1"`

--- a/backend/structs/structs.go
+++ b/backend/structs/structs.go
@@ -51,8 +51,8 @@ type RivalsCombined struct {
 type NameSearch struct {
 	NameStr    string `json:"name"`
 	Gender     string `json:"gender"`
-	CurrentAge int    `json:"current_age"`
 	Federation string `json:"federation"`
+	LastActive string `json:"last_active"`
 }
 
 type LifterHistory struct {
@@ -114,9 +114,9 @@ type LifterRoster struct {
 }
 
 type Lifter struct {
-	Gender            string  `json:"gender"`
-	Name              string  `json:"name"`
-	CurrentAge        int     `json:"current_age"`
+	Gender            string `json:"gender"`
+	Name              string `json:"name"`
+	CurrentAge        int
 	PrimaryFederation string  `json:"federation"`
 	Lifts             []*Lift `json:"-"` // back-reference; would cycle through Lift.Lifter
 }

--- a/backend/structs/structs.go
+++ b/backend/structs/structs.go
@@ -51,6 +51,7 @@ type RivalsCombined struct {
 type NameSearch struct {
 	NameStr    string `json:"name"`
 	Gender     string `json:"gender"`
+	CurrentAge int    `json:"current_age"`
 	Federation string `json:"federation"`
 }
 
@@ -115,7 +116,7 @@ type LifterRoster struct {
 type Lifter struct {
 	Gender            string  `json:"gender"`
 	Name              string  `json:"name"`
-	currentAge        uint8   //nolint:unused // todo: implement age calculation & linking
+	CurrentAge        int     `json:"current_age"`
 	PrimaryFederation string  `json:"federation"`
 	Lifts             []*Lift `json:"-"` // back-reference; would cycle through Lift.Lifter
 }
@@ -127,7 +128,7 @@ type AllLifts struct {
 type Lift struct {
 	Event      *Event     `json:"event"` // parent; already the context when nested under Event.Results/EventResponse
 	Lifter     *Lifter    `json:"lifter"`
-	ageOnDay   uint8      //nolint:unused // todo: implement age calculation & linking
+	ageOnDay   int        //nolint:unused // todo: implement age calculation & linking
 	Category   string     `json:"category"`
 	Bodyweight FixedFloat `json:"bodyweight"`
 	Sn1        FixedFloat `json:"snatch_1"`

--- a/event_data/US/1347.csv
+++ b/event_data/US/1347.csv
@@ -1,104 +1,104 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Adam Mehr,114.6,100,-103,-103,128,130,132,100,132,232
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Jake Anderson,98.18,92,-95,95,116,120,125,95,125,220
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Michael Trettel,107.8,88,91,93,116,119,123,93,123,216
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Gerrit Olsen,83.29,91,-94,-95,-114,115,116,91,116,207
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Joseph Splettstoeser,102.85,86,89,91,-115,115,-120,91,115,206
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Matthew Mientkiewicz,82.75,76,79,81,105,108,112,81,112,193
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Gabe Hall,82.21,73,77,81,103,105,108,81,108,189
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Eric Voxland,74.77,75,-80,80,100,104,-110,80,104,184
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Matthew Otto,98.04,80,82,84,100,-103,-103,84,100,184
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Cooper Smith,81.92,76,-79,79,98,101,104,79,104,183
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Andrew Egge,76.34,73,-77,77,100,105,-110,77,105,182
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Jackson Gilman,98.28,75,78,80,95,98,101,80,101,181
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Benn Olson,118.03,74,76,79,95,97,100,79,100,179
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Jacob Engel,90.17,75,-77,77,96,96,99,77,99,176
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Jacob Schreiber,68.94,75,-77,78,85,92,97,78,97,175
-Blaze High School Open,2014-02-08,Women's Masters (35-39) +75 kg,Sara Womack,78.9,72,-76,76,92,96,-98,76,96,172
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Josh Hedensten,118.14,75,-78,78,93,-97,-97,78,93,171
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Ali Husain,66.94,73,76,-80,-93,93,-96,76,93,169
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Brandon Dorshak,68.3,-72,74,-76,89,92,95,74,95,169
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Matt McDavid,85.09,70,-73,73,90,93,96,73,96,169
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Devin Kindon,75.97,60,-65,65,92,100,-105,65,100,165
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Drew Ehlers,68.14,63,65,68,93,94,96,68,96,164
-Blaze High School Open,2014-02-08,Open Men's 56 kg,Dithdecha Soundara,55.6,70,72,-75,85,-88,91,72,91,163
-Blaze High School Open,2014-02-08,Open Men's 62 kg,Nicholas Lorentz,61.5,70,75,78,85,-90,-91,78,85,163
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Tommy Haberlack,92.28,70,73,-76,90,-92,-92,73,90,163
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Ibrahim Mahmoud,75.02,70,72,-75,-90,90,-91,72,90,162
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Nick Burton,105.7,66,-68,69,-91,91,-92,69,91,160
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Armando Ramirez,106.3,65,67,69,85,88,91,69,91,160
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Jarrod Leake,89.41,70,73,-75,80,83,86,73,86,159
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Steven Hawkins,116.97,70,-72,72,80,82,84,72,84,156
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Logan Bruce,92.18,-70,-70,70,83,86,-89,70,86,156
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Andrew Lanhart,97.6,-65,-65,65,-87,87,89,65,89,154
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Nicholas Maslowski,110.56,52,56,59,87,-92,92,59,92,151
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Bailey Otto,75.85,62,65,-68,77,81,85,65,85,150
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Michael Orr,71.5,60,62,-65,85,87,88,62,88,150
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Maxwell Cantrell,71.72,62,64,-66,81,82,-85,64,82,146
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Trevor Liggett,74.39,61,63,66,80,-82,-82,66,80,146
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Jacob Parrent,80.12,62,64,-66,-78,78,81,64,81,145
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Alexander Garlington,65.34,56,59,61,77,79,82,61,82,143
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Jordan Leake,82.78,59,62,64,76,78,-80,64,78,142
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Micahjosiah Borreson,91.36,60,-64,-65,82,-86,-87,60,82,142
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Christopher Miller,74.55,-58,59,61,77,79,-81,61,79,140
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Samuel Johnson,66.99,-60,-61,62,75,77,-79,62,77,139
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Anton Sullivan,100,-62,62,-65,75,-78,-78,62,75,137
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group +75 kg,Alayna Theissen,84.11,54,-59,59,72,77,-80,59,77,136
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Noah Bachmeier,64.61,55,56,57,76,-77,78,57,78,135
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Austin George,72.4,60,62,-63,70,73,-75,62,73,135
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Nick Lane,65.06,56,58,60,70,74,-77,60,74,134
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Aron Hawkinson,74.45,57,59,-60,72,74,75,59,75,134
-Blaze High School Open,2014-02-08,Open Men's 62 kg,Theodore Shriver,60.42,56,-60,-60,70,75,-77,56,75,131
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Jared Shearer,64.5,-52,52,54,70,73,76,54,76,130
-Blaze High School Open,2014-02-08,Open Men's 69 kg,August Foss,67.28,50,-55,55,-75,75,-80,55,75,130
-Blaze High School Open,2014-02-08,Open Men's 94 kg,Kamal Martin,86.6,52,54,-57,72,74,76,54,76,130
-Blaze High School Open,2014-02-08,Open Men's 62 kg,John Perry,61.06,53,55,57,65,68,-71,57,68,125
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Justin Sturgeon,78.99,50,52,-53,70,71,73,52,73,125
-Blaze High School Open,2014-02-08,Open Men's 62 kg,Alex Jeon,61.49,52,-55,-55,-72,72,-74,52,72,124
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Jacob Baker,68.89,50,-52,53,65,-67,69,53,69,122
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Alexander Mckeever,67.56,48,-51,51,65,67,70,51,70,121
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group 69 kg,Natasha Rice,67.82,50,53,-56,62,-65,67,53,67,120
-Blaze High School Open,2014-02-08,Open Men's 62 kg,Luke Simon,56.95,47,50,53,65,67,-70,53,67,120
-Blaze High School Open,2014-02-08,Women's 14-15 Age Group 69 kg,Chase Schaefer,67.71,47,51,53,-63,63,65,53,65,118
-Blaze High School Open,2014-02-08,Open Women's 53 kg,Aneesa Ally,52.45,50,53,-55,60,62,64,53,64,117
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group +75 kg,Geneva Brandt,81.95,46,49,51,60,63,66,51,66,117
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Joseph Brue,73.17,-48,50,-53,61,64,-66,50,64,114
-Blaze High School Open,2014-02-08,Open Men's 56 kg,Quan Trang,55,40,43,-45,65,68,-71,43,68,111
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group 69 kg,Hailey Huseth,67.91,-43,44,-47,63,-66,66,44,66,110
-Blaze High School Open,2014-02-08,Open Women's 75 kg,Katie Yorek,74.46,43,45,-48,63,65,-68,45,65,110
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Jared Lozano,62.7,44,-45,-47,62,64,66,44,66,110
-Blaze High School Open,2014-02-08,Open Men's 62 kg,Bryce Jorgensen,56.36,42,44,47,58,60,62,47,62,109
-Blaze High School Open,2014-02-08,Open Women's 69 kg,Ariel Behnke,68.14,-44,44,46,56,59,-60,46,59,105
-Blaze High School Open,2014-02-08,Open Men's 56 kg,Yohanes Otto,52.63,44,-47,47,55,-58,58,47,58,105
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group +75 kg,Katrina Smith,77.85,39,-42,42,57,60,62,42,62,104
-Blaze High School Open,2014-02-08,Open Women's 69 kg,Katie Kleinow,68.74,42,-45,45,53,56,58,45,58,103
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group 63 kg,Grace Peterson,59.38,41,43,-45,53,56,58,43,58,101
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group 69 kg,Claire Boatman,67.97,39,42,44,52,-55,55,44,55,99
-Blaze High School Open,2014-02-08,Open Women's 69 kg,Lauren Lecy,68.51,40,-43,44,50,54,-57,44,54,98
-Blaze High School Open,2014-02-08,Open Men's 56 kg,Eric Paget,54.85,40,42,-43,54,56,-58,42,56,98
-Blaze High School Open,2014-02-08,Women's 14-15 Age Group +69 kg,Raezjine Merriweather,96.28,40,42,-44,-54,-54,55,42,55,97
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Matthew Melich,123.5,35,40,41,45,50,55,41,55,96
-Blaze High School Open,2014-02-08,Open Women's 63 kg,Unique McCants,62.55,35,37,-40,55,-58,58,37,58,95
-Blaze High School Open,2014-02-08,Men's 14-15 Age Group 69 kg,Jacob Boatman,63.35,38,39,40,50,52,54,40,54,94
-Blaze High School Open,2014-02-08,Open Women's 58 kg,Leela Johnson,57.22,40,-43,43,-47,47,50,43,50,93
-Blaze High School Open,2014-02-08,Open Women's 58 kg,Kallan Wenborg,57.85,37,40,-44,48,53,-55,40,53,93
-Blaze High School Open,2014-02-08,Open Men's 62 kg,Quinn Engstrom,56.7,35,37,39,50,52,54,39,54,93
-Blaze High School Open,2014-02-08,Open Men's 105 kg,Romelo Carter,95.71,40,42,-43,-50,51,-52,42,51,93
-Blaze High School Open,2014-02-08,Women's 16-17 Age Group 53 kg,McKenzie Meyers,51.75,-40,-40,40,50,-53,-55,40,50,90
-Blaze High School Open,2014-02-08,Open Women's 69 kg,Taylor Kunkel,64.58,32,34,-37,51,-53,55,34,55,89
-Blaze High School Open,2014-02-08,Open Women's 58 kg,Agnieszka Keefe,57.46,-37,-37,37,50,-52,-53,37,50,87
-Blaze High School Open,2014-02-08,Open Men's 69 kg,Lucas Meredith,68.49,-66,-69,-69,80,83,85,0,85,85
-Blaze High School Open,2014-02-08,Men's 14-15 Age Group 77 kg,Cade Maurer,75.34,28,33,36,40,44,47,36,47,83
-Blaze High School Open,2014-02-08,Open Women's 69 kg,Antonia Hopkins,67.88,-36,-36,36,46,-49,-49,36,46,82
-Blaze High School Open,2014-02-08,Men's 13 Under Age Group 56 Kg,Broderick Ulrich,54.89,-35,35,-40,47,-50,-50,35,47,82
-Blaze High School Open,2014-02-08,Open Women's 69 kg,Jamie Mittelstaedt,65.69,30,-32,32,39,42,-45,32,42,74
-Blaze High School Open,2014-02-08,Men's 13 Under Age Group 50 Kg,Thomas Gould,46.65,20,25,30,35,40,43,30,43,73
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Connor Flaten,114.95,67,72,-75,-85,-90,-90,72,0,72
-Blaze High School Open,2014-02-08,Women's 14-15 Age Group 69 kg,Erin Koestler,67.79,30,32,-34,-36,-39,39,32,39,71
-Blaze High School Open,2014-02-08,Open Men's 85 kg,Awel Mohamed,84.67,27,-29,-29,-42,44,-45,27,44,71
-Blaze High School Open,2014-02-08,Open Men's+105 kg,Jacob Boecker,124,-70,-70,70,-93,-95,-95,70,0,70
-Blaze High School Open,2014-02-08,Women's 14-15 Age Group +69 kg,Natalia Hiza,96.45,-30,30,-32,33,36,-39,30,36,66
-Blaze High School Open,2014-02-08,Women's 14-15 Age Group +69 kg,Bridget McLaughlin,89.75,-28,28,-30,31,-33,-33,28,31,59
-Blaze High School Open,2014-02-08,Women's 13 Under Age Group 44kg,Riley Meyers,41.79,20,-25,25,-28,28,33,25,33,58
-Blaze High School Open,2014-02-08,Open Men's 56 kg,Erich Hoffmann,45,18,20,21,21,22,24,21,24,45
-Blaze High School Open,2014-02-08,Open Men's 77 kg,Jeison Whipple,74.72,40,42,43,-56,-56,-56,43,0,43
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Adam Mehr,114.6,100,-103,-103,128,130,132,100,132,232,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Jake Anderson,98.18,92,-95,95,116,120,125,95,125,220,17
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Michael Trettel,107.8,88,91,93,116,119,123,93,123,216,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Gerrit Olsen,83.29,91,-94,-95,-114,115,116,91,116,207,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Joseph Splettstoeser,102.85,86,89,91,-115,115,-120,91,115,206,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Matthew Mientkiewicz,82.75,76,79,81,105,108,112,81,112,193,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Gabe Hall,82.21,73,77,81,103,105,108,81,108,189,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Eric Voxland,74.77,75,-80,80,100,104,-110,80,104,184,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Matthew Otto,98.04,80,82,84,100,-103,-103,84,100,184,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Cooper Smith,81.92,76,-79,79,98,101,104,79,104,183,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Andrew Egge,76.34,73,-77,77,100,105,-110,77,105,182,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Jackson Gilman,98.28,75,78,80,95,98,101,80,101,181,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Benn Olson,118.03,74,76,79,95,97,100,79,100,179,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Jacob Engel,90.17,75,-77,77,96,96,99,77,99,176,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Jacob Schreiber,68.94,75,-77,78,85,92,97,78,97,175,0
+Blaze High School Open,2014-02-08,Women's Masters (35-39) +75 kg,Sara Womack,78.9,72,-76,76,92,96,-98,76,96,172,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Josh Hedensten,118.14,75,-78,78,93,-97,-97,78,93,171,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Ali Husain,66.94,73,76,-80,-93,93,-96,76,93,169,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Brandon Dorshak,68.3,-72,74,-76,89,92,95,74,95,169,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Matt McDavid,85.09,70,-73,73,90,93,96,73,96,169,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Devin Kindon,75.97,60,-65,65,92,100,-105,65,100,165,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Drew Ehlers,68.14,63,65,68,93,94,96,68,96,164,0
+Blaze High School Open,2014-02-08,Open Men's 56 kg,Dithdecha Soundara,55.6,70,72,-75,85,-88,91,72,91,163,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,Nicholas Lorentz,61.5,70,75,78,85,-90,-91,78,85,163,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Tommy Haberlack,92.28,70,73,-76,90,-92,-92,73,90,163,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Ibrahim Mahmoud,75.02,70,72,-75,-90,90,-91,72,90,162,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Nick Burton,105.7,66,-68,69,-91,91,-92,69,91,160,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Armando Ramirez,106.3,65,67,69,85,88,91,69,91,160,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Jarrod Leake,89.41,70,73,-75,80,83,86,73,86,159,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Steven Hawkins,116.97,70,-72,72,80,82,84,72,84,156,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Logan Bruce,92.18,-70,-70,70,83,86,-89,70,86,156,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Andrew Lanhart,97.6,-65,-65,65,-87,87,89,65,89,154,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Nicholas Maslowski,110.56,52,56,59,87,-92,92,59,92,151,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Bailey Otto,75.85,62,65,-68,77,81,85,65,85,150,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Michael Orr,71.5,60,62,-65,85,87,88,62,88,150,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Maxwell Cantrell,71.72,62,64,-66,81,82,-85,64,82,146,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Trevor Liggett,74.39,61,63,66,80,-82,-82,66,80,146,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Jacob Parrent,80.12,62,64,-66,-78,78,81,64,81,145,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Alexander Garlington,65.34,56,59,61,77,79,82,61,82,143,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Jordan Leake,82.78,59,62,64,76,78,-80,64,78,142,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Micahjosiah Borreson,91.36,60,-64,-65,82,-86,-87,60,82,142,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Christopher Miller,74.55,-58,59,61,77,79,-81,61,79,140,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Samuel Johnson,66.99,-60,-61,62,75,77,-79,62,77,139,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Anton Sullivan,100,-62,62,-65,75,-78,-78,62,75,137,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group +75 kg,Alayna Theissen,84.11,54,-59,59,72,77,-80,59,77,136,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Noah Bachmeier,64.61,55,56,57,76,-77,78,57,78,135,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Austin George,72.4,60,62,-63,70,73,-75,62,73,135,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Nick Lane,65.06,56,58,60,70,74,-77,60,74,134,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Aron Hawkinson,74.45,57,59,-60,72,74,75,59,75,134,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,Theodore Shriver,60.42,56,-60,-60,70,75,-77,56,75,131,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Jared Shearer,64.5,-52,52,54,70,73,76,54,76,130,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,August Foss,67.28,50,-55,55,-75,75,-80,55,75,130,0
+Blaze High School Open,2014-02-08,Open Men's 94 kg,Kamal Martin,86.6,52,54,-57,72,74,76,54,76,130,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,John Perry,61.06,53,55,57,65,68,-71,57,68,125,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Justin Sturgeon,78.99,50,52,-53,70,71,73,52,73,125,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,Alex Jeon,61.49,52,-55,-55,-72,72,-74,52,72,124,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Jacob Baker,68.89,50,-52,53,65,-67,69,53,69,122,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Alexander Mckeever,67.56,48,-51,51,65,67,70,51,70,121,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group 69 kg,Natasha Rice,67.82,50,53,-56,62,-65,67,53,67,120,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,Luke Simon,56.95,47,50,53,65,67,-70,53,67,120,0
+Blaze High School Open,2014-02-08,Women's 14-15 Age Group 69 kg,Chase Schaefer,67.71,47,51,53,-63,63,65,53,65,118,0
+Blaze High School Open,2014-02-08,Open Women's 53 kg,Aneesa Ally,52.45,50,53,-55,60,62,64,53,64,117,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group +75 kg,Geneva Brandt,81.95,46,49,51,60,63,66,51,66,117,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Joseph Brue,73.17,-48,50,-53,61,64,-66,50,64,114,0
+Blaze High School Open,2014-02-08,Open Men's 56 kg,Quan Trang,55,40,43,-45,65,68,-71,43,68,111,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group 69 kg,Hailey Huseth,67.91,-43,44,-47,63,-66,66,44,66,110,0
+Blaze High School Open,2014-02-08,Open Women's 75 kg,Katie Yorek,74.46,43,45,-48,63,65,-68,45,65,110,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Jared Lozano,62.7,44,-45,-47,62,64,66,44,66,110,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,Bryce Jorgensen,56.36,42,44,47,58,60,62,47,62,109,0
+Blaze High School Open,2014-02-08,Open Women's 69 kg,Ariel Behnke,68.14,-44,44,46,56,59,-60,46,59,105,0
+Blaze High School Open,2014-02-08,Open Men's 56 kg,Yohanes Otto,52.63,44,-47,47,55,-58,58,47,58,105,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group +75 kg,Katrina Smith,77.85,39,-42,42,57,60,62,42,62,104,0
+Blaze High School Open,2014-02-08,Open Women's 69 kg,Katie Kleinow,68.74,42,-45,45,53,56,58,45,58,103,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group 63 kg,Grace Peterson,59.38,41,43,-45,53,56,58,43,58,101,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group 69 kg,Claire Boatman,67.97,39,42,44,52,-55,55,44,55,99,0
+Blaze High School Open,2014-02-08,Open Women's 69 kg,Lauren Lecy,68.51,40,-43,44,50,54,-57,44,54,98,0
+Blaze High School Open,2014-02-08,Open Men's 56 kg,Eric Paget,54.85,40,42,-43,54,56,-58,42,56,98,0
+Blaze High School Open,2014-02-08,Women's 14-15 Age Group +69 kg,Raezjine Merriweather,96.28,40,42,-44,-54,-54,55,42,55,97,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Matthew Melich,123.5,35,40,41,45,50,55,41,55,96,0
+Blaze High School Open,2014-02-08,Open Women's 63 kg,Unique McCants,62.55,35,37,-40,55,-58,58,37,58,95,0
+Blaze High School Open,2014-02-08,Men's 14-15 Age Group 69 kg,Jacob Boatman,63.35,38,39,40,50,52,54,40,54,94,0
+Blaze High School Open,2014-02-08,Open Women's 58 kg,Leela Johnson,57.22,40,-43,43,-47,47,50,43,50,93,0
+Blaze High School Open,2014-02-08,Open Women's 58 kg,Kallan Wenborg,57.85,37,40,-44,48,53,-55,40,53,93,0
+Blaze High School Open,2014-02-08,Open Men's 62 kg,Quinn Engstrom,56.7,35,37,39,50,52,54,39,54,93,0
+Blaze High School Open,2014-02-08,Open Men's 105 kg,Romelo Carter,95.71,40,42,-43,-50,51,-52,42,51,93,0
+Blaze High School Open,2014-02-08,Women's 16-17 Age Group 53 kg,McKenzie Meyers,51.75,-40,-40,40,50,-53,-55,40,50,90,0
+Blaze High School Open,2014-02-08,Open Women's 69 kg,Taylor Kunkel,64.58,32,34,-37,51,-53,55,34,55,89,0
+Blaze High School Open,2014-02-08,Open Women's 58 kg,Agnieszka Keefe,57.46,-37,-37,37,50,-52,-53,37,50,87,0
+Blaze High School Open,2014-02-08,Open Men's 69 kg,Lucas Meredith,68.49,-66,-69,-69,80,83,85,0,85,85,0
+Blaze High School Open,2014-02-08,Men's 14-15 Age Group 77 kg,Cade Maurer,75.34,28,33,36,40,44,47,36,47,83,0
+Blaze High School Open,2014-02-08,Open Women's 69 kg,Antonia Hopkins,67.88,-36,-36,36,46,-49,-49,36,46,82,0
+Blaze High School Open,2014-02-08,Men's 13 Under Age Group 56 Kg,Broderick Ulrich,54.89,-35,35,-40,47,-50,-50,35,47,82,0
+Blaze High School Open,2014-02-08,Open Women's 69 kg,Jamie Mittelstaedt,65.69,30,-32,32,39,42,-45,32,42,74,0
+Blaze High School Open,2014-02-08,Men's 13 Under Age Group 50 Kg,Thomas Gould,46.65,20,25,30,35,40,43,30,43,73,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Connor Flaten,114.95,67,72,-75,-85,-90,-90,72,0,72,0
+Blaze High School Open,2014-02-08,Women's 14-15 Age Group 69 kg,Erin Koestler,67.79,30,32,-34,-36,-39,39,32,39,71,0
+Blaze High School Open,2014-02-08,Open Men's 85 kg,Awel Mohamed,84.67,27,-29,-29,-42,44,-45,27,44,71,0
+Blaze High School Open,2014-02-08,Open Men's+105 kg,Jacob Boecker,124,-70,-70,70,-93,-95,-95,70,0,70,0
+Blaze High School Open,2014-02-08,Women's 14-15 Age Group +69 kg,Natalia Hiza,96.45,-30,30,-32,33,36,-39,30,36,66,0
+Blaze High School Open,2014-02-08,Women's 14-15 Age Group +69 kg,Bridget McLaughlin,89.75,-28,28,-30,31,-33,-33,28,31,59,0
+Blaze High School Open,2014-02-08,Women's 13 Under Age Group 44kg,Riley Meyers,41.79,20,-25,25,-28,28,33,25,33,58,0
+Blaze High School Open,2014-02-08,Open Men's 56 kg,Erich Hoffmann,45,18,20,21,21,22,24,21,24,45,0
+Blaze High School Open,2014-02-08,Open Men's 77 kg,Jeison Whipple,74.72,40,42,43,-56,-56,-56,43,0,43,0

--- a/event_data/US/1377.csv
+++ b/event_data/US/1377.csv
@@ -1,89 +1,89 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Eric Rousemiller,132.8,90,95,100,120,125,130,100,130,230
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Nate Oelke,68.65,90,94,95,123,126,130,95,130,225
-Rosemont High School Open,2014-01-18,Open Men's 105 kg,Tramail Peterson,104.4,85,89,95,120,126,130,95,130,225
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Gabriel Ehlers,92.55,85,90,95,115,120,125,95,125,220
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Jacob Koestler,114.2,84,87,90,121,126,130,90,130,220
-Rosemont High School Open,2014-01-18,Open Men's 105 kg,Jake Anderson,99.45,86,90,94,116,116,120,94,120,214
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Michael Trettel,108,86,90,92,116,120,120,92,120,212
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Joseph Splettstoeser,107.5,83,83,86,105,110,115,86,115,201
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,William O'Connell,92,80,85,87,102,109,112,87,112,199
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Jonas Hagen,91.4,80,83,83,105,108,111,83,111,194
-Rosemont High School Open,2014-01-18,Open Men's 85 kg,Auston Anderson,84.8,80,85,87,100,105,105,87,105,192
-Rosemont High School Open,2014-01-18,Open Men's 85 kg,Gabe Hall,83,72,76,80,98,102,107,80,107,187
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Andrew Egge,76.45,70,75,78,95,100,103,78,103,181
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Matthew Delk,108.1,72,75,78,95,100,103,78,103,181
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Carson Chytracek,66.6,72,75,78,87,92,95,78,95,173
-Rosemont High School Open,2014-01-18,Open Men's 105 kg,Jacob Boecker,103.5,70,72,75,93,97,97,75,97,172
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Bailey Mills,76.95,72,76,76,90,93,95,76,95,171
-Rosemont High School Open,2014-01-18,Open Men's 62 kg,Nicholas Lorentz,61.1,70,75,78,85,90,90,78,90,168
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Devan Heaney,69.2,69,72,75,83,88,93,75,93,168
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Josh Hedensten,118.5,61,64,68,88,92,97,68,97,165
-Rosemont High School Open,2014-01-18,Open Men's 62 kg,Kevin Trinh,60.8,65,65,65,85,90,95,65,95,160
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Sodasinh Simphilavong,65,60,65,70,75,85,90,70,90,160
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Logan Bruce,90.95,63,65,70,68,80,89,70,89,159
-Rosemont High School Open,2014-01-18,Open Men's 85 kg,Jacob Stewart,84.25,60,65,70,72,80,85,70,85,155
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Brett Fatturi,90.8,65,70,70,85,85,85,70,85,155
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Alex Hughes,108.85,60,65,70,75,85,85,70,85,155
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Connor Flaten,113.65,61,65,68,78,82,85,68,85,153
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Mason Berreth,110.25,60,65,65,55,80,85,65,85,150
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Trevor Liggett,72.55,60,63,66,80,83,83,66,83,149
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Bailey Otto,74.85,55,62,65,75,80,84,65,84,149
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Michael Orr,69.7,60,60,63,82,84,86,63,86,149
-Rosemont High School Open,2014-01-18,Open Women's 75 kg,Madasyn Hofstedt,71.85,58,62,66,78,82,82,66,82,148
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Lucas Meredith,68.35,64,66,68,75,77,80,68,80,148
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Micahjosiah Borreson,90.65,57,60,63,79,82,85,63,85,148
-Rosemont High School Open,2014-01-18,Open Men's 105 kg,Stephen Rossacci,102.9,52,56,59,77,80,85,59,85,144
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Mitchell Jacobson,71.9,50,55,62,60,70,80,62,80,142
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Nicholas Maslowski,111.75,50,52,56,83,85,85,56,85,141
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Tristin Leonard,131.7,55,58,60,70,75,80,60,80,140
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Alayna Theissen,83.15,51,53,58,67,72,76,58,76,134
-Rosemont High School Open,2014-01-18,Men's 14-15 Age Group +85 kg,Stephen Shabaz,89.95,40,50,58,60,70,75,58,75,133
-Rosemont High School Open,2014-01-18,Open Women's +75 Kg,Abigail Monn,98.7,50,53,56,67,70,74,56,74,130
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Aaron Hardel,66.5,50,55,60,60,70,70,60,70,130
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Jonathan Farren,87.15,45,50,58,60,65,70,58,70,128
-Rosemont High School Open,2014-01-18,Open Men's 56 kg,David Hausmann,55,55,58,62,63,63,65,62,65,127
-Rosemont High School Open,2014-01-18,Open Men's 62 kg,Alex Jeon,59.65,50,52,54,68,71,72,54,72,126
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Ellijah Maze,75.1,50,50,55,60,65,70,55,70,125
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Jonathan Elias,76,48,50,53,60,65,70,53,70,123
-Rosemont High School Open,2014-01-18,Open Men's 94 kg,Christopher Williams,87.7,40,45,50,60,60,70,50,70,120
-Rosemont High School Open,2014-01-18,Open Men's+105 kg,Brandon Harris,115.45,40,40,40,70,75,80,40,80,120
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Alexander Mckeever,64.85,48,51,53,63,66,66,53,66,119
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Joseph Brue,72.75,47,50,53,58,61,66,53,66,119
-Rosemont High School Open,2014-01-18,Open Men's 62 kg,John Perry,61.05,44,49,52,60,63,66,52,66,118
-Rosemont High School Open,2014-01-18,Open Men's 77 kg,Peter Eklund,75.95,40,45,48,50,60,70,48,70,118
-Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 69 kg,Chase Schaefer,67.55,47,50,53,57,63,65,53,65,118
-Rosemont High School Open,2014-01-18,Open Women's 69 kg,Alyssa Smith,68.3,47,50,52,60,63,65,52,65,117
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 69 kg,Natasha Rice,68,49,51,51,60,62,65,51,65,116
-Rosemont High School Open,2014-01-18,Open Men's 105 kg,Bryce Polson,101.2,45,50,55,60,60,60,55,60,115
-Rosemont High School Open,2014-01-18,Open Women's 75 kg,Katie Yorek,73.85,40,43,47,63,63,66,47,66,113
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 53 kg,Michaela McIntosh,50.45,43,45,47,61,64,66,47,66,113
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 69 kg,Hailey Huseth,68.75,44,47,47,58,60,65,47,65,112
-Rosemont High School Open,2014-01-18,Men's 14-15 Age Group 69 kg,Nicholas Rousemiller,69,40,45,50,50,55,60,50,60,110
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 75 kg,Katie Noble,71.9,45,48,48,55,59,62,48,62,110
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Abigail Hillyer,81.8,40,45,48,50,55,60,48,60,108
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 53 kg,Taran Pickar,52.95,43,46,47,55,58,61,47,61,108
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 48 kg,Destiny Young,47.5,44,46,48,54,56,59,48,59,107
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Madison Griffin,89.25,40,44,44,55,58,61,44,61,105
-Rosemont High School Open,2014-01-18,Open Men's 69 kg,Jory Rupp,68.85,40,45,45,50,55,60,45,60,105
-Rosemont High School Open,2014-01-18,Open Men's 56 kg,Yohanes Otto,51.65,40,45,47,50,51,55,47,55,102
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Stephanie Haag- Larson,89.6,33,37,40,52,57,62,40,62,102
-Rosemont High School Open,2014-01-18,Open Women's 69 kg,Lauren Lecy,68.3,40,40,45,50,53,56,45,56,101
-Rosemont High School Open,2014-01-18,Open Women's 58 kg,Renae Otto,57.7,38,40,42,50,53,56,42,56,98
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 69 kg,Haley Heilmann,68.3,35,38,40,50,54,58,40,58,98
-Rosemont High School Open,2014-01-18,Open Men's 62 kg,Benjamin Nhan,56.8,38,41,42,50,53,56,42,56,98
-Rosemont High School Open,2014-01-18,Open Women's 58 kg,Leela Johnson,57.3,40,43,43,48,51,53,43,53,96
-Rosemont High School Open,2014-01-18,Open Women's 58 kg,Kallan Wenborg,57.25,37,40,43,45,48,51,43,51,94
-Rosemont High School Open,2014-01-18,Men's 13 Under Age Group 56 Kg,Broderick Ulrich,55.65,33,37,40,45,50,52,40,52,92
-Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 48 kg,Tatum Pickar,47.4,35,38,40,40,49,51,40,51,91
-Rosemont High School Open,2014-01-18,Open Women's 69 kg,Taylor Kunkel,64.2,32,34,37,49,51,53,37,53,90
-Rosemont High School Open,2014-01-18,Open Women's 69 kg,Angela Shepherd,68.85,37,40,40,45,48,49,40,49,89
-Rosemont High School Open,2014-01-18,Open Men's 85 kg,John Allstot,80.75,30,32,34,45,45,47,34,47,81
-Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 63 kg,Mariah Miller,62.8,33,35,38,35,40,43,38,43,81
-Rosemont High School Open,2014-01-18,Open Women's 58 kg,Molly Thomforde,54.9,30,32,32,44,46,46,32,46,78
-Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 63 kg,Victoria Barnett,61.45,28,30,32,35,40,43,32,43,75
-Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 69 kg,Erin Koestler,67.85,28,29,31,35,38,41,31,41,72
-Rosemont High School Open,2014-01-18,Men's 14-15 Age Group 56 Kg,William Hoskins,53.8,24,27,30,36,36,40,30,40,70
-Rosemont High School Open,2014-01-18,Women's 14-15 Age Group +69 kg,Natalia Hiza,96.6,27,30,32,30,33,35,32,35,67
-Rosemont High School Open,2014-01-18,Women's 14-15 Age Group +69 kg,Bridget McLaughlin,88.85,27,30,30,30,33,33,30,33,63
-Rosemont High School Open,2014-01-18,Open Men's 56 kg,Erich Hoffmann,44.95,18,19,20,20,21,23,20,23,43
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Eric Rousemiller,132.8,90,95,100,120,125,130,100,130,230,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Nate Oelke,68.65,90,94,95,123,126,130,95,130,225,0
+Rosemont High School Open,2014-01-18,Open Men's 105 kg,Tramail Peterson,104.4,85,89,95,120,126,130,95,130,225,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Gabriel Ehlers,92.55,85,90,95,115,120,125,95,125,220,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Jacob Koestler,114.2,84,87,90,121,126,130,90,130,220,0
+Rosemont High School Open,2014-01-18,Open Men's 105 kg,Jake Anderson,99.45,86,90,94,116,116,120,94,120,214,17
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Michael Trettel,108,86,90,92,116,120,120,92,120,212,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Joseph Splettstoeser,107.5,83,83,86,105,110,115,86,115,201,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,William O'Connell,92,80,85,87,102,109,112,87,112,199,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Jonas Hagen,91.4,80,83,83,105,108,111,83,111,194,0
+Rosemont High School Open,2014-01-18,Open Men's 85 kg,Auston Anderson,84.8,80,85,87,100,105,105,87,105,192,0
+Rosemont High School Open,2014-01-18,Open Men's 85 kg,Gabe Hall,83,72,76,80,98,102,107,80,107,187,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Andrew Egge,76.45,70,75,78,95,100,103,78,103,181,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Matthew Delk,108.1,72,75,78,95,100,103,78,103,181,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Carson Chytracek,66.6,72,75,78,87,92,95,78,95,173,0
+Rosemont High School Open,2014-01-18,Open Men's 105 kg,Jacob Boecker,103.5,70,72,75,93,97,97,75,97,172,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Bailey Mills,76.95,72,76,76,90,93,95,76,95,171,0
+Rosemont High School Open,2014-01-18,Open Men's 62 kg,Nicholas Lorentz,61.1,70,75,78,85,90,90,78,90,168,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Devan Heaney,69.2,69,72,75,83,88,93,75,93,168,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Josh Hedensten,118.5,61,64,68,88,92,97,68,97,165,0
+Rosemont High School Open,2014-01-18,Open Men's 62 kg,Kevin Trinh,60.8,65,65,65,85,90,95,65,95,160,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Sodasinh Simphilavong,65,60,65,70,75,85,90,70,90,160,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Logan Bruce,90.95,63,65,70,68,80,89,70,89,159,0
+Rosemont High School Open,2014-01-18,Open Men's 85 kg,Jacob Stewart,84.25,60,65,70,72,80,85,70,85,155,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Brett Fatturi,90.8,65,70,70,85,85,85,70,85,155,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Alex Hughes,108.85,60,65,70,75,85,85,70,85,155,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Connor Flaten,113.65,61,65,68,78,82,85,68,85,153,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Mason Berreth,110.25,60,65,65,55,80,85,65,85,150,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Trevor Liggett,72.55,60,63,66,80,83,83,66,83,149,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Bailey Otto,74.85,55,62,65,75,80,84,65,84,149,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Michael Orr,69.7,60,60,63,82,84,86,63,86,149,0
+Rosemont High School Open,2014-01-18,Open Women's 75 kg,Madasyn Hofstedt,71.85,58,62,66,78,82,82,66,82,148,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Lucas Meredith,68.35,64,66,68,75,77,80,68,80,148,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Micahjosiah Borreson,90.65,57,60,63,79,82,85,63,85,148,0
+Rosemont High School Open,2014-01-18,Open Men's 105 kg,Stephen Rossacci,102.9,52,56,59,77,80,85,59,85,144,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Mitchell Jacobson,71.9,50,55,62,60,70,80,62,80,142,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Nicholas Maslowski,111.75,50,52,56,83,85,85,56,85,141,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Tristin Leonard,131.7,55,58,60,70,75,80,60,80,140,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Alayna Theissen,83.15,51,53,58,67,72,76,58,76,134,0
+Rosemont High School Open,2014-01-18,Men's 14-15 Age Group +85 kg,Stephen Shabaz,89.95,40,50,58,60,70,75,58,75,133,0
+Rosemont High School Open,2014-01-18,Open Women's +75 Kg,Abigail Monn,98.7,50,53,56,67,70,74,56,74,130,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Aaron Hardel,66.5,50,55,60,60,70,70,60,70,130,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Jonathan Farren,87.15,45,50,58,60,65,70,58,70,128,0
+Rosemont High School Open,2014-01-18,Open Men's 56 kg,David Hausmann,55,55,58,62,63,63,65,62,65,127,0
+Rosemont High School Open,2014-01-18,Open Men's 62 kg,Alex Jeon,59.65,50,52,54,68,71,72,54,72,126,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Ellijah Maze,75.1,50,50,55,60,65,70,55,70,125,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Jonathan Elias,76,48,50,53,60,65,70,53,70,123,0
+Rosemont High School Open,2014-01-18,Open Men's 94 kg,Christopher Williams,87.7,40,45,50,60,60,70,50,70,120,0
+Rosemont High School Open,2014-01-18,Open Men's+105 kg,Brandon Harris,115.45,40,40,40,70,75,80,40,80,120,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Alexander Mckeever,64.85,48,51,53,63,66,66,53,66,119,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Joseph Brue,72.75,47,50,53,58,61,66,53,66,119,0
+Rosemont High School Open,2014-01-18,Open Men's 62 kg,John Perry,61.05,44,49,52,60,63,66,52,66,118,0
+Rosemont High School Open,2014-01-18,Open Men's 77 kg,Peter Eklund,75.95,40,45,48,50,60,70,48,70,118,0
+Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 69 kg,Chase Schaefer,67.55,47,50,53,57,63,65,53,65,118,0
+Rosemont High School Open,2014-01-18,Open Women's 69 kg,Alyssa Smith,68.3,47,50,52,60,63,65,52,65,117,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 69 kg,Natasha Rice,68,49,51,51,60,62,65,51,65,116,0
+Rosemont High School Open,2014-01-18,Open Men's 105 kg,Bryce Polson,101.2,45,50,55,60,60,60,55,60,115,0
+Rosemont High School Open,2014-01-18,Open Women's 75 kg,Katie Yorek,73.85,40,43,47,63,63,66,47,66,113,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 53 kg,Michaela McIntosh,50.45,43,45,47,61,64,66,47,66,113,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 69 kg,Hailey Huseth,68.75,44,47,47,58,60,65,47,65,112,0
+Rosemont High School Open,2014-01-18,Men's 14-15 Age Group 69 kg,Nicholas Rousemiller,69,40,45,50,50,55,60,50,60,110,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 75 kg,Katie Noble,71.9,45,48,48,55,59,62,48,62,110,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Abigail Hillyer,81.8,40,45,48,50,55,60,48,60,108,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 53 kg,Taran Pickar,52.95,43,46,47,55,58,61,47,61,108,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 48 kg,Destiny Young,47.5,44,46,48,54,56,59,48,59,107,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Madison Griffin,89.25,40,44,44,55,58,61,44,61,105,0
+Rosemont High School Open,2014-01-18,Open Men's 69 kg,Jory Rupp,68.85,40,45,45,50,55,60,45,60,105,0
+Rosemont High School Open,2014-01-18,Open Men's 56 kg,Yohanes Otto,51.65,40,45,47,50,51,55,47,55,102,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group +75 kg,Stephanie Haag- Larson,89.6,33,37,40,52,57,62,40,62,102,0
+Rosemont High School Open,2014-01-18,Open Women's 69 kg,Lauren Lecy,68.3,40,40,45,50,53,56,45,56,101,0
+Rosemont High School Open,2014-01-18,Open Women's 58 kg,Renae Otto,57.7,38,40,42,50,53,56,42,56,98,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 69 kg,Haley Heilmann,68.3,35,38,40,50,54,58,40,58,98,0
+Rosemont High School Open,2014-01-18,Open Men's 62 kg,Benjamin Nhan,56.8,38,41,42,50,53,56,42,56,98,0
+Rosemont High School Open,2014-01-18,Open Women's 58 kg,Leela Johnson,57.3,40,43,43,48,51,53,43,53,96,0
+Rosemont High School Open,2014-01-18,Open Women's 58 kg,Kallan Wenborg,57.25,37,40,43,45,48,51,43,51,94,0
+Rosemont High School Open,2014-01-18,Men's 13 Under Age Group 56 Kg,Broderick Ulrich,55.65,33,37,40,45,50,52,40,52,92,0
+Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 48 kg,Tatum Pickar,47.4,35,38,40,40,49,51,40,51,91,0
+Rosemont High School Open,2014-01-18,Open Women's 69 kg,Taylor Kunkel,64.2,32,34,37,49,51,53,37,53,90,0
+Rosemont High School Open,2014-01-18,Open Women's 69 kg,Angela Shepherd,68.85,37,40,40,45,48,49,40,49,89,0
+Rosemont High School Open,2014-01-18,Open Men's 85 kg,John Allstot,80.75,30,32,34,45,45,47,34,47,81,0
+Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 63 kg,Mariah Miller,62.8,33,35,38,35,40,43,38,43,81,0
+Rosemont High School Open,2014-01-18,Open Women's 58 kg,Molly Thomforde,54.9,30,32,32,44,46,46,32,46,78,0
+Rosemont High School Open,2014-01-18,Women's 16-17 Age Group 63 kg,Victoria Barnett,61.45,28,30,32,35,40,43,32,43,75,0
+Rosemont High School Open,2014-01-18,Women's 14-15 Age Group 69 kg,Erin Koestler,67.85,28,29,31,35,38,41,31,41,72,0
+Rosemont High School Open,2014-01-18,Men's 14-15 Age Group 56 Kg,William Hoskins,53.8,24,27,30,36,36,40,30,40,70,0
+Rosemont High School Open,2014-01-18,Women's 14-15 Age Group +69 kg,Natalia Hiza,96.6,27,30,32,30,33,35,32,35,67,0
+Rosemont High School Open,2014-01-18,Women's 14-15 Age Group +69 kg,Bridget McLaughlin,88.85,27,30,30,30,33,33,30,33,63,0
+Rosemont High School Open,2014-01-18,Open Men's 56 kg,Erich Hoffmann,44.95,18,19,20,20,21,23,20,23,43,0

--- a/event_data/US/1384.csv
+++ b/event_data/US/1384.csv
@@ -1,93 +1,93 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Preston Anderson,92.4,115,-123,-131,130,-140,-145,115,130,245
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Jake Anderson,96.6,95,100,105,125,130,140,105,140,245
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Connor Rousemiller,96.5,105,110,-115,130,-140,-140,110,130,240
-MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Jacob Koestler,110.7,93,97,100,132,137,-141,100,137,237
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Tramail Peterson,104.3,95,100,-103,-135,135,-139,100,135,235
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Michael Schiller,74.4,95,97,100,130,133,-136,100,133,233
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Gabriel Ehlers,92.3,95,100,-104,128,132,-135,100,132,232
-MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Adam Mehr,118,95,-100,100,-130,-130,130,100,130,230
-MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Eric Rousemiller,131.2,100,-105,-105,125,-133,-133,100,125,225
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Nate Oelke,68.6,93,-97,-98,126,129,-132,93,129,222
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Jonas Hagen,89.4,88,-91,91,115,-120,122,91,122,213
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Joseph Splettstoeser,104.1,90,93,-96,118,-123,-123,93,118,211
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Kevin Kucera,91.6,90,-93,93,112,115,-120,93,115,208
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Evan Stoffregen,78.7,-90,90,-100,116,0,0,90,116,206
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Gerrit Olsen,83,-93,-93,93,-113,113,-114,93,113,206
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Steven Pfahning,76.6,85,88,91,-113,113,-120,91,113,204
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,William Staska,93.2,80,85,-88,100,-105,106,85,106,191
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Trevor Heagle,93.3,75,80,-85,100,106,-112,80,106,186
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Eric Voxland,73.6,76,-80,80,-105,-105,105,80,105,185
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Andrew Egge,75.9,72,77,-80,-102,102,107,77,107,184
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Grahm Johnson,76.4,76,79,-81,98,-102,102,79,102,181
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Carson Chytracek,67.5,-75,75,-80,95,-100,100,75,100,175
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Devan Heaney,68.9,72,74,76,90,93,97,76,97,173
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Kevin Trinh,60.9,68,72,-76,92,96,100,72,100,172
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Brandon Dorshak,68.1,-73,73,75,88,92,97,75,97,172
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Logan Bruce,92.9,80,-85,-85,85,89,-100,80,89,169
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Drew Ehlers,69,63,66,68,93,96,-99,68,96,164
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Brett Fatturi,83.6,70,73,-75,85,-90,90,73,90,163
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Nicholas Lorentz,61.4,73,-78,-78,85,90,-95,73,90,163
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Jacob Parrent,83.4,68,70,72,86,88,90,72,90,162
-MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Mason Berreth,110.2,70,75,-80,85,-95,-95,75,85,160
-MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group +69 kg,Alicia Vogel,85.7,62,66,-70,-85,85,91,66,91,157
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Bailey Otto,76.2,65,-70,-70,85,92,-95,65,92,157
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Alexander Garlington,65.9,62,64,-66,86,89,92,64,92,156
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Joseph Sevlie,73.8,66,-69,69,82,85,87,69,87,156
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Trevor Liggett,75,65,70,-72,-85,85,-88,70,85,155
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Jacob Stewart,83.8,65,70,-73,85,-88,-90,70,85,155
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Noah Bachmeier,65,60,62,65,86,88,-90,65,88,153
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 75 kg,Madasyn Hofstedt,73,60,64,-68,80,86,-90,64,86,150
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Andrew Manor,73.7,58,59,61,-86,86,-89,61,86,147
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group +75 kg,Alayna Theissen,83.7,58,62,65,76,81,-84,65,81,146
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Maxwell Cantrell,70.7,60,-62,62,80,81,83,62,83,145
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 75 kg,Sierra Virnig,72.4,53,57,60,68,72,75,60,75,135
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,John Perry,61.1,54,56,58,70,-73,73,58,73,131
-MN HS Weightlifting State Championship,2014-03-08,Open Women's +75 Kg,Abigail Monn,102,54,-56,57,70,-73,73,57,73,130
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Natasha Rice,68.4,56,59,-61,64,67,70,59,70,129
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Erica Kesseh,61.7,54,-56,56,71,73,-76,56,73,129
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Rachel Tuma,63,55,-57,57,68,70,-73,57,70,127
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 69 kg,Payton Schulze,67.8,50,53,55,69,72,-75,55,72,127
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,David Hausmann,54.2,55,59,62,-65,-65,65,62,65,127
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Luke Simon,59.3,50,52,54,69,-71,71,54,71,125
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 69 kg,Alyssa Smith,68,-50,50,-53,64,67,70,50,70,120
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group +75 kg,Geneva Brandt,82.4,48,-51,51,-64,64,66,51,66,117
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Yohanes Otto,52,49,-52,52,60,-63,65,52,65,117
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 75 kg,Katie Yorek,74,45,47,-49,65,67,-70,47,67,114
-MN HS Weightlifting State Championship,2014-03-08,Men's 14-15 Age Group 56 Kg,William Meacham,55,47,49,51,59,63,-67,51,63,114
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Emily Lundstrom,62,49,-52,-52,64,-66,-66,49,64,113
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Hailey Huseth,68.6,-45,46,48,65,-70,-73,48,65,113
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 53 kg,Michaela McIntosh,52.4,46,-48,-49,-65,65,-68,46,65,111
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 69 kg,Ariel Behnke,68.3,46,48,-50,57,59,61,48,61,109
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 75 kg,Katie Noble,71.8,-45,45,-48,55,60,63,45,63,108
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 63 kg,Grace Peterson,59.9,42,44,46,57,60,62,46,62,108
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Quan Trang,54.6,43,46,48,57,-60,60,48,60,108
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 75 kg,Tessa Guon,69.3,-45,45,-47,-57,57,62,45,62,107
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 48 kg,Destiny Young,47.4,-46,46,-49,57,-60,60,46,60,106
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Benjamin Nhan,57.1,42,-45,45,56,60,-62,45,60,105
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 63 kg,Cassidie Parker,61,39,42,44,55,59,-63,44,59,103
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Haley Heilmann,67.3,40,43,-46,-60,60,-65,43,60,103
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Kallan Wenborg,57.9,44,-46,46,54,57,-60,46,57,103
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Maggie DeGroot,58.1,-45,-45,46,55,57,-59,46,57,103
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Eric Paget,55.1,-40,-42,42,59,61,-63,42,61,103
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 53 kg,Taran Pickar,52.6,42,45,-47,54,57,-60,45,57,102
-MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group +69 kg,Raezjine Merriweather,97.5,-41,41,-42,-60,-60,60,41,60,101
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Leela Johnson,57.8,40,43,45,50,53,55,45,55,100
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group +75 kg,Stephanie Haag- Larson,89.5,37,-41,41,-58,58,-62,41,58,99
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Abigail Goerdt,56.3,-41,41,-43,58,-61,-61,41,58,99
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Gabriel Farmer,45.1,36,40,-44,52,56,58,40,58,98
-MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group 58 kg,Madisyn Heaney,57.4,40,-42,42,52,55,-58,42,55,97
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Natalie Parker,67.2,39,-42,-42,54,57,-60,39,57,96
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Unique McCants,62.8,38,-40,-40,-58,-58,58,38,58,96
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Agnieszka Keefe,57.3,38,40,42,52,-54,-54,42,52,94
-MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Renae Otto,57.5,-38,38,-41,53,-56,-56,38,53,91
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Nick Burton,103.3,-70,-70,-70,90,91,-92,0,91,91
-MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group 48 kg,Tatum Pickar,48,35,39,-42,48,51,-53,39,51,90
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 53 kg,McKenzie Meyers,52.7,-35,35,40,50,-55,-57,40,50,90
-MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group 63 kg,Mariah Miller,62.6,32,36,40,43,46,50,40,50,90
-MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Bailey Neumann,60.6,-70,-73,-73,87,90,-95,0,90,90
-MN HS Weightlifting State Championship,2014-03-08,Men's 13 Under Age Group 50 Kg,Hadyn Anderson,45.4,33,36,38,42,46,50,38,50,88
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 63 kg,Victoria Barnett,59.6,30,33,36,40,43,-46,36,43,79
-MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 48 kg,Jackie Levvintre,45.5,25,28,30,35,37,-39,30,37,67
-MN HS Weightlifting State Championship,2014-03-08,Women's 13 Under Age Group 44kg,Riley Meyers,42.1,20,24,28,28,33,-37,28,33,61
-MN HS Weightlifting State Championship,2014-03-08,Men's 14-15 Age Group 62 kg,Joseph Heagle,56.2,37,-41,-43,0,0,0,37,0,37
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Preston Anderson,92.4,115,-123,-131,130,-140,-145,115,130,245,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Jake Anderson,96.6,95,100,105,125,130,140,105,140,245,17
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Connor Rousemiller,96.5,105,110,-115,130,-140,-140,110,130,240,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Jacob Koestler,110.7,93,97,100,132,137,-141,100,137,237,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Tramail Peterson,104.3,95,100,-103,-135,135,-139,100,135,235,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Michael Schiller,74.4,95,97,100,130,133,-136,100,133,233,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Gabriel Ehlers,92.3,95,100,-104,128,132,-135,100,132,232,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Adam Mehr,118,95,-100,100,-130,-130,130,100,130,230,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Eric Rousemiller,131.2,100,-105,-105,125,-133,-133,100,125,225,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Nate Oelke,68.6,93,-97,-98,126,129,-132,93,129,222,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Jonas Hagen,89.4,88,-91,91,115,-120,122,91,122,213,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Joseph Splettstoeser,104.1,90,93,-96,118,-123,-123,93,118,211,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Kevin Kucera,91.6,90,-93,93,112,115,-120,93,115,208,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Evan Stoffregen,78.7,-90,90,-100,116,0,0,90,116,206,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Gerrit Olsen,83,-93,-93,93,-113,113,-114,93,113,206,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Steven Pfahning,76.6,85,88,91,-113,113,-120,91,113,204,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,William Staska,93.2,80,85,-88,100,-105,106,85,106,191,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Trevor Heagle,93.3,75,80,-85,100,106,-112,80,106,186,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Eric Voxland,73.6,76,-80,80,-105,-105,105,80,105,185,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Andrew Egge,75.9,72,77,-80,-102,102,107,77,107,184,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Grahm Johnson,76.4,76,79,-81,98,-102,102,79,102,181,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Carson Chytracek,67.5,-75,75,-80,95,-100,100,75,100,175,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Devan Heaney,68.9,72,74,76,90,93,97,76,97,173,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Kevin Trinh,60.9,68,72,-76,92,96,100,72,100,172,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Brandon Dorshak,68.1,-73,73,75,88,92,97,75,97,172,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 94 kg,Logan Bruce,92.9,80,-85,-85,85,89,-100,80,89,169,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Drew Ehlers,69,63,66,68,93,96,-99,68,96,164,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Brett Fatturi,83.6,70,73,-75,85,-90,90,73,90,163,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Nicholas Lorentz,61.4,73,-78,-78,85,90,-95,73,90,163,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Jacob Parrent,83.4,68,70,72,86,88,90,72,90,162,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's+105 kg,Mason Berreth,110.2,70,75,-80,85,-95,-95,75,85,160,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group +69 kg,Alicia Vogel,85.7,62,66,-70,-85,85,91,66,91,157,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Bailey Otto,76.2,65,-70,-70,85,92,-95,65,92,157,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Alexander Garlington,65.9,62,64,-66,86,89,92,64,92,156,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Joseph Sevlie,73.8,66,-69,69,82,85,87,69,87,156,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Trevor Liggett,75,65,70,-72,-85,85,-88,70,85,155,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 85 kg,Jacob Stewart,83.8,65,70,-73,85,-88,-90,70,85,155,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 69 kg,Noah Bachmeier,65,60,62,65,86,88,-90,65,88,153,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 75 kg,Madasyn Hofstedt,73,60,64,-68,80,86,-90,64,86,150,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Andrew Manor,73.7,58,59,61,-86,86,-89,61,86,147,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group +75 kg,Alayna Theissen,83.7,58,62,65,76,81,-84,65,81,146,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 77 kg,Maxwell Cantrell,70.7,60,-62,62,80,81,83,62,83,145,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 75 kg,Sierra Virnig,72.4,53,57,60,68,72,75,60,75,135,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,John Perry,61.1,54,56,58,70,-73,73,58,73,131,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's +75 Kg,Abigail Monn,102,54,-56,57,70,-73,73,57,73,130,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Natasha Rice,68.4,56,59,-61,64,67,70,59,70,129,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Erica Kesseh,61.7,54,-56,56,71,73,-76,56,73,129,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Rachel Tuma,63,55,-57,57,68,70,-73,57,70,127,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 69 kg,Payton Schulze,67.8,50,53,55,69,72,-75,55,72,127,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,David Hausmann,54.2,55,59,62,-65,-65,65,62,65,127,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Luke Simon,59.3,50,52,54,69,-71,71,54,71,125,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 69 kg,Alyssa Smith,68,-50,50,-53,64,67,70,50,70,120,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group +75 kg,Geneva Brandt,82.4,48,-51,51,-64,64,66,51,66,117,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Yohanes Otto,52,49,-52,52,60,-63,65,52,65,117,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 75 kg,Katie Yorek,74,45,47,-49,65,67,-70,47,67,114,0
+MN HS Weightlifting State Championship,2014-03-08,Men's 14-15 Age Group 56 Kg,William Meacham,55,47,49,51,59,63,-67,51,63,114,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Emily Lundstrom,62,49,-52,-52,64,-66,-66,49,64,113,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Hailey Huseth,68.6,-45,46,48,65,-70,-73,48,65,113,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 53 kg,Michaela McIntosh,52.4,46,-48,-49,-65,65,-68,46,65,111,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 69 kg,Ariel Behnke,68.3,46,48,-50,57,59,61,48,61,109,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 75 kg,Katie Noble,71.8,-45,45,-48,55,60,63,45,63,108,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 63 kg,Grace Peterson,59.9,42,44,46,57,60,62,46,62,108,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Quan Trang,54.6,43,46,48,57,-60,60,48,60,108,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 75 kg,Tessa Guon,69.3,-45,45,-47,-57,57,62,45,62,107,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 48 kg,Destiny Young,47.4,-46,46,-49,57,-60,60,46,60,106,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Benjamin Nhan,57.1,42,-45,45,56,60,-62,45,60,105,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 63 kg,Cassidie Parker,61,39,42,44,55,59,-63,44,59,103,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Haley Heilmann,67.3,40,43,-46,-60,60,-65,43,60,103,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Kallan Wenborg,57.9,44,-46,46,54,57,-60,46,57,103,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Maggie DeGroot,58.1,-45,-45,46,55,57,-59,46,57,103,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Eric Paget,55.1,-40,-42,42,59,61,-63,42,61,103,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 53 kg,Taran Pickar,52.6,42,45,-47,54,57,-60,45,57,102,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group +69 kg,Raezjine Merriweather,97.5,-41,41,-42,-60,-60,60,41,60,101,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Leela Johnson,57.8,40,43,45,50,53,55,45,55,100,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group +75 kg,Stephanie Haag- Larson,89.5,37,-41,41,-58,58,-62,41,58,99,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Abigail Goerdt,56.3,-41,41,-43,58,-61,-61,41,58,99,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 56 kg,Gabriel Farmer,45.1,36,40,-44,52,56,58,40,58,98,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group 58 kg,Madisyn Heaney,57.4,40,-42,42,52,55,-58,42,55,97,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 69 kg,Natalie Parker,67.2,39,-42,-42,54,57,-60,39,57,96,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 63 kg,Unique McCants,62.8,38,-40,-40,-58,-58,58,38,58,96,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Agnieszka Keefe,57.3,38,40,42,52,-54,-54,42,52,94,0
+MN HS Weightlifting State Championship,2014-03-08,Open Women's 58 kg,Renae Otto,57.5,-38,38,-41,53,-56,-56,38,53,91,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 105 kg,Nick Burton,103.3,-70,-70,-70,90,91,-92,0,91,91,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group 48 kg,Tatum Pickar,48,35,39,-42,48,51,-53,39,51,90,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 53 kg,McKenzie Meyers,52.7,-35,35,40,50,-55,-57,40,50,90,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 14-15 Age Group 63 kg,Mariah Miller,62.6,32,36,40,43,46,50,40,50,90,0
+MN HS Weightlifting State Championship,2014-03-08,Open Men's 62 kg,Bailey Neumann,60.6,-70,-73,-73,87,90,-95,0,90,90,0
+MN HS Weightlifting State Championship,2014-03-08,Men's 13 Under Age Group 50 Kg,Hadyn Anderson,45.4,33,36,38,42,46,50,38,50,88,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 63 kg,Victoria Barnett,59.6,30,33,36,40,43,-46,36,43,79,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 16-17 Age Group 48 kg,Jackie Levvintre,45.5,25,28,30,35,37,-39,30,37,67,0
+MN HS Weightlifting State Championship,2014-03-08,Women's 13 Under Age Group 44kg,Riley Meyers,42.1,20,24,28,28,33,-37,28,33,61,0
+MN HS Weightlifting State Championship,2014-03-08,Men's 14-15 Age Group 62 kg,Joseph Heagle,56.2,37,-41,-43,0,0,0,37,0,37,0

--- a/event_data/US/1640.csv
+++ b/event_data/US/1640.csv
@@ -1,496 +1,496 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Ryan Sennett,131.3,137,141,-145,165,-170,170,141,170,311
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Michael H Cohen,83.64,115,119,122,150,159,159,122,159,281
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dominick Trozzi,76.6,116,120,124,146,155,155,124,155,279
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Clarence Cummings,63.98,108,114,118,138,146,153,118,153,271
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Dylan Cooper,83.52,110,115,115,137,145,150,115,150,265
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Bradon Luedke,114.87,115,-120,-121,140,145,-150,115,145,260
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,J Simonds,95.11,112,117,-121,131,136,141,117,141,258
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Omar Cummings,75.96,108,115,119,138,-151,-151,119,138,257
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Connor Rousemiller,94.58,110,-115,117,130,135,140,117,140,257
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Ryan Peters,82.01,100,105,108,130,135,137,108,137,245
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Matthew Montgomery,92.88,98,102,106,138,-144,-146,106,138,244
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Christian Seymour,116.72,106,-111,-111,-135,135,138,106,138,244
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Chayce Dement,112.9,95,100,105,127,132,136,105,136,241
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Cody Wilson,73.8,98,-104,-104,140,-146,-146,98,140,238
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Daniel Vaden,75.64,107,-111,-111,-130,-131,131,107,131,238
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Jake Anderson,102.38,-100,103,-107,-125,125,135,103,135,238
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Tramail Peterson,109.32,97,101,-104,-135,-137,137,101,137,238
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Harrison Maurus,68.17,100,105,105,125,129,132,105,132,237
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Sam Ernst,81.87,99,104,105,120,125,130,105,130,235
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jared Brydon,89.7,100,106,109,116,121,126,109,126,235
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jonah Matthes,93.23,100,105,-110,130,-135,-135,105,130,235
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Nate Oelke,68.11,95,-100,-102,130,138,-145,95,138,233
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Zackary Burks,76.79,95,-100,100,122,131,-133,100,131,231
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Leighton Hope,86.42,96,-101,102,-128,128,-135,102,128,230
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Jacob Reine,82.87,98,102,104,121,121,125,104,125,229
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Dillon Riley,80.9,102,102,104,115,120,125,104,125,229
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Jack Norton,83.74,98,104,104,118,122,122,104,122,226
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Eric Rousemiller,133.71,100,-105,-105,-125,125,-133,100,125,225
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Hunter Wooten,72.26,97,98,105,119,-130,-131,105,119,224
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Melvin Peete,65,95,99,-102,120,124,-128,99,124,223
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Max Whitlock,93.25,96,-101,-107,121,127,-136,96,127,223
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,John Bloom,90.68,97,-102,-102,125,-132,-138,97,125,222
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Richard Beemer,74.94,-100,100,-105,120,-125,-125,100,120,220
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Christian Weller,133.92,95,-100,100,120,-126,-129,100,120,220
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Austin Gean,79.62,88,93,98,110,115,120,98,120,218
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dillon Guffey,70.31,-100,100,-104,110,117,-122,100,117,217
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Soren Jensen,97.6,95,97,100,117,-123,-123,100,117,217
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Christian Hunt,80.92,92,96,98,105,110,118,98,118,216
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Luke Moran,81.77,90,100,100,110,110,115,100,115,215
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Andrew Clark,102.95,-84,84,89,120,126,-131,89,126,215
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Seth Allen,136.3,91,97,-102,-117,117,-124,97,117,214
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Slade Villalobos,73.48,84,88,92,116,121,-125,92,121,213
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 62 kg,William Cohen,61.2,88,91,93,110,116,120,93,120,213
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Bailey Druck,74.46,90,97,100,107,112,-115,100,112,212
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Cole Fandale,73.55,85,-95,-95,115,-125,125,85,125,210
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Joseph Splettstoeser,103.17,93,97,100,110,-117,-118,100,110,210
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Luke Lenoch,77.09,75,82,87,105,112,120,87,120,207
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,James Bence,102.26,-92,92,-95,110,115,-120,92,115,207
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group +85 kg,Marcos Bribiesca,118.21,81,84,87,110,115,118,87,118,205
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Michael White,67.44,80,85,90,105,110,115,90,115,205
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Colton Dalzell,79.97,80,87,92,95,102,111,92,111,203
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Everard Reynolds,79.95,68,75,80,111,118,122,80,122,202
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Devin Kindon,78.88,75,80,85,107,115,116,85,116,201
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Ryan DuChanois,112.93,80,-85,85,110,116,-121,85,116,201
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Tyler Maizels,67.76,86,90,-95,110,-115,-119,90,110,200
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,William Sherman,68.65,79,85,90,97,104,110,90,110,200
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Alvin Vu,75.1,85,90,-96,110,-116,-118,90,110,200
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Brian Costello,70.04,77,84,-87,109,116,-120,84,116,200
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Jesus Arocho,80.55,80,86,90,100,102,110,90,110,200
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Shae Watkins,87.02,80,-85,90,105,110,-115,90,110,200
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Brennan Hafer,99.51,82,-85,85,105,112,-117,85,112,197
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Anthony Trevino,97.6,75,80,-85,106,111,116,80,116,196
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Jacob Schreiber,71.47,90,-95,-97,105,-112,-115,90,105,195
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Cory Salt,120.34,72,79,82,-108,108,113,82,113,195
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Deirdre Lenzsch,83.3,84,-88,88,106,-112,-112,88,106,194
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Ronald Phelps,155.18,80,84,88,100,100,105,88,105,193
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jacob Horst,59.83,88,-93,-95,105,-110,-110,88,105,193
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Brandon Floores,113.45,79,84,-91,-109,-109,109,84,109,193
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dale Loch,74.64,83,87,90,98,102,102,90,102,192
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Tyler Bell,72.35,75,80,86,100,-106,106,86,106,192
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Jacob Hamby,68.49,75,80,85,98,102,106,85,106,191
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Tariq Hollandsworth,86.71,80,83,86,100,105,105,86,105,191
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Tyler Gordon,66.2,-83,85,-87,105,-110,-111,85,105,190
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Samuel Wong-Rapuano,72.65,78,82,85,100,105,-110,85,105,190
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,KJAYLA MARTIN,81.77,80,85,-89,105,-114,-114,85,105,190
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jonas Hagen,93.05,85,-90,90,100,-105,-105,90,100,190
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Tristan Curl,76.19,73,76,79,103,108,110,79,110,189
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Chance Clark,67.31,77,83,-87,105,-110,-112,83,105,188
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Alec Cosentino,61.13,-75,78,81,93,100,106,81,106,187
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Harrison Owens,85.04,75,80,83,95,100,104,83,104,187
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dakota Maher,69.96,77,81,85,97,101,-105,85,101,186
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Kongmong Vanchiasong,73.34,80,82,83,95,99,102,83,102,185
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Austin Goral,78.1,75,80,83,95,100,102,83,102,185
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Toot Swallows,144.89,75,80,-83,98,105,-110,80,105,185
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Dean Scicchitano,74.02,75,79,79,100,105,105,79,105,184
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Vedder Miller,82.72,76,79,82,93,98,102,82,102,184
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 85 Kg,Dylan Williams,82.31,69,74,77,93,107,107,77,107,184
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Dylan Joyner,83.07,75,80,82,93,98,101,82,101,183
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Matthew Olafsen,87.17,74,77,80,95,100,102,80,102,182
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,D'Angelo Ross,60.76,75,-80,-80,-102,102,106,75,106,181
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Zaire Anderson,68.13,76,80,-82,95,100,-102,80,100,180
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Kyonte Johnson,73.87,74,77,80,95,98,100,80,100,180
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Robert Hill,75.7,75,77,80,92,96,100,80,100,180
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Andrew Spangenberg,89.21,65,70,75,-97,98,104,75,104,179
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Anthony Kent,73.51,70,75,80,90,96,98,80,98,178
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Kyle Tullos,75.82,78,-82,82,92,96,-100,82,96,178
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Bret Pfeiffer,54.99,72,76,-80,90,95,101,76,101,177
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jacob Moak,60.82,-75,75,-77,100,-105,-109,75,100,175
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Sam Wootten,64.74,-76,76,82,-90,93,-98,82,93,175
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Mark Scott,67.69,73,78,-83,92,97,-102,78,97,175
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Benjamin Schrenk,93.3,75,-80,80,86,-92,95,80,95,175
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Stan (Tre') Luttrell,59.85,73,76,80,85,90,95,80,95,175
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Sage Pletka,73.43,76,79,79,92,92,95,79,95,174
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jake Scarborough,61.46,75,78,-81,96,-101,-102,78,96,174
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Wes Jansen,79.7,75,80,80,88,93,94,80,94,174
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Matthew Stevens,68.18,70,74,77,89,92,95,77,95,172
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Chris Dang,61.19,70,75,77,90,95,-100,77,95,172
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Alex LeFavi,61.54,77,-81,-81,95,-100,-100,77,95,172
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Maddy Myers,62.26,66,-70,71,92,96,101,71,101,172
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Adrian Flores,71.38,-73,73,-76,95,98,-103,73,98,171
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Brandon Jones,63.73,60,65,70,90,95,100,70,100,170
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Connor Brown,66.4,74,75,-80,88,95,-102,75,95,170
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Curtis Davis,74.39,70,-74,75,90,95,-100,75,95,170
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Alexander Brennan,82.6,60,65,70,90,95,100,70,100,170
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Fredrick Nunn,66.09,75,75,75,87,90,93,75,93,168
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Jackson Ramey,90.05,68,72,76,88,92,-96,76,92,168
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Caymen Smith,73.03,70,73,73,90,93,94,73,94,167
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dylan Contreras,73.45,57,62,66,91,96,100,66,100,166
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Shala McMillan,132.6,70,-75,75,82,90,-95,75,90,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Sean Peterson,64.68,75,-80,-80,90,-95,-96,75,90,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Nathane Martinez,66.1,67,70,70,87,91,95,70,95,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Michael Humbert,67.25,65,69,69,87,92,96,69,96,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,William Hitchcock,75.16,-70,70,-74,90,95,-98,70,95,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Josh McMillin,75.03,-65,65,-70,90,100,-107,65,100,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Erik Strahan,81.88,72,75,78,82,87,87,78,87,165
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Diante Hartsfield,78.62,60,66,71,84,84,93,71,93,164
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Kyle Dimovitz,61.71,65,-70,71,88,93,-95,71,93,164
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Huitzilo Garcia-Pena,65.85,68,71,74,85,88,89,74,89,163
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Luke Mcpherson,68.5,65,70,70,85,90,93,70,93,163
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Brett Ollila,75.7,68,-70,72,84,-91,91,72,91,163
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Andrew Hunt,79.65,67,70,70,85,90,93,70,93,163
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Justin Flickner,61.06,60,65,68,87,90,95,68,95,163
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,David Urovish,84.65,68,68,68,87,91,94,68,94,162
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Nicole Tennant,68.81,65,69,72,85,90,90,72,90,162
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 62 kg,Michael Gallant,59.22,65,68,71,83,88,91,71,91,162
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Austin Lackey,59.64,68,71,74,82,87,88,74,88,162
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Phoenix Phillips,60.76,67,-71,71,85,90,-94,71,90,161
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Eli Lind,68.26,65,71,-76,90,-95,-95,71,90,161
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jacob Hart,91.67,63,67,-74,94,-97,-97,67,94,161
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Travis Puhlmann,65.48,67,71,75,84,85,85,75,85,160
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Gary Holloway,61.99,65,70,-75,82,-87,90,70,90,160
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Joseph Fisher,83.53,61,66,66,85,90,94,66,94,160
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Collin Trank,71.38,67,73,79,80,-87,-93,79,80,159
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Sarah Kalkhoff,82.67,68,71,74,85,-90,-90,74,85,159
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Doyle Harrell,60.23,57,63,68,80,23,91,68,91,159
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Franz Carranza,72.49,58,63,68,80,85,90,68,90,158
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Kenneth Pratt,69.52,64,67,71,78,81,85,71,85,156
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Spencer Johnson,60.14,65,70,-75,86,-91,-91,70,86,156
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 62 kg,Marshall Mays,60.42,60,64,67,77,82,86,67,86,153
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Cael Blease,60.83,60,63,66,82,-85,86,66,86,152
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Isaac Dorsey,68.1,55,64,68,82,84,84,68,84,152
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Joshua Desmore,60.85,62,65,67,77,80,85,67,85,152
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Cody Long,83.03,58,58,63,80,84,88,63,88,151
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Drew Pashik,53.42,63,67,70,78,-81,81,70,81,151
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Douglas Bassi Rodriguez,67.3,58,58,60,83,86,90,60,90,150
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Thomas Wolfe,67.99,60,65,65,85,85,85,65,85,150
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Peter Eklund,79.23,55,58,60,80,85,90,60,90,150
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Skylar Martin,67.59,65,69,69,73,77,81,69,81,150
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Stephen Short,55.37,64,-67,67,78,82,-85,67,82,149
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Stephen Kercher,60.77,57,-62,62,77,82,86,62,86,148
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Riley Bohan,57.79,-55,62,-66,78,81,86,62,86,148
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Paul Smith,0,0,0,0,148,0,0,0,148,148
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Danny Flynn,64.56,65,69,-72,-79,79,-84,69,79,148
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Benjamin Fugger,63.71,58,62,62,78,83,85,62,85,147
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Nathan Prokop,62.08,56,61,66,76,81,81,66,81,147
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Braxton Byrd,73.28,60,64,67,70,75,80,67,80,147
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Johnny White,80.41,60,63,63,80,80,84,63,84,147
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Connor Robinson,102.63,59,61,64,78,80,83,64,83,147
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Jessica Sipos,83.89,65,-70,-70,75,78,81,65,81,146
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Benjamin Jaros,64.72,60,62,65,72,78,81,65,81,146
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Nicholas Rousemiller,75.57,60,65,65,75,80,80,65,80,145
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Sydney Goad,47.86,59,-62,62,78,80,83,62,83,145
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Theodore Shriver,60.99,60,65,-70,75,80,-83,65,80,145
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Amara Wiggan,117.09,55,-58,-60,85,90,-92,55,90,145
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Alayna Theissen,82.96,60,63,-67,75,80,82,63,82,145
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group +85 kg,Joshua Ingram,100.7,55,60,64,75,80,80,64,80,144
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Kaija Bramwell,52.41,60,-63,64,80,-83,-83,64,80,144
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Carlos Molano,67.43,60,64,64,75,75,80,64,80,144
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Bishop Hernandez,67.62,57,57,62,78,81,82,62,82,144
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Jakub Vogel,56.6,62,65,67,70,74,77,67,77,144
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,JonAnthony Bartley,67.97,55,59,61,77,81,82,61,82,143
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Isaac Fraire,66.37,59,61,63,75,79,80,63,80,143
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Madison Stenbo,66.25,59,63,65,73,75,78,65,78,143
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Adrian Dougherty,57.58,58,60,-62,80,83,-88,60,83,143
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Steven Croom,68.39,56,60,60,78,82,82,60,82,142
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Linden Stewart,67.91,63,63,65,73,76,77,65,77,142
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Sean Gleason,74.39,60,-61,-64,75,-80,81,60,81,141
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Lauren Snyder,72.33,55,59,-61,75,-80,81,59,81,140
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Damean Murphy-Short,60.91,56,60,63,71,74,77,63,77,140
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Brent Gwinn,61.06,-58,58,-63,74,78,82,58,82,140
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Olivia Perez,52.97,57,60,61,79,-83,-84,61,79,140
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Jerome Smith,53.69,60,-65,-65,70,75,80,60,80,140
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Clayton Jordan,69,51,51,60,70,76,79,60,79,139
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,David Hausmann,55.43,57,61,63,70,73,76,63,76,139
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Dylan McMahon,86.21,57,60,62,71,74,77,62,77,139
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Alexa Burks,52.83,54,57,60,69,75,77,60,77,137
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Sydney Rogoff,60.86,60,63,-66,70,-74,74,63,74,137
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Madison Vincent,57.66,56,59,61,70,73,75,61,75,136
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,William Warm,55.51,52,-56,56,-76,76,80,56,80,136
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jacob Bishop,59.6,54,54,58,73,76,78,58,78,136
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Kalee Noe,66.32,54,57,60,70,70,75,60,75,135
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Natasha Rice,68.24,59,62,62,71,73,73,62,73,135
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Matthew Wininger,54.9,-60,-60,60,-75,75,-76,60,75,135
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Malanna Boyd,68.78,55,58,61,70,73,-75,61,73,134
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Tyera Zweygardt,57.5,53,-56,57,72,-76,77,57,77,134
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Hannah Damron,57.57,56,-59,59,70,73,75,59,75,134
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Nairobi Romero,61.69,53,56,-60,73,76,78,56,78,134
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Destiny Hall,58.44,52,56,-60,73,-76,78,56,78,134
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Annsley Lowe,66.99,50,55,57,70,75,77,57,77,134
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Sarah Bond,67.53,52,56,57,74,74,76,57,76,133
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Cierra Germann,67.41,54,57,60,73,73,73,60,73,133
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Aidan Wood,63.8,50,53,56,72,72,76,56,76,132
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Ellise Jenkins,72.88,56,58,-61,71,74,-77,58,74,132
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Jarynn Stewart,55.26,55,58,-60,-69,70,74,58,74,132
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Alyisha Anderson,66.3,50,54,55,70,72,77,55,77,132
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Olivia Davis,74.91,54,57,-61,75,-80,-80,57,75,132
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Troy Tom,54.54,56,59,-61,73,-76,-76,59,73,132
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Sterling Valentine,57.75,40,-46,46,75,80,85,46,85,131
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,John Foran,84.42,57,-60,60,71,-74,-79,60,71,131
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Devin Errico,54.23,-56,56,59,64,67,71,59,71,130
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Christopher Hernandez,59.48,-52,52,56,68,-72,74,56,74,130
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Camille Caskey,52.33,55,-57,57,71,73,-75,57,73,130
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Hayden Du Pont,54.94,55,-60,60,70,-75,-76,60,70,130
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Vincent Wertel,60.42,50,55,56,64,69,74,56,74,130
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Alexandra Hamilton,52.93,50,-54,-55,75,79,-82,50,79,129
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Azriel Medina,60.01,50,54,58,66,71,71,58,71,129
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Hayley Reichardt,47.76,-54,55,58,70,-73,-73,58,70,128
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Emily Camacho,61.59,53,-56,56,67,71,-73,56,71,127
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Jaylien Duncan,64.95,55,-60,-60,72,-75,-75,55,72,127
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Autumn Makins-Null,99.51,50,54,-56,68,72,-75,54,72,126
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jack Keryluk,60.38,52,55,56,62,65,70,56,70,126
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Victoria Crooks,88.75,53,57,58,67,-72,-72,58,67,125
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Leann Holappa,67.3,50,55,55,60,65,70,55,70,125
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Mariah LaRonge,74.75,51,52,55,65,70,-73,55,70,125
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Brianna Gantt,62.48,54,-58,-58,70,-76,-76,54,70,124
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Jerrone Wynn,43.79,51,54,-57,61,65,70,54,70,124
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,A'Leah Ross,57.17,50,52,-54,67,70,71,52,71,123
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Sophia Perrone,74.01,-48,50,53,59,65,70,53,70,123
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Ryan Knaus,80.02,52,55,58,63,65,-70,58,65,123
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Ethan Brown,53.06,50,-52,53,66,68,70,53,70,123
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Mackenzie Baker,72.99,-54,-56,56,62,65,-69,56,65,121
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Brycen Thielbar,53.89,44,48,52,61,66,69,52,69,121
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Cody Bailey,49.51,55,57,-59,60,64,-71,57,64,121
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Parker Holman,55.63,50,-55,-55,63,66,69,50,69,119
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,MICALA BRUNELL,52.08,48,51,-53,61,65,67,51,67,118
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Kiara Wood-Myrick,52.16,-46,46,-49,70,72,-75,46,72,118
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Alyssa Morales,81.54,50,-55,-55,66,-68,68,50,68,118
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Tyler Bailey,55.03,46,-49,50,64,68,-71,50,68,118
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Morgan Layton,51.46,41,46,52,56,62,65,52,65,117
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Callista Durrett,51.9,-47,47,-49,65,68,70,47,70,117
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Presley Cruz,54.03,43,47,54,58,63,-69,54,63,117
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,John Kresila,55.48,47,50,-53,67,-70,-72,50,67,117
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Rico Medina,54.47,46,-49,-49,63,66,70,46,70,116
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Chase Volk,86.95,45,-49,50,59,-64,66,50,66,116
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Ulysses Yarbrough,42.95,-50,-52,52,60,-63,63,52,63,115
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Eugene Sanchell,49.5,-48,48,50,61,65,-70,50,65,115
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Harry Stinger,63.24,43,47,-50,58,63,68,47,68,115
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Christian Zeglinski,68.55,46,50,52,56,-61,63,52,63,115
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Michael House,94,43,-47,48,57,62,67,48,67,115
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Paris Derrick,68.07,48,51,53,58,58,61,53,61,114
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Alexis Raffaeli,65.22,46,49,-52,59,62,64,49,64,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Michaela McIntosh,52.03,-48,48,-51,65,-68,-68,48,65,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Zoe Rustand,56.95,47,48,51,57,60,62,51,62,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Xziria Williams,67.02,50,53,53,60,60,60,53,60,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Alexandra Thornton,46.48,43,47,53,55,60,-66,53,60,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Blake Stachowicz,54.94,42,45,49,61,64,-68,49,64,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Avery Owens,62.31,-47,47,50,59,63,-65,50,63,113
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Tamora Burroughs,100.1,45,-50,50,60,62,-65,50,62,112
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Victoria Berrios,83.48,43,45,-47,63,-67,67,45,67,112
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Anna Novak,57.01,45,-50,52,57,60,-64,52,60,112
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Benjamin Tibbs,55.38,46,-50,-50,-63,63,66,46,66,112
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Lillian Acton,54.85,46,48,50,56,59,61,50,61,111
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Jasmun Mudhar,68.34,45,-50,50,56,-60,61,50,61,111
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Johnny Vong,53.37,47,-50,-51,58,61,64,47,64,111
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Sarah Sirois,50.45,-47,47,49,56,59,61,49,61,110
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Gabriel Wertel,54.84,41,45,48,57,62,-67,48,62,110
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Athena Schrijver,57.02,45,48,-50,62,-66,-66,48,62,110
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Na'Erykah Goodwin,76.8,47,49,-51,59,-61,61,49,61,110
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Ashley Kent,57,-48,48,51,55,58,-61,51,58,109
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Garrett Bosch,55.23,44,46,-50,58,63,-69,46,63,109
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Alicia Neher,60.21,45,48,-50,56,61,-64,48,61,109
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Noah Henderson,55.43,42,46,47,50,55,62,47,62,109
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Rebecca Philipsen,54.82,44,47,50,55,58,-61,50,58,108
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Amanda Bianchi,52.18,42,45,-47,60,63,-66,45,63,108
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Rachel Cole,62.55,-47,47,-50,-56,56,61,47,61,108
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Anthony Kilbert,48.39,45,48,51,54,57,-60,51,57,108
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Andrew Gray,49.7,45,-50,-50,55,59,63,45,63,108
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Clarines Martinez,56.11,41,44,-47,60,63,-65,44,63,107
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Chavonne Fedna,97.21,40,-43,-45,55,59,67,40,67,107
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Parker Bruton,49.95,-43,43,47,54,-58,60,47,60,107
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Ava Davis,60.51,44,47,50,57,-60,-60,50,57,107
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Arrington Jensen,61.18,43,45,48,55,58,-61,48,58,106
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Erin Catlin,55.96,42,44,46,58,60,60,46,60,106
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Sheridan Lintz,62.18,45,48,-51,-58,-58,58,48,58,106
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Chloe Tacata,42.65,46,-49,49,53,56,-60,49,56,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Halley Lawrence,50.67,40,45,-50,53,-57,60,45,60,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Logan Helton,54.62,45,50,-52,55,-57,-57,50,55,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Taylor Noonan,85.87,43,-46,-48,57,60,62,43,62,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Destiny Young,46.53,42,46,48,50,55,57,48,57,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Cassidy Konzelman,50.94,42,46,48,50,55,57,48,57,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Alexus Cisco,57.24,40,42,45,52,56,60,45,60,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Alexis Smith,74.82,41,43,46,52,56,59,46,59,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Dade Stanley,48.14,41,44,47,53,56,58,47,58,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Celestino Perez,55.35,45,-48,-48,55,60,-65,45,60,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Camille Uhlenkamp,59.82,41,44,46,50,54,59,46,59,105
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Erin McDonald,57.36,40,44,46,50,55,58,46,58,104
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Noah Casey,47.96,42,44,-47,55,58,60,44,60,104
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Gabe Perman,55.85,42,45,-48,54,56,59,45,59,104
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Maya Uemura,47.42,42,45,47,52,56,-58,47,56,103
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Shianne Carpenter,55.97,42,44,46,54,57,-61,46,57,103
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Morgan Sanders,68.42,42,46,-50,55,57,-59,46,57,103
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Nia Walker,76.38,37,-42,42,-59,59,61,42,61,103
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Ian Estopare,47.82,41,-45,46,53,56,-58,46,56,102
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Casey Simmons,47.67,43,47,49,53,-56,-57,49,53,102
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Jon Grimes,85.06,43,47,-49,50,55,-60,47,55,102
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Brooklin Smith,46.63,40,43,45,50,-54,56,45,56,101
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Ashleigh Dean,57.78,41,-45,47,49,54,-58,47,54,101
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Jhanee O'Neal,56.15,37,40,40,52,55,60,40,60,100
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Riley Simonds,110.02,38,41,45,47,51,55,45,55,100
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Samantha Watkins,55.23,40,-45,45,50,-55,55,45,55,100
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Morgan Rhone,50.84,39,41,43,52,55,56,43,56,99
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,McKenna Neeb,77.97,38,41,43,53,-56,56,43,56,99
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Case Cosentino,47.05,40,43,-46,50,53,56,43,56,99
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Garhett Kaegi,47.75,40,44,-47,-55,55,-61,44,55,99
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Alex Lawrence,68.33,40,43,-46,50,55,-60,43,55,98
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Payton Maxheimer,73.69,42,45,-47,50,52,-54,45,52,97
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Rachel Terrill,51.38,40,43,-46,51,54,-57,43,54,97
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Dean Goad,34.81,41,-42,-43,50,53,56,41,56,97
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Lance Watkins,66.55,-40,40,42,50,-54,55,42,55,97
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Clay Johnson,47.92,-40,42,44,48,50,53,44,53,97
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Danielle Durrett,55.46,35,38,41,49,52,55,41,55,96
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,William Moore,49.48,40,43,46,-50,50,-54,46,50,96
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Michelle Foster,53.24,40,46,-49,50,-54,-56,46,50,96
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Ashley Vogen,55.48,33,36,39,50,53,56,39,56,95
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Kyle Nelson,52.01,37,40,42,53,-55,-55,42,53,95
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Eli Wilson-Brown,56.73,37,40,43,46,48,52,43,52,95
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,David Anderson,54.99,36,40,-44,50,55,-60,40,55,95
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Gabrielle Berrios,63.19,36,39,42,50,53,-56,42,53,95
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Rachel Hicks,49.59,38,-40,40,48,50,54,40,54,94
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Cynara White,68.05,42,-46,0,52,-59,-62,42,52,94
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Risa Enrique,80.66,42,-45,-45,50,52,-56,42,52,94
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Deangelo Charles,43.46,35,38,40,45,50,54,40,54,94
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Gwendolyn Rojas,43.34,38,41,44,46,47,50,44,50,94
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Garrett Hultquist,47.55,40,-45,-45,50,-53,53,40,53,93
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Ty Johnston,47.41,37,-39,-39,50,52,56,37,56,93
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Amariah Martin,57.33,37,40,43,47,-50,50,43,50,93
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Blaine Brooks,43.1,35,38,-40,46,50,54,38,54,92
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Shelby Rodriguez,61,37,39,-43,52,-55,-55,39,52,91
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Margaret Bielski,61.97,32,-34,36,48,52,55,36,55,91
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,DYANNA RAINONE,51.98,32,35,37,49,53,54,37,54,91
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Abigail Linkhart,55.49,35,38,38,49,53,53,38,53,91
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Mckenzie Barnes,46.63,34,37,40,45,48,50,40,50,90
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Emily Warren,61.36,30,34,-41,48,-53,56,34,56,90
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Hadyn Anderson,46.73,36,39,41,-49,-49,49,41,49,90
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Kylie Price,47.67,37,40,-43,47,50,-52,40,50,90
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Mason Carter,49.89,40,-43,-43,50,-54,-58,40,50,90
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Aarika Johnson,55.1,35,35,37,43,47,51,37,51,88
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Jared Jones,57.63,33,35,38,44,47,50,38,50,88
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Anna Luttrell,51.34,35,37,-40,45,47,50,37,50,87
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Emma Esterbrook,61.67,39,-43,-44,-47,48,-49,39,48,87
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Mia Zechowy,43.63,33,36,38,42,45,48,38,48,86
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Brandon Ober,62.32,36,40,-46,45,-50,-53,40,45,85
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Maddie Bentley,48.69,33,36,-39,44,47,49,36,49,85
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Savannah Nied,46.68,34,36,37,41,44,47,37,47,84
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Destiny Haynes,59.7,35,38,-40,46,-50,-50,38,46,84
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Elisabeth Abdo,64.27,35,37,-38,45,47,-50,37,47,84
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Emma Droz,68.49,-34,37,39,41,44,45,39,45,84
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Kristin Kuntz,47.41,30,33,-36,45,48,51,33,51,84
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 44kg,Max Wootten,43.29,31,34,-37,43,-47,50,34,50,84
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 44kg,Nicholas Fantini,42.33,32,35,-37,42,46,48,35,48,83
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Justin Henderson,71.62,30,34,-37,42,45,48,34,48,82
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Anya Penner,43.63,-26,26,30,42,45,51,30,51,81
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Triniti Redfern,59.95,32,35,-38,42,43,46,35,46,81
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Kady Bauer,55.57,34,36,36,42,45,45,36,45,81
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Dalton Touchinsky,40.26,31,-35,-35,43,47,50,31,50,81
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Ashley Haynes,52.43,32,35,-37,-41,41,46,35,46,81
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Zoeie Kaufman,66.52,32,35,38,-43,-43,43,38,43,81
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Julia McKairnes,41.47,31,33,-35,41,44,47,33,47,80
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Jensen Kiesow,51.45,33,-35,35,42,45,-48,35,45,80
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Gabrielle Torsell,52.74,30,34,34,40,42,46,34,46,80
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Donald Luttrell,34.24,35,-40,-40,40,43,45,35,45,80
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 44kg,Jacob Denton,43.79,30,33,-35,40,43,47,33,47,80
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Kaitlyn House,75.16,32,-34,35,40,45,-48,35,45,80
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Kylie Kaufman,67.18,30,32,-35,41,44,47,32,47,79
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Natalya Concepcion,46.51,-33,33,36,42,-45,-46,36,42,78
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Bradley Broussard,53.38,32,35,38,-40,40,-42,38,40,78
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Maureen Riepe,45.21,30,33,35,40,-43,43,35,43,78
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Seth Tom,31.09,29,-31,33,40,42,44,33,44,77
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Abram Baier,38.25,30,33,-35,42,44,-45,33,44,77
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Thomas Gould,47.65,25,32,-36,35,-42,45,32,45,77
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Ethan Crooks,61.41,31,35,-37,42,-45,-47,35,42,77
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Janiah Jones,56.4,33,35,-37,42,-45,-45,35,42,77
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Justin Short,36.18,31,33,-34,41,43,-45,33,43,76
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Elijah Moussiaux,36.28,28,30,33,41,43,-45,33,43,76
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Kelley Evart,41.41,29,31,33,38,41,43,33,43,76
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Gabrielle Scicchitano,54.85,-33,-33,33,43,-46,-50,33,43,76
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Devon Jenkins,41.65,30,-33,-33,40,43,45,30,45,75
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Jenna Hoover,42.86,27,28,31,40,43,44,31,44,75
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Grace Fuchs {Fox},56.53,23,25,28,40,43,47,28,47,75
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,William Prokop,43.04,29,31,33,36,39,41,33,41,74
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Trent Coleman,41.32,30,33,-36,38,41,-44,33,41,74
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Cole Fisher,47.39,27,30,-33,36,40,44,30,44,74
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Tanner Dudasch,47.39,31,-34,-34,36,-40,43,31,43,74
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Elizabeth Heaton,47.05,28,-31,33,-40,40,-44,33,40,73
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Emma Nye,38.43,26,30,-32,36,40,43,30,43,73
-National Youth Championships & Youth Olympic Trials,2014-06-15,{'type': 'unset'},Stone GEHLING,35.59,28,30,-32,37,39,42,30,42,72
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Jacob Dressler,38.71,27,-29,30,39,42,-43,30,42,72
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Allison McDonald,43.28,27,29,31,36,39,41,31,41,72
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Justin McInnis,77.65,27,31,-33,37,41,-44,31,41,72
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Chloe Crooks,64.29,27,30,-31,37,40,42,30,42,72
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Brenna Lowrey,38.59,26,28,-31,37,40,43,28,43,71
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Molly Smith,48.78,28,-30,30,35,38,41,30,41,71
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Micah Mays,51.3,29,-32,-32,38,41,-43,29,41,70
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Fallon McLaughlin,58.68,-30,30,-32,35,40,-45,30,40,70
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Christopher Reding,59.34,-64,65,70,-100,-100,-100,70,0,70
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Talen Jackson,43.99,28,-30,30,-36,38,40,30,40,70
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Hannah DeGenaro,48.73,27,30,32,35,38,-40,32,38,70
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Brandon Hunt,59.22,61,66,70,0,0,0,70,0,70
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Rachel Nykamp,43.37,-31,31,33,36,-39,-39,33,36,69
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Caden Cahoy,31.01,27,-29,29,37,40,-42,29,40,69
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Jonathan Bafford,41.45,30,32,-35,37,-39,-39,32,37,69
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Dan King,46.51,29,33,35,34,-37,-39,35,34,69
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Preston McCormick,51.49,30,32,32,34,37,-40,32,37,69
-National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Frank Beauvais,59.77,-55,-55,-60,-68,68,-75,0,68,68
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Iyana Grubbs,48.68,28,31,32,-36,36,-39,32,36,68
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Stephanie Estrada,47.35,22,25,-29,42,-45,-45,25,42,67
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Talia Lloyd,38.18,26,28,29,36,37,38,29,38,67
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Aleyah White,67.96,29,31,-32,36,-40,-40,31,36,67
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Brieanna Hirsheimer,52.98,28,28,28,36,38,38,28,38,66
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Hutch Friend,28.43,23,26,-27,34,37,40,26,40,66
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Natalie Santos-De La Torre,50.22,23,26,-29,36,-39,39,26,39,65
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Sarah Henderson,43.01,23,26,27,33,36,37,27,37,64
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Hailey Sheppard,52.76,24,-26,26,33,35,38,26,38,64
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Jade Garvin,90.53,25,27,28,32,34,36,28,36,64
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Sydney Schreck,67.53,26,28,-30,32,33,35,28,35,63
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Garrison Bailey,52.95,26,28,-32,31,-34,34,28,34,62
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Lukas Moran,37.84,24,27,-30,31,34,-38,27,34,61
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Abigail Flickner,30.67,21,24,25,30,34,36,25,36,61
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Amy Reyes,32.14,22,24,26,29,32,35,26,35,61
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Alexis Barnwell,75.96,25,27,-29,31,33,-35,27,33,60
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Rachel Bielski,50.43,-25,25,-27,32,35,-39,25,35,60
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Haylee Garrett,34.99,-23,23,25,32,34,-37,25,34,59
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Cody Hoerr,40.36,23,25,-27,33,-36,-36,25,33,58
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Elaina Ostendorf,49.53,-24,-24,24,31,-34,34,24,34,58
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Ethan Babiarz,38.45,23,25,-28,28,32,-35,25,32,57
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Connor Gunderson,36.51,23,25,-27,30,32,-35,25,32,57
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Kiley Cosentino,32.82,20,-23,24,28,31,33,24,33,57
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Bianca Lafont,41.92,20,23,-26,33,-35,-36,23,33,56
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Conrad Wolf,40.35,22,24,26,27,-29,30,26,30,56
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Quincy Petree,46.77,20,-22,22,30,32,34,22,34,56
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Noah Peek,34.53,-21,22,-23,31,32,33,22,33,55
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Alexis Graham,26.5,21,-23,23,28,-30,32,23,32,55
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Stacy Jones,31.63,20,-22,22,30,32,-34,22,32,54
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Coleman Nesmith,37.07,18,-21,21,27,-30,33,21,33,54
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Karan Lawyer,42.89,22,24,-25,26,28,30,24,30,54
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Cassidy Burns,55.8,18,20,22,27,-30,32,22,32,54
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Julian Castillo,33.53,22,23,-25,30,-32,-32,23,30,53
-National Youth Championships & Youth Olympic Trials,2014-06-15,{'type': 'unset'},Dawson Barnes,35.55,19,21,23,26,28,30,23,30,53
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's Masters (45-49) 48 kg,Melissa Hornberger,33.53,22,23,-25,30,-32,-32,23,30,53
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Allie Leal,39,21,-25,-25,28,-32,32,21,32,53
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Ayanna Bartley,42.3,19,21,23,28,-30,30,23,30,53
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Konner Kluth,54.36,49,53,-56,-67,-70,-70,53,0,53
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Abigail Sharp,59.68,-37,-38,-38,47,50,52,0,52,52
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Gabriella Swajanen,38.85,-20,20,-22,28,30,32,20,32,52
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Samuel Cohen,30.63,-22,-22,22,25,28,-30,22,28,50
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Paige Christophersen,34.74,18,19,20,28,29,30,20,30,50
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Madison Olinger,51.93,22,-23,23,-27,27,-30,23,27,50
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Meghan Figueroa,43.59,17,19,-21,26,28,30,19,30,49
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Allyson Johnson,45.48,16,18,20,25,27,29,20,29,49
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Derek Uemura,33.06,18,20,22,24,26,-28,22,26,48
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Anthony Ciampaglio,54.98,-40,-40,-40,48,-52,-52,0,48,48
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Rubylyn Goad,24.08,-19,19,-21,24,26,28,19,28,47
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Brooke Minichino,42.7,17,18,-21,27,29,-30,18,29,47
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Kyra Fetter,31.95,16,18,-18,26,28,-31,18,28,46
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Eli Smith,34.22,-18,-18,18,22,24,27,18,27,45
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Robin Reardon,32.47,17,-19,19,22,24,26,19,26,45
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Dina Rami,37.55,17,-19,19,24,26,-28,19,26,45
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Paige Holman,47.53,41,44,-46,-56,-59,-59,44,0,44
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Allison Riepe,36.82,16,18,-20,23,26,-28,18,26,44
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Danielle Jones,45.23,19,21,-22,-21,21,23,21,23,44
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Grayson Brooks,27.62,17,19,-21,22,24,-26,19,24,43
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Halli Hoopes,29.72,15,17,-20,23,26,-29,17,26,43
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Blake Maxheimer,38.97,16,18,-20,21,23,-25,18,23,41
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Siena Bertacco,31.69,14,16,17,21,23,-25,17,23,40
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Brixton Maizels,24.65,14,16,-17,16,18,20,16,20,36
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Alana Beddow,37.16,16,-18,-18,20,-23,-24,16,20,36
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Antwan Kilbert,44.22,32,-35,-35,-40,-43,-43,32,0,32
-National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Devynn Woodall,48.05,29,32,-35,-40,-42,-42,32,0,32
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Emery Archer,26.93,11,13,-15,15,18,-19,13,18,31
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Na'Chelle Thomas,27.43,10,11,12,15,17,-19,12,17,29
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Gracie Aicher,31.01,9,11,13,-13,-15,16,13,16,29
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Raelynn Moran,30.49,8,11,13,12,15,-19,13,15,28
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Audrey Bink,47.52,-15,-15,-15,15,-17,18,0,18,18
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Shelby Wait,72.78,-50,-50,-50,-63,-63,-63,0,0,0
-National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Lorraine Johnson,95.89,-72,-72,-72,0,0,0,0,0,0
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Ryan Sennett,131.3,137,141,-145,165,-170,170,141,170,311,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Michael H Cohen,83.64,115,119,122,150,159,159,122,159,281,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dominick Trozzi,76.6,116,120,124,146,155,155,124,155,279,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Clarence Cummings,63.98,108,114,118,138,146,153,118,153,271,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Dylan Cooper,83.52,110,115,115,137,145,150,115,150,265,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Bradon Luedke,114.87,115,-120,-121,140,145,-150,115,145,260,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,J Simonds,95.11,112,117,-121,131,136,141,117,141,258,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Omar Cummings,75.96,108,115,119,138,-151,-151,119,138,257,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Connor Rousemiller,94.58,110,-115,117,130,135,140,117,140,257,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Ryan Peters,82.01,100,105,108,130,135,137,108,137,245,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Matthew Montgomery,92.88,98,102,106,138,-144,-146,106,138,244,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Christian Seymour,116.72,106,-111,-111,-135,135,138,106,138,244,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Chayce Dement,112.9,95,100,105,127,132,136,105,136,241,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Cody Wilson,73.8,98,-104,-104,140,-146,-146,98,140,238,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Daniel Vaden,75.64,107,-111,-111,-130,-131,131,107,131,238,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Jake Anderson,102.38,-100,103,-107,-125,125,135,103,135,238,17
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Tramail Peterson,109.32,97,101,-104,-135,-137,137,101,137,238,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Harrison Maurus,68.17,100,105,105,125,129,132,105,132,237,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Sam Ernst,81.87,99,104,105,120,125,130,105,130,235,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jared Brydon,89.7,100,106,109,116,121,126,109,126,235,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jonah Matthes,93.23,100,105,-110,130,-135,-135,105,130,235,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Nate Oelke,68.11,95,-100,-102,130,138,-145,95,138,233,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Zackary Burks,76.79,95,-100,100,122,131,-133,100,131,231,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Leighton Hope,86.42,96,-101,102,-128,128,-135,102,128,230,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Jacob Reine,82.87,98,102,104,121,121,125,104,125,229,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Dillon Riley,80.9,102,102,104,115,120,125,104,125,229,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Jack Norton,83.74,98,104,104,118,122,122,104,122,226,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Eric Rousemiller,133.71,100,-105,-105,-125,125,-133,100,125,225,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Hunter Wooten,72.26,97,98,105,119,-130,-131,105,119,224,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Melvin Peete,65,95,99,-102,120,124,-128,99,124,223,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Max Whitlock,93.25,96,-101,-107,121,127,-136,96,127,223,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,John Bloom,90.68,97,-102,-102,125,-132,-138,97,125,222,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Richard Beemer,74.94,-100,100,-105,120,-125,-125,100,120,220,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Christian Weller,133.92,95,-100,100,120,-126,-129,100,120,220,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Austin Gean,79.62,88,93,98,110,115,120,98,120,218,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dillon Guffey,70.31,-100,100,-104,110,117,-122,100,117,217,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Soren Jensen,97.6,95,97,100,117,-123,-123,100,117,217,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Christian Hunt,80.92,92,96,98,105,110,118,98,118,216,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Luke Moran,81.77,90,100,100,110,110,115,100,115,215,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Andrew Clark,102.95,-84,84,89,120,126,-131,89,126,215,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Seth Allen,136.3,91,97,-102,-117,117,-124,97,117,214,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Slade Villalobos,73.48,84,88,92,116,121,-125,92,121,213,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 62 kg,William Cohen,61.2,88,91,93,110,116,120,93,120,213,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Bailey Druck,74.46,90,97,100,107,112,-115,100,112,212,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Cole Fandale,73.55,85,-95,-95,115,-125,125,85,125,210,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Joseph Splettstoeser,103.17,93,97,100,110,-117,-118,100,110,210,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Luke Lenoch,77.09,75,82,87,105,112,120,87,120,207,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,James Bence,102.26,-92,92,-95,110,115,-120,92,115,207,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group +85 kg,Marcos Bribiesca,118.21,81,84,87,110,115,118,87,118,205,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Michael White,67.44,80,85,90,105,110,115,90,115,205,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Colton Dalzell,79.97,80,87,92,95,102,111,92,111,203,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Everard Reynolds,79.95,68,75,80,111,118,122,80,122,202,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Devin Kindon,78.88,75,80,85,107,115,116,85,116,201,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Ryan DuChanois,112.93,80,-85,85,110,116,-121,85,116,201,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Tyler Maizels,67.76,86,90,-95,110,-115,-119,90,110,200,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,William Sherman,68.65,79,85,90,97,104,110,90,110,200,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Alvin Vu,75.1,85,90,-96,110,-116,-118,90,110,200,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Brian Costello,70.04,77,84,-87,109,116,-120,84,116,200,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Jesus Arocho,80.55,80,86,90,100,102,110,90,110,200,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Shae Watkins,87.02,80,-85,90,105,110,-115,90,110,200,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Brennan Hafer,99.51,82,-85,85,105,112,-117,85,112,197,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Anthony Trevino,97.6,75,80,-85,106,111,116,80,116,196,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Jacob Schreiber,71.47,90,-95,-97,105,-112,-115,90,105,195,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Cory Salt,120.34,72,79,82,-108,108,113,82,113,195,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Deirdre Lenzsch,83.3,84,-88,88,106,-112,-112,88,106,194,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Ronald Phelps,155.18,80,84,88,100,100,105,88,105,193,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jacob Horst,59.83,88,-93,-95,105,-110,-110,88,105,193,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Brandon Floores,113.45,79,84,-91,-109,-109,109,84,109,193,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dale Loch,74.64,83,87,90,98,102,102,90,102,192,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Tyler Bell,72.35,75,80,86,100,-106,106,86,106,192,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Jacob Hamby,68.49,75,80,85,98,102,106,85,106,191,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Tariq Hollandsworth,86.71,80,83,86,100,105,105,86,105,191,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Tyler Gordon,66.2,-83,85,-87,105,-110,-111,85,105,190,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Samuel Wong-Rapuano,72.65,78,82,85,100,105,-110,85,105,190,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,KJAYLA MARTIN,81.77,80,85,-89,105,-114,-114,85,105,190,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jonas Hagen,93.05,85,-90,90,100,-105,-105,90,100,190,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Tristan Curl,76.19,73,76,79,103,108,110,79,110,189,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Chance Clark,67.31,77,83,-87,105,-110,-112,83,105,188,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Alec Cosentino,61.13,-75,78,81,93,100,106,81,106,187,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Harrison Owens,85.04,75,80,83,95,100,104,83,104,187,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dakota Maher,69.96,77,81,85,97,101,-105,85,101,186,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Kongmong Vanchiasong,73.34,80,82,83,95,99,102,83,102,185,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Austin Goral,78.1,75,80,83,95,100,102,83,102,185,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's+105 kg,Toot Swallows,144.89,75,80,-83,98,105,-110,80,105,185,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Dean Scicchitano,74.02,75,79,79,100,105,105,79,105,184,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Vedder Miller,82.72,76,79,82,93,98,102,82,102,184,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 85 Kg,Dylan Williams,82.31,69,74,77,93,107,107,77,107,184,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Dylan Joyner,83.07,75,80,82,93,98,101,82,101,183,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Matthew Olafsen,87.17,74,77,80,95,100,102,80,102,182,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,D'Angelo Ross,60.76,75,-80,-80,-102,102,106,75,106,181,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Zaire Anderson,68.13,76,80,-82,95,100,-102,80,100,180,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Kyonte Johnson,73.87,74,77,80,95,98,100,80,100,180,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Robert Hill,75.7,75,77,80,92,96,100,80,100,180,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Andrew Spangenberg,89.21,65,70,75,-97,98,104,75,104,179,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Anthony Kent,73.51,70,75,80,90,96,98,80,98,178,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Kyle Tullos,75.82,78,-82,82,92,96,-100,82,96,178,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Bret Pfeiffer,54.99,72,76,-80,90,95,101,76,101,177,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jacob Moak,60.82,-75,75,-77,100,-105,-109,75,100,175,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Sam Wootten,64.74,-76,76,82,-90,93,-98,82,93,175,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Mark Scott,67.69,73,78,-83,92,97,-102,78,97,175,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Benjamin Schrenk,93.3,75,-80,80,86,-92,95,80,95,175,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Stan (Tre') Luttrell,59.85,73,76,80,85,90,95,80,95,175,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Sage Pletka,73.43,76,79,79,92,92,95,79,95,174,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jake Scarborough,61.46,75,78,-81,96,-101,-102,78,96,174,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Wes Jansen,79.7,75,80,80,88,93,94,80,94,174,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Matthew Stevens,68.18,70,74,77,89,92,95,77,95,172,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Chris Dang,61.19,70,75,77,90,95,-100,77,95,172,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Alex LeFavi,61.54,77,-81,-81,95,-100,-100,77,95,172,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Maddy Myers,62.26,66,-70,71,92,96,101,71,101,172,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Adrian Flores,71.38,-73,73,-76,95,98,-103,73,98,171,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Brandon Jones,63.73,60,65,70,90,95,100,70,100,170,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Connor Brown,66.4,74,75,-80,88,95,-102,75,95,170,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Curtis Davis,74.39,70,-74,75,90,95,-100,75,95,170,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Alexander Brennan,82.6,60,65,70,90,95,100,70,100,170,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Fredrick Nunn,66.09,75,75,75,87,90,93,75,93,168,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Jackson Ramey,90.05,68,72,76,88,92,-96,76,92,168,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Caymen Smith,73.03,70,73,73,90,93,94,73,94,167,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Dylan Contreras,73.45,57,62,66,91,96,100,66,100,166,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Shala McMillan,132.6,70,-75,75,82,90,-95,75,90,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Sean Peterson,64.68,75,-80,-80,90,-95,-96,75,90,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Nathane Martinez,66.1,67,70,70,87,91,95,70,95,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Michael Humbert,67.25,65,69,69,87,92,96,69,96,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,William Hitchcock,75.16,-70,70,-74,90,95,-98,70,95,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Josh McMillin,75.03,-65,65,-70,90,100,-107,65,100,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Erik Strahan,81.88,72,75,78,82,87,87,78,87,165,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Diante Hartsfield,78.62,60,66,71,84,84,93,71,93,164,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Kyle Dimovitz,61.71,65,-70,71,88,93,-95,71,93,164,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Huitzilo Garcia-Pena,65.85,68,71,74,85,88,89,74,89,163,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Luke Mcpherson,68.5,65,70,70,85,90,93,70,93,163,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Brett Ollila,75.7,68,-70,72,84,-91,91,72,91,163,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Andrew Hunt,79.65,67,70,70,85,90,93,70,93,163,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Justin Flickner,61.06,60,65,68,87,90,95,68,95,163,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,David Urovish,84.65,68,68,68,87,91,94,68,94,162,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Nicole Tennant,68.81,65,69,72,85,90,90,72,90,162,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 62 kg,Michael Gallant,59.22,65,68,71,83,88,91,71,91,162,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Austin Lackey,59.64,68,71,74,82,87,88,74,88,162,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Phoenix Phillips,60.76,67,-71,71,85,90,-94,71,90,161,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Eli Lind,68.26,65,71,-76,90,-95,-95,71,90,161,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 94 kg,Jacob Hart,91.67,63,67,-74,94,-97,-97,67,94,161,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Travis Puhlmann,65.48,67,71,75,84,85,85,75,85,160,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Gary Holloway,61.99,65,70,-75,82,-87,90,70,90,160,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Joseph Fisher,83.53,61,66,66,85,90,94,66,94,160,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Collin Trank,71.38,67,73,79,80,-87,-93,79,80,159,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Sarah Kalkhoff,82.67,68,71,74,85,-90,-90,74,85,159,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Doyle Harrell,60.23,57,63,68,80,23,91,68,91,159,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Franz Carranza,72.49,58,63,68,80,85,90,68,90,158,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Kenneth Pratt,69.52,64,67,71,78,81,85,71,85,156,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Spencer Johnson,60.14,65,70,-75,86,-91,-91,70,86,156,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 62 kg,Marshall Mays,60.42,60,64,67,77,82,86,67,86,153,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Cael Blease,60.83,60,63,66,82,-85,86,66,86,152,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Isaac Dorsey,68.1,55,64,68,82,84,84,68,84,152,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Joshua Desmore,60.85,62,65,67,77,80,85,67,85,152,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Cody Long,83.03,58,58,63,80,84,88,63,88,151,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Drew Pashik,53.42,63,67,70,78,-81,81,70,81,151,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Douglas Bassi Rodriguez,67.3,58,58,60,83,86,90,60,90,150,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Thomas Wolfe,67.99,60,65,65,85,85,85,65,85,150,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Peter Eklund,79.23,55,58,60,80,85,90,60,90,150,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Skylar Martin,67.59,65,69,69,73,77,81,69,81,150,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Stephen Short,55.37,64,-67,67,78,82,-85,67,82,149,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Stephen Kercher,60.77,57,-62,62,77,82,86,62,86,148,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Riley Bohan,57.79,-55,62,-66,78,81,86,62,86,148,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Paul Smith,0,0,0,0,148,0,0,0,148,148,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Danny Flynn,64.56,65,69,-72,-79,79,-84,69,79,148,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Benjamin Fugger,63.71,58,62,62,78,83,85,62,85,147,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Nathan Prokop,62.08,56,61,66,76,81,81,66,81,147,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Braxton Byrd,73.28,60,64,67,70,75,80,67,80,147,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 85 kg,Johnny White,80.41,60,63,63,80,80,84,63,84,147,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 105 kg,Connor Robinson,102.63,59,61,64,78,80,83,64,83,147,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Jessica Sipos,83.89,65,-70,-70,75,78,81,65,81,146,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Benjamin Jaros,64.72,60,62,65,72,78,81,65,81,146,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 77 kg,Nicholas Rousemiller,75.57,60,65,65,75,80,80,65,80,145,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Sydney Goad,47.86,59,-62,62,78,80,83,62,83,145,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Theodore Shriver,60.99,60,65,-70,75,80,-83,65,80,145,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Amara Wiggan,117.09,55,-58,-60,85,90,-92,55,90,145,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Alayna Theissen,82.96,60,63,-67,75,80,82,63,82,145,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group +85 kg,Joshua Ingram,100.7,55,60,64,75,80,80,64,80,144,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Kaija Bramwell,52.41,60,-63,64,80,-83,-83,64,80,144,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Carlos Molano,67.43,60,64,64,75,75,80,64,80,144,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Bishop Hernandez,67.62,57,57,62,78,81,82,62,82,144,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Jakub Vogel,56.6,62,65,67,70,74,77,67,77,144,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,JonAnthony Bartley,67.97,55,59,61,77,81,82,61,82,143,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Isaac Fraire,66.37,59,61,63,75,79,80,63,80,143,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Madison Stenbo,66.25,59,63,65,73,75,78,65,78,143,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Adrian Dougherty,57.58,58,60,-62,80,83,-88,60,83,143,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 69 kg,Steven Croom,68.39,56,60,60,78,82,82,60,82,142,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Linden Stewart,67.91,63,63,65,73,76,77,65,77,142,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 77 kg,Sean Gleason,74.39,60,-61,-64,75,-80,81,60,81,141,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Lauren Snyder,72.33,55,59,-61,75,-80,81,59,81,140,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Damean Murphy-Short,60.91,56,60,63,71,74,77,63,77,140,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Brent Gwinn,61.06,-58,58,-63,74,78,82,58,82,140,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Olivia Perez,52.97,57,60,61,79,-83,-84,61,79,140,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Jerome Smith,53.69,60,-65,-65,70,75,80,60,80,140,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Clayton Jordan,69,51,51,60,70,76,79,60,79,139,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,David Hausmann,55.43,57,61,63,70,73,76,63,76,139,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Dylan McMahon,86.21,57,60,62,71,74,77,62,77,139,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Alexa Burks,52.83,54,57,60,69,75,77,60,77,137,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Sydney Rogoff,60.86,60,63,-66,70,-74,74,63,74,137,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Madison Vincent,57.66,56,59,61,70,73,75,61,75,136,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,William Warm,55.51,52,-56,56,-76,76,80,56,80,136,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jacob Bishop,59.6,54,54,58,73,76,78,58,78,136,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Kalee Noe,66.32,54,57,60,70,70,75,60,75,135,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Natasha Rice,68.24,59,62,62,71,73,73,62,73,135,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Matthew Wininger,54.9,-60,-60,60,-75,75,-76,60,75,135,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Malanna Boyd,68.78,55,58,61,70,73,-75,61,73,134,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Tyera Zweygardt,57.5,53,-56,57,72,-76,77,57,77,134,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Hannah Damron,57.57,56,-59,59,70,73,75,59,75,134,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Nairobi Romero,61.69,53,56,-60,73,76,78,56,78,134,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Destiny Hall,58.44,52,56,-60,73,-76,78,56,78,134,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Annsley Lowe,66.99,50,55,57,70,75,77,57,77,134,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Sarah Bond,67.53,52,56,57,74,74,76,57,76,133,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Cierra Germann,67.41,54,57,60,73,73,73,60,73,133,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 69 kg,Aidan Wood,63.8,50,53,56,72,72,76,56,76,132,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Ellise Jenkins,72.88,56,58,-61,71,74,-77,58,74,132,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Jarynn Stewart,55.26,55,58,-60,-69,70,74,58,74,132,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Alyisha Anderson,66.3,50,54,55,70,72,77,55,77,132,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Olivia Davis,74.91,54,57,-61,75,-80,-80,57,75,132,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Troy Tom,54.54,56,59,-61,73,-76,-76,59,73,132,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Sterling Valentine,57.75,40,-46,46,75,80,85,46,85,131,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,John Foran,84.42,57,-60,60,71,-74,-79,60,71,131,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Devin Errico,54.23,-56,56,59,64,67,71,59,71,130,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Christopher Hernandez,59.48,-52,52,56,68,-72,74,56,74,130,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Camille Caskey,52.33,55,-57,57,71,73,-75,57,73,130,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Hayden Du Pont,54.94,55,-60,60,70,-75,-76,60,70,130,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Vincent Wertel,60.42,50,55,56,64,69,74,56,74,130,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Alexandra Hamilton,52.93,50,-54,-55,75,79,-82,50,79,129,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Azriel Medina,60.01,50,54,58,66,71,71,58,71,129,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Hayley Reichardt,47.76,-54,55,58,70,-73,-73,58,70,128,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Emily Camacho,61.59,53,-56,56,67,71,-73,56,71,127,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Jaylien Duncan,64.95,55,-60,-60,72,-75,-75,55,72,127,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Autumn Makins-Null,99.51,50,54,-56,68,72,-75,54,72,126,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Jack Keryluk,60.38,52,55,56,62,65,70,56,70,126,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Victoria Crooks,88.75,53,57,58,67,-72,-72,58,67,125,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Leann Holappa,67.3,50,55,55,60,65,70,55,70,125,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Mariah LaRonge,74.75,51,52,55,65,70,-73,55,70,125,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Brianna Gantt,62.48,54,-58,-58,70,-76,-76,54,70,124,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Jerrone Wynn,43.79,51,54,-57,61,65,70,54,70,124,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,A'Leah Ross,57.17,50,52,-54,67,70,71,52,71,123,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Sophia Perrone,74.01,-48,50,53,59,65,70,53,70,123,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Ryan Knaus,80.02,52,55,58,63,65,-70,58,65,123,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Ethan Brown,53.06,50,-52,53,66,68,70,53,70,123,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Mackenzie Baker,72.99,-54,-56,56,62,65,-69,56,65,121,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Brycen Thielbar,53.89,44,48,52,61,66,69,52,69,121,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Cody Bailey,49.51,55,57,-59,60,64,-71,57,64,121,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Parker Holman,55.63,50,-55,-55,63,66,69,50,69,119,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,MICALA BRUNELL,52.08,48,51,-53,61,65,67,51,67,118,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Kiara Wood-Myrick,52.16,-46,46,-49,70,72,-75,46,72,118,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Alyssa Morales,81.54,50,-55,-55,66,-68,68,50,68,118,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Tyler Bailey,55.03,46,-49,50,64,68,-71,50,68,118,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Morgan Layton,51.46,41,46,52,56,62,65,52,65,117,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Callista Durrett,51.9,-47,47,-49,65,68,70,47,70,117,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Presley Cruz,54.03,43,47,54,58,63,-69,54,63,117,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,John Kresila,55.48,47,50,-53,67,-70,-72,50,67,117,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Rico Medina,54.47,46,-49,-49,63,66,70,46,70,116,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Chase Volk,86.95,45,-49,50,59,-64,66,50,66,116,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Ulysses Yarbrough,42.95,-50,-52,52,60,-63,63,52,63,115,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Eugene Sanchell,49.5,-48,48,50,61,65,-70,50,65,115,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Harry Stinger,63.24,43,47,-50,58,63,68,47,68,115,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Christian Zeglinski,68.55,46,50,52,56,-61,63,52,63,115,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Michael House,94,43,-47,48,57,62,67,48,67,115,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Paris Derrick,68.07,48,51,53,58,58,61,53,61,114,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Alexis Raffaeli,65.22,46,49,-52,59,62,64,49,64,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Michaela McIntosh,52.03,-48,48,-51,65,-68,-68,48,65,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Zoe Rustand,56.95,47,48,51,57,60,62,51,62,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 69 kg,Xziria Williams,67.02,50,53,53,60,60,60,53,60,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Alexandra Thornton,46.48,43,47,53,55,60,-66,53,60,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Blake Stachowicz,54.94,42,45,49,61,64,-68,49,64,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Avery Owens,62.31,-47,47,50,59,63,-65,50,63,113,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Tamora Burroughs,100.1,45,-50,50,60,62,-65,50,62,112,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Victoria Berrios,83.48,43,45,-47,63,-67,67,45,67,112,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Anna Novak,57.01,45,-50,52,57,60,-64,52,60,112,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Benjamin Tibbs,55.38,46,-50,-50,-63,63,66,46,66,112,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Lillian Acton,54.85,46,48,50,56,59,61,50,61,111,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Jasmun Mudhar,68.34,45,-50,50,56,-60,61,50,61,111,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Johnny Vong,53.37,47,-50,-51,58,61,64,47,64,111,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Sarah Sirois,50.45,-47,47,49,56,59,61,49,61,110,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Gabriel Wertel,54.84,41,45,48,57,62,-67,48,62,110,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Athena Schrijver,57.02,45,48,-50,62,-66,-66,48,62,110,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Na'Erykah Goodwin,76.8,47,49,-51,59,-61,61,49,61,110,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Ashley Kent,57,-48,48,51,55,58,-61,51,58,109,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Garrett Bosch,55.23,44,46,-50,58,63,-69,46,63,109,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Alicia Neher,60.21,45,48,-50,56,61,-64,48,61,109,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Noah Henderson,55.43,42,46,47,50,55,62,47,62,109,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Rebecca Philipsen,54.82,44,47,50,55,58,-61,50,58,108,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Amanda Bianchi,52.18,42,45,-47,60,63,-66,45,63,108,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Rachel Cole,62.55,-47,47,-50,-56,56,61,47,61,108,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Anthony Kilbert,48.39,45,48,51,54,57,-60,51,57,108,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Andrew Gray,49.7,45,-50,-50,55,59,63,45,63,108,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Clarines Martinez,56.11,41,44,-47,60,63,-65,44,63,107,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Chavonne Fedna,97.21,40,-43,-45,55,59,67,40,67,107,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Parker Bruton,49.95,-43,43,47,54,-58,60,47,60,107,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Ava Davis,60.51,44,47,50,57,-60,-60,50,57,107,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Arrington Jensen,61.18,43,45,48,55,58,-61,48,58,106,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Erin Catlin,55.96,42,44,46,58,60,60,46,60,106,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 63 kg,Sheridan Lintz,62.18,45,48,-51,-58,-58,58,48,58,106,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Chloe Tacata,42.65,46,-49,49,53,56,-60,49,56,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Halley Lawrence,50.67,40,45,-50,53,-57,60,45,60,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Logan Helton,54.62,45,50,-52,55,-57,-57,50,55,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Taylor Noonan,85.87,43,-46,-48,57,60,62,43,62,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Destiny Young,46.53,42,46,48,50,55,57,48,57,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Cassidy Konzelman,50.94,42,46,48,50,55,57,48,57,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Alexus Cisco,57.24,40,42,45,52,56,60,45,60,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Alexis Smith,74.82,41,43,46,52,56,59,46,59,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Dade Stanley,48.14,41,44,47,53,56,58,47,58,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Celestino Perez,55.35,45,-48,-48,55,60,-65,45,60,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Camille Uhlenkamp,59.82,41,44,46,50,54,59,46,59,105,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Erin McDonald,57.36,40,44,46,50,55,58,46,58,104,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Noah Casey,47.96,42,44,-47,55,58,60,44,60,104,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Gabe Perman,55.85,42,45,-48,54,56,59,45,59,104,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Maya Uemura,47.42,42,45,47,52,56,-58,47,56,103,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Shianne Carpenter,55.97,42,44,46,54,57,-61,46,57,103,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Morgan Sanders,68.42,42,46,-50,55,57,-59,46,57,103,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Nia Walker,76.38,37,-42,42,-59,59,61,42,61,103,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Ian Estopare,47.82,41,-45,46,53,56,-58,46,56,102,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Casey Simmons,47.67,43,47,49,53,-56,-57,49,53,102,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Jon Grimes,85.06,43,47,-49,50,55,-60,47,55,102,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Brooklin Smith,46.63,40,43,45,50,-54,56,45,56,101,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 58 kg,Ashleigh Dean,57.78,41,-45,47,49,54,-58,47,54,101,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Jhanee O'Neal,56.15,37,40,40,52,55,60,40,60,100,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Riley Simonds,110.02,38,41,45,47,51,55,45,55,100,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Samantha Watkins,55.23,40,-45,45,50,-55,55,45,55,100,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Morgan Rhone,50.84,39,41,43,52,55,56,43,56,99,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,McKenna Neeb,77.97,38,41,43,53,-56,56,43,56,99,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Case Cosentino,47.05,40,43,-46,50,53,56,43,56,99,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 56 kg,Garhett Kaegi,47.75,40,44,-47,-55,55,-61,44,55,99,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Alex Lawrence,68.33,40,43,-46,50,55,-60,43,55,98,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group +69 kg,Payton Maxheimer,73.69,42,45,-47,50,52,-54,45,52,97,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Rachel Terrill,51.38,40,43,-46,51,54,-57,43,54,97,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Dean Goad,34.81,41,-42,-43,50,53,56,41,56,97,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Lance Watkins,66.55,-40,40,42,50,-54,55,42,55,97,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Clay Johnson,47.92,-40,42,44,48,50,53,44,53,97,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Danielle Durrett,55.46,35,38,41,49,52,55,41,55,96,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,William Moore,49.48,40,43,46,-50,50,-54,46,50,96,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Michelle Foster,53.24,40,46,-49,50,-54,-56,46,50,96,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Ashley Vogen,55.48,33,36,39,50,53,56,39,56,95,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Kyle Nelson,52.01,37,40,42,53,-55,-55,42,53,95,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Eli Wilson-Brown,56.73,37,40,43,46,48,52,43,52,95,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,David Anderson,54.99,36,40,-44,50,55,-60,40,55,95,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Gabrielle Berrios,63.19,36,39,42,50,53,-56,42,53,95,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Rachel Hicks,49.59,38,-40,40,48,50,54,40,54,94,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Cynara White,68.05,42,-46,0,52,-59,-62,42,52,94,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Risa Enrique,80.66,42,-45,-45,50,52,-56,42,52,94,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Deangelo Charles,43.46,35,38,40,45,50,54,40,54,94,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Gwendolyn Rojas,43.34,38,41,44,46,47,50,44,50,94,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Garrett Hultquist,47.55,40,-45,-45,50,-53,53,40,53,93,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Ty Johnston,47.41,37,-39,-39,50,52,56,37,56,93,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Amariah Martin,57.33,37,40,43,47,-50,50,43,50,93,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Blaine Brooks,43.1,35,38,-40,46,50,54,38,54,92,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Shelby Rodriguez,61,37,39,-43,52,-55,-55,39,52,91,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Margaret Bielski,61.97,32,-34,36,48,52,55,36,55,91,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,DYANNA RAINONE,51.98,32,35,37,49,53,54,37,54,91,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Abigail Linkhart,55.49,35,38,38,49,53,53,38,53,91,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Mckenzie Barnes,46.63,34,37,40,45,48,50,40,50,90,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Emily Warren,61.36,30,34,-41,48,-53,56,34,56,90,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Hadyn Anderson,46.73,36,39,41,-49,-49,49,41,49,90,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Kylie Price,47.67,37,40,-43,47,50,-52,40,50,90,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 50 Kg,Mason Carter,49.89,40,-43,-43,50,-54,-58,40,50,90,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Aarika Johnson,55.1,35,35,37,43,47,51,37,51,88,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Jared Jones,57.63,33,35,38,44,47,50,38,50,88,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Anna Luttrell,51.34,35,37,-40,45,47,50,37,50,87,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Emma Esterbrook,61.67,39,-43,-44,-47,48,-49,39,48,87,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Mia Zechowy,43.63,33,36,38,42,45,48,38,48,86,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 69 Kg,Brandon Ober,62.32,36,40,-46,45,-50,-53,40,45,85,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Maddie Bentley,48.69,33,36,-39,44,47,49,36,49,85,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Savannah Nied,46.68,34,36,37,41,44,47,37,47,84,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Destiny Haynes,59.7,35,38,-40,46,-50,-50,38,46,84,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Elisabeth Abdo,64.27,35,37,-38,45,47,-50,37,47,84,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 69 kg,Emma Droz,68.49,-34,37,39,41,44,45,39,45,84,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Kristin Kuntz,47.41,30,33,-36,45,48,51,33,51,84,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 44kg,Max Wootten,43.29,31,34,-37,43,-47,50,34,50,84,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 44kg,Nicholas Fantini,42.33,32,35,-37,42,46,48,35,48,83,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Justin Henderson,71.62,30,34,-37,42,45,48,34,48,82,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Anya Penner,43.63,-26,26,30,42,45,51,30,51,81,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Triniti Redfern,59.95,32,35,-38,42,43,46,35,46,81,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 58 kg,Kady Bauer,55.57,34,36,36,42,45,45,36,45,81,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Dalton Touchinsky,40.26,31,-35,-35,43,47,50,31,50,81,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Ashley Haynes,52.43,32,35,-37,-41,41,46,35,46,81,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Zoeie Kaufman,66.52,32,35,38,-43,-43,43,38,43,81,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Julia McKairnes,41.47,31,33,-35,41,44,47,33,47,80,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Jensen Kiesow,51.45,33,-35,35,42,45,-48,35,45,80,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Gabrielle Torsell,52.74,30,34,34,40,42,46,34,46,80,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Donald Luttrell,34.24,35,-40,-40,40,43,45,35,45,80,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 44kg,Jacob Denton,43.79,30,33,-35,40,43,47,33,47,80,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Kaitlyn House,75.16,32,-34,35,40,45,-48,35,45,80,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Kylie Kaufman,67.18,30,32,-35,41,44,47,32,47,79,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Natalya Concepcion,46.51,-33,33,36,42,-45,-46,36,42,78,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Bradley Broussard,53.38,32,35,38,-40,40,-42,38,40,78,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Maureen Riepe,45.21,30,33,35,40,-43,43,35,43,78,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Seth Tom,31.09,29,-31,33,40,42,44,33,44,77,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Abram Baier,38.25,30,33,-35,42,44,-45,33,44,77,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Thomas Gould,47.65,25,32,-36,35,-42,45,32,45,77,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 62 Kg,Ethan Crooks,61.41,31,35,-37,42,-45,-47,35,42,77,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Janiah Jones,56.4,33,35,-37,42,-45,-45,35,42,77,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Justin Short,36.18,31,33,-34,41,43,-45,33,43,76,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Elijah Moussiaux,36.28,28,30,33,41,43,-45,33,43,76,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Kelley Evart,41.41,29,31,33,38,41,43,33,43,76,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Gabrielle Scicchitano,54.85,-33,-33,33,43,-46,-50,33,43,76,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Devon Jenkins,41.65,30,-33,-33,40,43,45,30,45,75,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Jenna Hoover,42.86,27,28,31,40,43,44,31,44,75,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Grace Fuchs {Fox},56.53,23,25,28,40,43,47,28,47,75,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,William Prokop,43.04,29,31,33,36,39,41,33,41,74,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Trent Coleman,41.32,30,33,-36,38,41,-44,33,41,74,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Cole Fisher,47.39,27,30,-33,36,40,44,30,44,74,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Tanner Dudasch,47.39,31,-34,-34,36,-40,43,31,43,74,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Elizabeth Heaton,47.05,28,-31,33,-40,40,-44,33,40,73,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Emma Nye,38.43,26,30,-32,36,40,43,30,43,73,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,{'type': 'unset'},Stone GEHLING,35.59,28,30,-32,37,39,42,30,42,72,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Jacob Dressler,38.71,27,-29,30,39,42,-43,30,42,72,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Allison McDonald,43.28,27,29,31,36,39,41,31,41,72,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group +69 Kg,Justin McInnis,77.65,27,31,-33,37,41,-44,31,41,72,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Chloe Crooks,64.29,27,30,-31,37,40,42,30,42,72,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Brenna Lowrey,38.59,26,28,-31,37,40,43,28,43,71,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Molly Smith,48.78,28,-30,30,35,38,41,30,41,71,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Micah Mays,51.3,29,-32,-32,38,41,-43,29,41,70,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Fallon McLaughlin,58.68,-30,30,-32,35,40,-45,30,40,70,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Christopher Reding,59.34,-64,65,70,-100,-100,-100,70,0,70,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Talen Jackson,43.99,28,-30,30,-36,38,40,30,40,70,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Hannah DeGenaro,48.73,27,30,32,35,38,-40,32,38,70,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Brandon Hunt,59.22,61,66,70,0,0,0,70,0,70,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Rachel Nykamp,43.37,-31,31,33,36,-39,-39,33,36,69,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Caden Cahoy,31.01,27,-29,29,37,40,-42,29,40,69,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Jonathan Bafford,41.45,30,32,-35,37,-39,-39,32,37,69,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Dan King,46.51,29,33,35,34,-37,-39,35,34,69,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Preston McCormick,51.49,30,32,32,34,37,-40,32,37,69,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Open Men's 62 kg,Frank Beauvais,59.77,-55,-55,-60,-68,68,-75,0,68,68,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Iyana Grubbs,48.68,28,31,32,-36,36,-39,32,36,68,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 48 kg,Stephanie Estrada,47.35,22,25,-29,42,-45,-45,25,42,67,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Talia Lloyd,38.18,26,28,29,36,37,38,29,38,67,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Aleyah White,67.96,29,31,-32,36,-40,-40,31,36,67,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 53 kg,Brieanna Hirsheimer,52.98,28,28,28,36,38,38,28,38,66,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Hutch Friend,28.43,23,26,-27,34,37,40,26,40,66,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 53 kg,Natalie Santos-De La Torre,50.22,23,26,-29,36,-39,39,26,39,65,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Sarah Henderson,43.01,23,26,27,33,36,37,27,37,64,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Hailey Sheppard,52.76,24,-26,26,33,35,38,26,38,64,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Jade Garvin,90.53,25,27,28,32,34,36,28,36,64,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Sydney Schreck,67.53,26,28,-30,32,33,35,28,35,63,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 56 Kg,Garrison Bailey,52.95,26,28,-32,31,-34,34,28,34,62,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Lukas Moran,37.84,24,27,-30,31,34,-38,27,34,61,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Abigail Flickner,30.67,21,24,25,30,34,36,25,36,61,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Amy Reyes,32.14,22,24,26,29,32,35,26,35,61,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group +58 Kg,Alexis Barnwell,75.96,25,27,-29,31,33,-35,27,33,60,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Rachel Bielski,50.43,-25,25,-27,32,35,-39,25,35,60,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Haylee Garrett,34.99,-23,23,25,32,34,-37,25,34,59,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Cody Hoerr,40.36,23,25,-27,33,-36,-36,25,33,58,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Elaina Ostendorf,49.53,-24,-24,24,31,-34,34,24,34,58,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Ethan Babiarz,38.45,23,25,-28,28,32,-35,25,32,57,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Connor Gunderson,36.51,23,25,-27,30,32,-35,25,32,57,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Kiley Cosentino,32.82,20,-23,24,28,31,33,24,33,57,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 44 kg,Bianca Lafont,41.92,20,23,-26,33,-35,-36,23,33,56,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 44kg,Conrad Wolf,40.35,22,24,26,27,-29,30,26,30,56,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Quincy Petree,46.77,20,-22,22,30,32,34,22,34,56,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Noah Peek,34.53,-21,22,-23,31,32,33,22,33,55,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Alexis Graham,26.5,21,-23,23,28,-30,32,23,32,55,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Stacy Jones,31.63,20,-22,22,30,32,-34,22,32,54,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Coleman Nesmith,37.07,18,-21,21,27,-30,33,21,33,54,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Karan Lawyer,42.89,22,24,-25,26,28,30,24,30,54,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 58kg,Cassidy Burns,55.8,18,20,22,27,-30,32,22,32,54,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Julian Castillo,33.53,22,23,-25,30,-32,-32,23,30,53,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,{'type': 'unset'},Dawson Barnes,35.55,19,21,23,26,28,30,23,30,53,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's Masters (45-49) 48 kg,Melissa Hornberger,33.53,22,23,-25,30,-32,-32,23,30,53,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Allie Leal,39,21,-25,-25,28,-32,32,21,32,53,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Ayanna Bartley,42.3,19,21,23,28,-30,30,23,30,53,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Konner Kluth,54.36,49,53,-56,-67,-70,-70,53,0,53,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 63 kg,Abigail Sharp,59.68,-37,-38,-38,47,50,52,0,52,52,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Gabriella Swajanen,38.85,-20,20,-22,28,30,32,20,32,52,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Samuel Cohen,30.63,-22,-22,22,25,28,-30,22,28,50,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Paige Christophersen,34.74,18,19,20,28,29,30,20,30,50,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 53kg,Madison Olinger,51.93,22,-23,23,-27,27,-30,23,27,50,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Meghan Figueroa,43.59,17,19,-21,26,28,30,19,30,49,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Allyson Johnson,45.48,16,18,20,25,27,29,20,29,49,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Derek Uemura,33.06,18,20,22,24,26,-28,22,26,48,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 14-15 Age Group 56 Kg,Anthony Ciampaglio,54.98,-40,-40,-40,48,-52,-52,0,48,48,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Rubylyn Goad,24.08,-19,19,-21,24,26,28,19,28,47,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 44kg,Brooke Minichino,42.7,17,18,-21,27,29,-30,18,29,47,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Kyra Fetter,31.95,16,18,-18,26,28,-31,18,28,46,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 35 Kg,Eli Smith,34.22,-18,-18,18,22,24,27,18,27,45,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Robin Reardon,32.47,17,-19,19,22,24,26,19,26,45,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Dina Rami,37.55,17,-19,19,24,26,-28,19,26,45,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 14-15 Age Group 48 kg,Paige Holman,47.53,41,44,-46,-56,-59,-59,44,0,44,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Allison Riepe,36.82,16,18,-20,23,26,-28,18,26,44,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Danielle Jones,45.23,19,21,-22,-21,21,23,21,23,44,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Grayson Brooks,27.62,17,19,-21,22,24,-26,19,24,43,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Halli Hoopes,29.72,15,17,-20,23,26,-29,17,26,43,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 39kg,Blake Maxheimer,38.97,16,18,-20,21,23,-25,18,23,41,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Siena Bertacco,31.69,14,16,17,21,23,-25,17,23,40,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 31 Kg,Brixton Maizels,24.65,14,16,-17,16,18,20,16,20,36,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 39kg,Alana Beddow,37.16,16,-18,-18,20,-23,-24,16,20,36,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Antwan Kilbert,44.22,32,-35,-35,-40,-43,-43,32,0,32,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Men's 13 Under Age Group 50 Kg,Devynn Woodall,48.05,29,32,-35,-40,-42,-42,32,0,32,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Emery Archer,26.93,11,13,-15,15,18,-19,13,18,31,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Na'Chelle Thomas,27.43,10,11,12,15,17,-19,12,17,29,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 35kg,Gracie Aicher,31.01,9,11,13,-13,-15,16,13,16,29,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 31kg,Raelynn Moran,30.49,8,11,13,12,15,-19,13,15,28,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 13 Under Age Group 48kg,Audrey Bink,47.52,-15,-15,-15,15,-17,18,0,18,18,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group 75 kg,Shelby Wait,72.78,-50,-50,-50,-63,-63,-63,0,0,0,0
+National Youth Championships & Youth Olympic Trials,2014-06-15,Women's 16-17 Age Group +75 kg,Lorraine Johnson,95.89,-72,-72,-72,0,0,0,0,0,0,0

--- a/event_data/US/267.csv
+++ b/event_data/US/267.csv
@@ -1,112 +1,112 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-Brian Trussell,2015-01-17,Open Men's+105 kg,Jake Anderson,108.4,90,95,100,130,135,143,100,143,243
-Brian Trussell,2015-01-17,Open Men's+105 kg,Tramail Peterson,108.2,95,100,103,130,133,138,103,138,241
-Brian Trussell,2015-01-17,Open Men's 105 kg,Logan Bruce,100.3,88,95,97,105,114,120,97,120,217
-Brian Trussell,2015-01-17,Open Men's 94 kg,Gabe Hall,92.45,84,86,86,121,126,130,86,130,216
-Brian Trussell,2015-01-17,Open Men's 85 kg,Ryan Daake,84.4,88,90,90,113,116,118,90,118,208
-Brian Trussell,2015-01-17,Open Men's+105 kg,Nicholas Maslowski,120.1,81,85,90,106,111,116,90,116,206
-Brian Trussell,2015-01-17,Open Men's 85 kg,Andrew Egge,83.7,77,82,85,108,113,118,85,118,203
-Brian Trussell,2015-01-17,Open Men's 105 kg,Grant Brokl,94.9,75,78,78,115,120,125,78,125,203
-Brian Trussell,2015-01-17,Open Men's 94 kg,Trevor Liggett,86.6,80,86,86,105,110,116,86,116,202
-Brian Trussell,2015-01-17,Open Men's+105 kg,Connor Flaten,118.24,78,83,86,105,110,115,86,115,201
-Brian Trussell,2015-01-17,Open Men's 69 kg,Carson Chytracek,68.2,80,85,88,105,110,110,88,110,198
-Brian Trussell,2015-01-17,Open Men's 69 kg,Kevin Trinh,63.9,76,80,85,100,106,112,85,112,197
-Brian Trussell,2015-01-17,Open Men's 105 kg,Matthew Delk,102.6,76,79,84,103,106,110,84,110,194
-Brian Trussell,2015-01-17,Open Men's 77 kg,Mason Hofstedt,71.77,75,79,83,95,100,105,83,105,188
-Brian Trussell,2015-01-17,Open Men's 85 kg,Peter Eklund,83.7,70,75,78,100,105,110,78,110,188
-Brian Trussell,2015-01-17,Open Men's+105 kg,Mason Berreth,119,75,80,83,95,100,105,83,105,188
-Brian Trussell,2015-01-17,Open Men's 69 kg,Tyler Chytracek,67.8,81,84,84,95,98,101,84,101,185
-Brian Trussell,2015-01-17,Open Men's 85 kg,Bailey Otto,82.7,75,78,81,95,95,101,81,101,182
-Brian Trussell,2015-01-17,Open Men's+105 kg,Brandon Hernke,109.4,75,80,80,90,95,101,80,101,181
-Brian Trussell,2015-01-17,Open Men's 85 kg,Brighton Goodrich,84.4,67,72,76,95,98,104,76,104,180
-Brian Trussell,2015-01-17,Open Men's 56 kg,An Phan,55.4,70,74,79,88,91,96,79,96,175
-Brian Trussell,2015-01-17,Open Men's 69 kg,Nicholas Lorentz,66.2,75,80,80,90,95,95,80,95,175
-Brian Trussell,2015-01-17,Open Men's 77 kg,Matthew Eklund,76.7,70,75,80,85,93,95,80,95,175
-Brian Trussell,2015-01-17,Open Men's 77 kg,Joseph Brue,76.8,75,75,75,95,98,100,75,100,175
-Brian Trussell,2015-01-17,Open Men's 85 kg,Nicholas Rousemiller,78.9,70,70,78,85,90,95,78,95,173
-Brian Trussell,2015-01-17,Open Men's 77 kg,Logan Miller,74.3,60,65,70,90,95,100,70,100,170
-Brian Trussell,2015-01-17,Open Men's 77 kg,Michael Orr,73.5,67,70,70,91,94,100,70,100,170
-Brian Trussell,2015-01-17,Open Men's 85 kg,Jordan Daniels,84.4,70,73,75,90,92,95,75,95,170
-Brian Trussell,2015-01-17,Open Men's 69 kg,John Perry,68.4,68,71,75,86,90,94,75,94,169
-Brian Trussell,2015-01-17,Open Men's 77 kg,Andrew Forsman,74.49,70,72,75,88,88,92,75,92,167
-Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Alayna Theissen,84.82,65,66,68,90,92,93,68,93,161
-Brian Trussell,2015-01-17,Open Men's 62 kg,David Hausmann,57,66,69,69,84,88,92,69,92,161
-Brian Trussell,2015-01-17,Open Men's+105 kg,Tristin Leonard,144.1,60,65,65,85,90,95,65,95,160
-Brian Trussell,2015-01-17,Open Men's+105 kg,Lucas Stachowski,144.9,65,70,70,75,80,85,70,85,155
-Brian Trussell,2015-01-17,Open Men's 69 kg,Jackson Bahr,63.6,63,63,67,83,87,87,67,87,154
-Brian Trussell,2015-01-17,Open Men's+105 kg,Zachary Chalmers,112.5,55,60,65,70,75,80,65,80,145
-Brian Trussell,2015-01-17,Open Men's 62 kg,Alex Jeon,59.6,56,56,60,80,84,84,60,84,144
-Brian Trussell,2015-01-17,Open Men's 105 kg,Brandon Harris,100.7,60,60,64,80,80,80,64,80,144
-Brian Trussell,2015-01-17,Open Men's 62 kg,Logan Hofstedt,61.7,56,58,62,76,79,82,62,82,144
-Brian Trussell,2015-01-17,Open Men's 77 kg,Aaron Hardel,70.3,55,60,63,70,75,80,63,80,143
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Natasha Rice,71.8,60,63,64,70,73,76,64,76,140
-Brian Trussell,2015-01-17,Open Men's 94 kg,Shea Hillesheim,89.5,62,64,64,76,76,76,64,76,140
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 69 kg,Chase Schaefer,67.94,55,58,61,71,74,77,61,77,138
-Brian Trussell,2015-01-17,Open Men's 56 kg,Yohanes Otto,53.82,50,56,61,69,69,75,61,75,136
-Brian Trussell,2015-01-17,Open Men's 85 kg,William Rousemiller,78.2,55,60,65,60,70,70,65,70,135
-Brian Trussell,2015-01-17,Open Men's 105 kg,John Allstot,99.5,55,59,63,63,67,72,63,72,135
-Brian Trussell,2015-01-17,Open Men's 105 kg,Cade Bianchi,97.2,45,50,55,65,70,75,55,75,130
-Brian Trussell,2015-01-17,Open Men's+105 kg,Ian Bass,107.5,44,48,53,69,73,76,53,76,129
-Brian Trussell,2015-01-17,Men's 14-15 Age Group 62 kg,Broderick Ulrich,59.8,48,52,56,67,70,71,56,71,127
-Brian Trussell,2015-01-17,Open Men's 69 kg,Timothy McNamara,64.8,48,51,51,67,71,76,51,76,127
-Brian Trussell,2015-01-17,Open Women's 69 kg,Alyssa Smith,68.29,52,54,56,64,67,70,56,70,126
-Brian Trussell,2015-01-17,Open Women's +75 Kg,Dannick Boyogueno,112.93,50,53,56,64,64,68,56,68,124
-Brian Trussell,2015-01-17,Open Men's 94 kg,Michael Judd,88.9,47,51,52,65,68,71,52,71,123
-Brian Trussell,2015-01-17,Open Men's 69 kg,Douglas Rowe,65.4,48,52,52,63,67,71,52,71,123
-Brian Trussell,2015-01-17,Open Women's 63 kg,Anna Novak,61.38,45,50,55,55,59,62,55,62,117
-Brian Trussell,2015-01-17,Open Men's 85 kg,Josiah Skaar,79.97,45,45,48,55,60,65,48,65,113
-Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Tessa Guon,88.47,43,46,48,55,60,65,48,65,113
-Brian Trussell,2015-01-17,Open Men's 69 kg,Liam Franken,64.78,45,49,52,55,58,60,52,60,112
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 69 kg,Mary Robertson,67.52,40,45,47,52,57,65,47,65,112
-Brian Trussell,2015-01-17,Men's 14-15 Age Group 50 Kg,Hadyn Anderson,48.67,43,46,48,54,58,60,48,60,108
-Brian Trussell,2015-01-17,Open Women's 58 kg,Taran Pickar,53.23,40,44,46,55,59,59,46,59,105
-Brian Trussell,2015-01-17,Open Men's 56 kg,Nathan Stein,55.5,40,44,47,50,54,58,47,58,105
-Brian Trussell,2015-01-17,Open Women's 48 kg,Destiny Young,44.51,39,42,45,55,58,58,45,58,103
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 53 kg,McKenzie Meyers,51.97,40,45,46,52,57,57,46,57,103
-Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Stephanie Haag- Larson,93.61,35,38,41,55,59,62,41,62,103
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Theresa Hausmann,62.99,38,41,41,54,58,61,41,61,102
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Chelsea Moran,73.25,38,41,47,50,52,53,47,53,100
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 53 kg,Tatum Pickar,51.07,42,45,47,52,52,52,47,52,99
-Brian Trussell,2015-01-17,Open Women's 69 kg,Autumn Zupko,66.4,34,39,43,43,48,53,43,53,96
-Brian Trussell,2015-01-17,Open Women's 69 kg,Avery Lillemoe,66.04,34,39,43,43,48,53,43,53,96
-Brian Trussell,2015-01-17,Men's 14-15 Age Group 50 Kg,Trenton Matthies,49.24,35,38,40,48,52,56,40,56,96
-Brian Trussell,2015-01-17,Open Men's 56 kg,Erik Iversen,53.33,35,40,45,48,51,51,45,51,96
-Brian Trussell,2015-01-17,Open Women's 69 kg,Marissa Virnig,68.13,33,35,39,49,53,56,39,56,95
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Lauren Thielman,62.85,34,36,39,49,54,56,39,56,95
-Brian Trussell,2015-01-17,Open Women's 75 kg,Katelynn Kanieski,73.54,33,37,41,43,48,53,41,53,94
-Brian Trussell,2015-01-17,Women's 14-15 Age Group +69 kg,Addie Saathoff,77.03,32,37,40,45,49,54,40,54,94
-Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Jaimie McNamee,109.72,35,38,41,40,47,52,41,52,93
-Brian Trussell,2015-01-17,Open Women's +75 Kg,Carly Becker,102.98,33,37,41,45,50,52,41,52,93
-Brian Trussell,2015-01-17,Open Men's 62 kg,Leib Hammond,61.6,38,38,41,45,48,52,41,52,93
-Brian Trussell,2015-01-17,Open Women's 63 kg,Mercedes Waagen,62.27,39,44,44,39,44,46,44,46,90
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 58 kg,Brea Watson,55.04,35,38,38,45,48,51,38,51,89
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Elizabeth Becker,61.27,33,38,38,40,45,50,38,50,88
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 69 kg,Maia Johnson,67.96,33,35,38,45,47,50,38,50,88
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 58 kg,Andrea Holtz,56.76,29,32,35,44,47,50,35,50,85
-Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Jehdessa Borreson,79.63,33,36,40,45,45,45,40,45,85
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Kaylee Hanson,70.95,30,33,36,43,45,48,36,48,84
-Brian Trussell,2015-01-17,Men's 13 Under Age Group +69 Kg,Cameron Williams,82.3,27,32,37,35,40,46,37,46,83
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 48 kg,Riley Meyers,46.12,30,33,35,45,48,48,35,48,83
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Erin Koestler,71.08,34,36,38,42,45,45,38,45,83
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 58 kg,Maddie Differding,53.31,25,28,31,40,44,50,31,50,81
-Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Bridget McLaughlin,92.32,32,35,35,42,45,45,35,45,80
-Brian Trussell,2015-01-17,Men's 13 Under Age Group 69 Kg,Nolan Bianchi,66.5,24,28,33,35,40,46,33,46,79
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Victoria Barnett,60.81,27,30,33,36,41,45,33,45,78
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Madalynn Lundell,60.04,25,29,32,40,43,46,32,46,78
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Adele Wolf,61.23,26,29,31,40,43,47,31,47,78
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 58 kg,Marit Molde,57.67,27,30,33,36,39,42,33,42,75
-Brian Trussell,2015-01-17,Open Men's 56 kg,Brodie Hansen,49.46,24,28,30,40,40,45,30,45,75
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 53 kg,Julie Oman,52.99,30,30,33,35,38,39,33,39,72
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 44 kg,Ellie Stodden,43.24,26,29,32,33,37,40,32,40,72
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Madyson Morse,62.94,27,29,29,30,34,42,29,42,71
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Hannah Delk,59.05,25,28,30,35,37,40,30,40,70
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 58 kg,Skylar Mielke,54.41,28,30,30,32,35,39,30,39,69
-Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Tsola Onesirosan,60.2,25,28,31,30,33,35,31,35,66
-Brian Trussell,2015-01-17,Men's 13 Under Age Group 44kg,Drew Otte,43.98,23,26,28,30,34,36,28,36,64
-Brian Trussell,2015-01-17,Men's 13 Under Age Group 44kg,Braxton Ulrich,39.6,20,24,27,30,34,37,27,37,64
-Brian Trussell,2015-01-17,Women's 16-17 Age Group 48 kg,Grace Knoll,45.3,20,23,23,28,32,32,23,32,55
-Brian Trussell,2015-01-17,Open Men's 56 kg,Alvaro Badrinas,53.85,20,24,24,25,30,30,24,30,54
-Brian Trussell,2015-01-17,Open Men's 56 kg,Erich Hoffmann,45.3,19,20,22,26,28,30,22,30,52
-Brian Trussell,2015-01-17,Men's 14-15 Age Group 77 kg,Dylan King,77,15,18,20,25,28,30,20,30,50
-Brian Trussell,2015-01-17,Men's 13 Under Age Group 44kg,Brayden Otto,41.56,15,18,21,25,27,27,21,27,48
-Brian Trussell,2015-01-17,Women's 13 Under Age Group 35kg,Margaret Bahr,32.6,15,16,17,16,18,20,17,20,37
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+Brian Trussell,2015-01-17,Open Men's+105 kg,Jake Anderson,108.4,90,95,100,130,135,143,100,143,243,18
+Brian Trussell,2015-01-17,Open Men's+105 kg,Tramail Peterson,108.2,95,100,103,130,133,138,103,138,241,0
+Brian Trussell,2015-01-17,Open Men's 105 kg,Logan Bruce,100.3,88,95,97,105,114,120,97,120,217,0
+Brian Trussell,2015-01-17,Open Men's 94 kg,Gabe Hall,92.45,84,86,86,121,126,130,86,130,216,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Ryan Daake,84.4,88,90,90,113,116,118,90,118,208,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Nicholas Maslowski,120.1,81,85,90,106,111,116,90,116,206,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Andrew Egge,83.7,77,82,85,108,113,118,85,118,203,0
+Brian Trussell,2015-01-17,Open Men's 105 kg,Grant Brokl,94.9,75,78,78,115,120,125,78,125,203,0
+Brian Trussell,2015-01-17,Open Men's 94 kg,Trevor Liggett,86.6,80,86,86,105,110,116,86,116,202,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Connor Flaten,118.24,78,83,86,105,110,115,86,115,201,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Carson Chytracek,68.2,80,85,88,105,110,110,88,110,198,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Kevin Trinh,63.9,76,80,85,100,106,112,85,112,197,0
+Brian Trussell,2015-01-17,Open Men's 105 kg,Matthew Delk,102.6,76,79,84,103,106,110,84,110,194,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Mason Hofstedt,71.77,75,79,83,95,100,105,83,105,188,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Peter Eklund,83.7,70,75,78,100,105,110,78,110,188,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Mason Berreth,119,75,80,83,95,100,105,83,105,188,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Tyler Chytracek,67.8,81,84,84,95,98,101,84,101,185,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Bailey Otto,82.7,75,78,81,95,95,101,81,101,182,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Brandon Hernke,109.4,75,80,80,90,95,101,80,101,181,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Brighton Goodrich,84.4,67,72,76,95,98,104,76,104,180,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,An Phan,55.4,70,74,79,88,91,96,79,96,175,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Nicholas Lorentz,66.2,75,80,80,90,95,95,80,95,175,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Matthew Eklund,76.7,70,75,80,85,93,95,80,95,175,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Joseph Brue,76.8,75,75,75,95,98,100,75,100,175,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Nicholas Rousemiller,78.9,70,70,78,85,90,95,78,95,173,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Logan Miller,74.3,60,65,70,90,95,100,70,100,170,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Michael Orr,73.5,67,70,70,91,94,100,70,100,170,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Jordan Daniels,84.4,70,73,75,90,92,95,75,95,170,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,John Perry,68.4,68,71,75,86,90,94,75,94,169,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Andrew Forsman,74.49,70,72,75,88,88,92,75,92,167,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Alayna Theissen,84.82,65,66,68,90,92,93,68,93,161,0
+Brian Trussell,2015-01-17,Open Men's 62 kg,David Hausmann,57,66,69,69,84,88,92,69,92,161,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Tristin Leonard,144.1,60,65,65,85,90,95,65,95,160,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Lucas Stachowski,144.9,65,70,70,75,80,85,70,85,155,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Jackson Bahr,63.6,63,63,67,83,87,87,67,87,154,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Zachary Chalmers,112.5,55,60,65,70,75,80,65,80,145,0
+Brian Trussell,2015-01-17,Open Men's 62 kg,Alex Jeon,59.6,56,56,60,80,84,84,60,84,144,0
+Brian Trussell,2015-01-17,Open Men's 105 kg,Brandon Harris,100.7,60,60,64,80,80,80,64,80,144,0
+Brian Trussell,2015-01-17,Open Men's 62 kg,Logan Hofstedt,61.7,56,58,62,76,79,82,62,82,144,0
+Brian Trussell,2015-01-17,Open Men's 77 kg,Aaron Hardel,70.3,55,60,63,70,75,80,63,80,143,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Natasha Rice,71.8,60,63,64,70,73,76,64,76,140,0
+Brian Trussell,2015-01-17,Open Men's 94 kg,Shea Hillesheim,89.5,62,64,64,76,76,76,64,76,140,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 69 kg,Chase Schaefer,67.94,55,58,61,71,74,77,61,77,138,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,Yohanes Otto,53.82,50,56,61,69,69,75,61,75,136,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,William Rousemiller,78.2,55,60,65,60,70,70,65,70,135,0
+Brian Trussell,2015-01-17,Open Men's 105 kg,John Allstot,99.5,55,59,63,63,67,72,63,72,135,0
+Brian Trussell,2015-01-17,Open Men's 105 kg,Cade Bianchi,97.2,45,50,55,65,70,75,55,75,130,0
+Brian Trussell,2015-01-17,Open Men's+105 kg,Ian Bass,107.5,44,48,53,69,73,76,53,76,129,0
+Brian Trussell,2015-01-17,Men's 14-15 Age Group 62 kg,Broderick Ulrich,59.8,48,52,56,67,70,71,56,71,127,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Timothy McNamara,64.8,48,51,51,67,71,76,51,76,127,0
+Brian Trussell,2015-01-17,Open Women's 69 kg,Alyssa Smith,68.29,52,54,56,64,67,70,56,70,126,0
+Brian Trussell,2015-01-17,Open Women's +75 Kg,Dannick Boyogueno,112.93,50,53,56,64,64,68,56,68,124,0
+Brian Trussell,2015-01-17,Open Men's 94 kg,Michael Judd,88.9,47,51,52,65,68,71,52,71,123,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Douglas Rowe,65.4,48,52,52,63,67,71,52,71,123,0
+Brian Trussell,2015-01-17,Open Women's 63 kg,Anna Novak,61.38,45,50,55,55,59,62,55,62,117,0
+Brian Trussell,2015-01-17,Open Men's 85 kg,Josiah Skaar,79.97,45,45,48,55,60,65,48,65,113,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Tessa Guon,88.47,43,46,48,55,60,65,48,65,113,0
+Brian Trussell,2015-01-17,Open Men's 69 kg,Liam Franken,64.78,45,49,52,55,58,60,52,60,112,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 69 kg,Mary Robertson,67.52,40,45,47,52,57,65,47,65,112,0
+Brian Trussell,2015-01-17,Men's 14-15 Age Group 50 Kg,Hadyn Anderson,48.67,43,46,48,54,58,60,48,60,108,0
+Brian Trussell,2015-01-17,Open Women's 58 kg,Taran Pickar,53.23,40,44,46,55,59,59,46,59,105,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,Nathan Stein,55.5,40,44,47,50,54,58,47,58,105,0
+Brian Trussell,2015-01-17,Open Women's 48 kg,Destiny Young,44.51,39,42,45,55,58,58,45,58,103,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 53 kg,McKenzie Meyers,51.97,40,45,46,52,57,57,46,57,103,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Stephanie Haag- Larson,93.61,35,38,41,55,59,62,41,62,103,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Theresa Hausmann,62.99,38,41,41,54,58,61,41,61,102,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Chelsea Moran,73.25,38,41,47,50,52,53,47,53,100,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 53 kg,Tatum Pickar,51.07,42,45,47,52,52,52,47,52,99,0
+Brian Trussell,2015-01-17,Open Women's 69 kg,Autumn Zupko,66.4,34,39,43,43,48,53,43,53,96,0
+Brian Trussell,2015-01-17,Open Women's 69 kg,Avery Lillemoe,66.04,34,39,43,43,48,53,43,53,96,0
+Brian Trussell,2015-01-17,Men's 14-15 Age Group 50 Kg,Trenton Matthies,49.24,35,38,40,48,52,56,40,56,96,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,Erik Iversen,53.33,35,40,45,48,51,51,45,51,96,0
+Brian Trussell,2015-01-17,Open Women's 69 kg,Marissa Virnig,68.13,33,35,39,49,53,56,39,56,95,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Lauren Thielman,62.85,34,36,39,49,54,56,39,56,95,0
+Brian Trussell,2015-01-17,Open Women's 75 kg,Katelynn Kanieski,73.54,33,37,41,43,48,53,41,53,94,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group +69 kg,Addie Saathoff,77.03,32,37,40,45,49,54,40,54,94,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Jaimie McNamee,109.72,35,38,41,40,47,52,41,52,93,0
+Brian Trussell,2015-01-17,Open Women's +75 Kg,Carly Becker,102.98,33,37,41,45,50,52,41,52,93,0
+Brian Trussell,2015-01-17,Open Men's 62 kg,Leib Hammond,61.6,38,38,41,45,48,52,41,52,93,0
+Brian Trussell,2015-01-17,Open Women's 63 kg,Mercedes Waagen,62.27,39,44,44,39,44,46,44,46,90,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 58 kg,Brea Watson,55.04,35,38,38,45,48,51,38,51,89,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Elizabeth Becker,61.27,33,38,38,40,45,50,38,50,88,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 69 kg,Maia Johnson,67.96,33,35,38,45,47,50,38,50,88,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 58 kg,Andrea Holtz,56.76,29,32,35,44,47,50,35,50,85,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Jehdessa Borreson,79.63,33,36,40,45,45,45,40,45,85,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Kaylee Hanson,70.95,30,33,36,43,45,48,36,48,84,0
+Brian Trussell,2015-01-17,Men's 13 Under Age Group +69 Kg,Cameron Williams,82.3,27,32,37,35,40,46,37,46,83,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 48 kg,Riley Meyers,46.12,30,33,35,45,48,48,35,48,83,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 75 kg,Erin Koestler,71.08,34,36,38,42,45,45,38,45,83,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 58 kg,Maddie Differding,53.31,25,28,31,40,44,50,31,50,81,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group +75 kg,Bridget McLaughlin,92.32,32,35,35,42,45,45,35,45,80,0
+Brian Trussell,2015-01-17,Men's 13 Under Age Group 69 Kg,Nolan Bianchi,66.5,24,28,33,35,40,46,33,46,79,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Victoria Barnett,60.81,27,30,33,36,41,45,33,45,78,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Madalynn Lundell,60.04,25,29,32,40,43,46,32,46,78,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Adele Wolf,61.23,26,29,31,40,43,47,31,47,78,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 58 kg,Marit Molde,57.67,27,30,33,36,39,42,33,42,75,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,Brodie Hansen,49.46,24,28,30,40,40,45,30,45,75,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 53 kg,Julie Oman,52.99,30,30,33,35,38,39,33,39,72,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 44 kg,Ellie Stodden,43.24,26,29,32,33,37,40,32,40,72,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 63 kg,Madyson Morse,62.94,27,29,29,30,34,42,29,42,71,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Hannah Delk,59.05,25,28,30,35,37,40,30,40,70,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 58 kg,Skylar Mielke,54.41,28,30,30,32,35,39,30,39,69,0
+Brian Trussell,2015-01-17,Women's 14-15 Age Group 63 kg,Tsola Onesirosan,60.2,25,28,31,30,33,35,31,35,66,0
+Brian Trussell,2015-01-17,Men's 13 Under Age Group 44kg,Drew Otte,43.98,23,26,28,30,34,36,28,36,64,0
+Brian Trussell,2015-01-17,Men's 13 Under Age Group 44kg,Braxton Ulrich,39.6,20,24,27,30,34,37,27,37,64,0
+Brian Trussell,2015-01-17,Women's 16-17 Age Group 48 kg,Grace Knoll,45.3,20,23,23,28,32,32,23,32,55,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,Alvaro Badrinas,53.85,20,24,24,25,30,30,24,30,54,0
+Brian Trussell,2015-01-17,Open Men's 56 kg,Erich Hoffmann,45.3,19,20,22,26,28,30,22,30,52,0
+Brian Trussell,2015-01-17,Men's 14-15 Age Group 77 kg,Dylan King,77,15,18,20,25,28,30,20,30,50,0
+Brian Trussell,2015-01-17,Men's 13 Under Age Group 44kg,Brayden Otto,41.56,15,18,21,25,27,27,21,27,48,0
+Brian Trussell,2015-01-17,Women's 13 Under Age Group 35kg,Margaret Bahr,32.6,15,16,17,16,18,20,17,20,37,0

--- a/event_data/US/271.csv
+++ b/event_data/US/271.csv
@@ -1,121 +1,121 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Nate Oelke,76.6,112,116,-120,147,151,-155,116,151,267
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Michael Schiller,79,-110,110,-112,145,148,-150,110,148,258
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Jake Anderson,107.7,110,115,-123,135,140,-145,115,140,255
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Eric Rousemiller,135.8,105,-110,-110,130,-135,-135,105,130,235
-Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Connor Rousemiller,101.1,-110,110,-121,120,-151,-151,110,120,230
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Gabe Hall,92,93,97,-100,-126,126,131,97,131,228
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Anders Grahn,139.9,90,93,96,120,125,132,96,132,228
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,William Staska,91.8,100,-105,-105,125,127,-130,100,127,227
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Gerrit Olsen,87.3,-97,97,100,117,-121,122,100,122,222
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Nick Burton,117.9,88,91,94,120,125,-130,94,125,219
-Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Jackson Gilman,103.3,87,-89,-90,127,130,131,87,131,218
-Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Logan Bruce,100.6,98,-102,102,-115,-115,115,102,115,217
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Kevin Kucera,84.7,90,93,-96,-120,120,-123,93,120,213
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Grant Brokl,92.1,-83,-84,84,-125,125,-130,84,125,209
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Jacob Engel,92.8,88,91,93,-116,116,-118,93,116,209
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Carson Chytracek,67.6,85,90,-93,115,-120,-120,90,115,205
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Kevin Trinh,67.1,85,-89,90,110,115,-121,90,115,205
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Ryan Daake,84.1,-83,-83,83,118,121,-125,83,121,204
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Andrew Egge,83.5,80,-85,-85,-116,-116,116,80,116,196
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Kyle Tullos,75.9,82,-85,-86,102,107,111,82,111,193
-Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Benjamin Nhan,60.9,76,79,82,103,-107,110,82,110,192
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Tanner Billmeyer,66.4,-79,79,82,103,106,109,82,109,191
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Francis Torres,68,80,82,-85,-105,107,109,82,109,191
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Mason Hofstedt,74.7,80,85,-90,100,105,-108,85,105,190
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Devan Heaney,76.3,83,-85,-86,-104,106,-112,83,106,189
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Jake Staats,135.5,72,75,78,100,103,108,78,108,186
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Tyler Chytracek,68.6,85,-90,-90,-100,100,-105,85,100,185
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Peter Eklund,86.8,70,75,-80,105,-110,-115,75,105,180
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Mason Berreth,120.1,75,-80,80,-100,-100,100,80,100,180
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Andrew Forsman,75.8,74,76,78,96,-98,98,78,98,176
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Nicholas Lorentz,65.3,75,-80,-80,90,95,-100,75,95,170
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Tate Rench,72.9,-75,75,-78,95,-100,-105,75,95,170
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Noah Bachmeier,66.3,65,69,72,90,94,97,72,97,169
-Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Emerson Pagel,102.7,68,71,-75,-97,-97,97,71,97,168
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,An Phan,55.1,-72,72,-75,95,-98,-98,72,95,167
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Jared Shearer,67.9,70,-72,73,90,93,-96,73,93,166
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Nicholas Rousemiller,79.7,-70,70,-78,85,90,-95,70,90,160
-Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Jacob Goerdt,93.1,68,70,-71,-88,90,-92,70,90,160
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,William Meacham,66.1,65,67,-69,85,88,90,67,90,157
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Alayna Theissen,83.5,64,67,-70,82,85,88,67,88,155
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Matthew Odegard,83.8,-62,62,65,84,87,-90,65,87,152
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Dante Fitzsimmons,66.2,63,-68,-68,80,85,-90,63,85,148
-Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Bryce Jorgensen,62,-60,61,63,80,82,84,63,84,147
-Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Logan Hofstedt,60.1,58,-62,-62,80,87,-90,58,87,145
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Daniel Glampe,74.3,60,63,65,-80,80,-84,65,80,145
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 75 kg,Natasha Rice,72.8,64,67,-70,-74,74,77,67,77,144
-Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Travis Agarano,58.6,59,62,65,-77,-79,79,65,79,144
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Jacob Boatman,65.8,60,62,-65,-77,78,80,62,80,142
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Max Mallory,75.7,-62,-62,62,-75,75,78,62,78,140
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Alicia Vogel,83.7,60,63,-68,70,73,76,63,76,139
-Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Michael Fischer,60.6,55,58,-61,71,74,78,58,78,136
-Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Luke Simon,60.3,56,58,59,72,75,77,59,77,136
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Chase Schaefer,68.1,58,62,-65,73,-77,-79,62,73,135
-Minnesota State High School Championships,2015-03-07,Men's 14-15 Age Group 62 kg,Broderick Ulrich,60.6,53,57,60,70,74,-76,60,74,134
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Raezjine Merriweather,105,-59,60,62,67,69,72,62,72,134
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Yohanes Otto,55.1,60,-63,-67,70,73,-75,60,73,133
-Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Katrina Smith,85.3,48,-51,51,76,79,80,51,80,131
-Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Alyssa Smith,68.4,53,56,59,68,71,-74,59,71,130
-Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Geneva Brandt,82.9,53,55,-58,72,75,-78,55,75,130
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Jon McKeon,53,53,55,56,65,68,70,56,70,126
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 75 kg,Natalie Parker,70.3,47,50,52,64,68,70,52,70,122
-Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Madison Griffin,100.6,45,47,-49,70,73,75,47,75,122
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 63 kg,Cassidie Parker,62.3,44,46,48,67,70,73,48,73,121
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Michaela McIntosh,53,-50,50,52,-68,69,-71,52,69,121
-Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Claire Boatman,67.5,49,51,-54,65,66,69,51,69,120
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Eric Voxland,76.8,-90,-91,-91,115,118,120,0,120,120
-Minnesota State High School Championships,2015-03-07,Open Women's 48 kg,Destiny Young,46,49,51,53,63,66,-69,53,66,119
-Minnesota State High School Championships,2015-03-07,Open Women's 63 kg,Grace Peterson,59,49,52,-54,62,65,-67,52,65,117
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 63 kg,Theresa Hausmann,62.6,45,48,-50,62,66,-71,48,66,114
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Abdi Farah,55.9,45,48,-49,60,-63,64,48,64,112
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 69 kg,Mary Robertson,68,45,48,52,60,-65,-67,52,60,112
-Minnesota State High School Championships,2015-03-07,Open Women's 63 kg,Kallan Wenborg,62.3,-47,47,50,57,-61,61,50,61,111
-Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Karina Cisar,68.9,-43,43,45,61,63,66,45,66,111
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 75 kg,Erin Holman,71.9,44,47,49,56,60,-63,49,60,109
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Preston Hoffer,55.2,42,46,-49,55,60,61,46,61,107
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Jonas Hagen,84,-106,106,-109,-133,-133,-133,106,0,106
-Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Tanner Remlinger,73.1,-80,-83,-86,105,-109,-109,0,105,105
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Tramail Peterson,109.5,102,105,-108,-140,-140,-140,105,0,105
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Jennifer Antoine,112,40,-43,-44,57,61,65,40,65,105
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Jared Larsen,53.7,-44,-44,44,58,60,-63,44,60,104
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group +69 kg,Addie Saathoff,78.2,40,-44,46,55,58,-61,46,58,104
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Jehdessa Borreson,78.6,45,-47,-49,-55,57,59,45,59,104
-Minnesota State High School Championships,2015-03-07,Open Women's 75 kg,Katie Kleinow,70.7,43,46,-48,57,-60,-60,46,57,103
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Erik Iversen,55.1,43,45,-47,54,57,-60,45,57,102
-Minnesota State High School Championships,2015-03-07,Men's 14-15 Age Group 50 Kg,Hadyn Anderson,49.1,42,-47,-49,55,58,-62,42,58,100
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Nathan Stein,55.3,42,-47,-47,-58,58,-63,42,58,100
-Minnesota State High School Championships,2015-03-07,Open Women's 58 kg,Taran Pickar,56.1,43,-46,-46,56,-59,-59,43,56,99
-Minnesota State High School Championships,2015-03-07,Men's 14-15 Age Group 56 Kg,Trenton Matthies,53.8,38,-43,43,50,-55,56,43,56,99
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,McKenzie Meyers,51.1,-43,43,-46,-55,55,-59,43,55,98
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Lauren Thielman,63.3,37,40,-44,51,56,-60,40,56,96
-Minnesota State High School Championships,2015-03-07,Open Women's 58 kg,Abigail Goerdt,56,-38,38,-41,52,55,57,38,57,95
-Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Nicholas Maslowski,120.7,90,-93,95,-120,-125,-125,95,0,95
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Erin Koestler,69,38,41,44,-50,51,-55,44,51,95
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 58 kg,Andrea Holtz,56.9,35,37,-39,-53,54,56,37,56,93
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Tatum Pickar,52.4,-42,42,-47,45,50,-55,42,50,92
-Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,John Perry,68.6,-74,-74,-74,90,-95,-97,0,90,90
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Grahm Johnson,82,90,-93,-93,0,0,0,90,0,90
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 58 kg,Maddie Differding,56.1,35,37,-40,-53,-53,53,37,53,90
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Maia Johnson,68.6,-38,-38,38,-50,50,52,38,52,90
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 63 kg,Miah Keller,59.8,34,-36,38,47,-49,51,38,51,89
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 48 kg,Riley Meyers,46.9,33,36,-34,48,-52,52,36,52,88
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Julie Oman,52.1,34,-36,36,48,51,-54,36,51,87
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Brodie Hansen,49.2,27,32,35,45,-50,52,35,52,87
-Minnesota State High School Championships,2015-03-07,Open Women's 53 kg,Briana Berninghaus,51.3,32,35,-37,49,-51,52,35,52,87
-Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Gabino Rodriguez-Arguelles,81.4,-85,85,-88,-122,-122,-122,85,0,85
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 58 kg,Skylar Mielke,55,-35,-36,36,41,44,46,36,46,82
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Hannah Johnson,52.4,30,33,35,40,43,46,35,46,81
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 58 kg,Madison Bauer,56.6,31,33,36,41,-44,44,36,44,80
-Minnesota State High School Championships,2015-03-07,Open Women's 48 kg,Jackie Levvintre,45.6,33,35,-37,40,43,45,35,45,80
-Minnesota State High School Championships,2015-03-07,Men's 13 Under Age Group 50 Kg,Drew Otte,46,27,32,-35,40,45,-47,32,45,77
-Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Dannick Boyogueno,118.6,-60,-60,-60,72,75,-78,0,75,75
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,David Hausmann,55,65,70,-73,-90,-90,-90,70,0,70
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 48 kg,Grace Knoll,46.1,25,-27,28,33,36,38,28,38,66
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 53 kg,Brooke Stanga,51.5,26,28,-30,34,36,38,28,38,66
-Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 44 kg,Erin Bachmeier,42.2,23,25,26,33,35,37,26,37,63
-Minnesota State High School Championships,2015-03-07,Open Women's 58 kg,Anna Novak,57.8,-50,-52,-52,-56,56,58,0,58,58
-Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Avery Lillemoe,67,-45,-47,-48,55,-58,-60,0,55,55
-Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 58 kg,Brea Watson,53.7,-42,-43,-43,53,-54,54,0,54,54
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Erich Hoffmann,44.5,22,23,25,26,0,0,25,26,51
-Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Jon Kuivinen,55.5,-43,-43,43,-53,-53,-53,43,0,43
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Nate Oelke,76.6,112,116,-120,147,151,-155,116,151,267,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Michael Schiller,79,-110,110,-112,145,148,-150,110,148,258,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Jake Anderson,107.7,110,115,-123,135,140,-145,115,140,255,18
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Eric Rousemiller,135.8,105,-110,-110,130,-135,-135,105,130,235,0
+Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Connor Rousemiller,101.1,-110,110,-121,120,-151,-151,110,120,230,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Gabe Hall,92,93,97,-100,-126,126,131,97,131,228,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Anders Grahn,139.9,90,93,96,120,125,132,96,132,228,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,William Staska,91.8,100,-105,-105,125,127,-130,100,127,227,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Gerrit Olsen,87.3,-97,97,100,117,-121,122,100,122,222,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Nick Burton,117.9,88,91,94,120,125,-130,94,125,219,0
+Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Jackson Gilman,103.3,87,-89,-90,127,130,131,87,131,218,0
+Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Logan Bruce,100.6,98,-102,102,-115,-115,115,102,115,217,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Kevin Kucera,84.7,90,93,-96,-120,120,-123,93,120,213,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Grant Brokl,92.1,-83,-84,84,-125,125,-130,84,125,209,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Jacob Engel,92.8,88,91,93,-116,116,-118,93,116,209,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Carson Chytracek,67.6,85,90,-93,115,-120,-120,90,115,205,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Kevin Trinh,67.1,85,-89,90,110,115,-121,90,115,205,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Ryan Daake,84.1,-83,-83,83,118,121,-125,83,121,204,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Andrew Egge,83.5,80,-85,-85,-116,-116,116,80,116,196,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Kyle Tullos,75.9,82,-85,-86,102,107,111,82,111,193,0
+Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Benjamin Nhan,60.9,76,79,82,103,-107,110,82,110,192,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Tanner Billmeyer,66.4,-79,79,82,103,106,109,82,109,191,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Francis Torres,68,80,82,-85,-105,107,109,82,109,191,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Mason Hofstedt,74.7,80,85,-90,100,105,-108,85,105,190,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Devan Heaney,76.3,83,-85,-86,-104,106,-112,83,106,189,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Jake Staats,135.5,72,75,78,100,103,108,78,108,186,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Tyler Chytracek,68.6,85,-90,-90,-100,100,-105,85,100,185,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Peter Eklund,86.8,70,75,-80,105,-110,-115,75,105,180,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Mason Berreth,120.1,75,-80,80,-100,-100,100,80,100,180,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Andrew Forsman,75.8,74,76,78,96,-98,98,78,98,176,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Nicholas Lorentz,65.3,75,-80,-80,90,95,-100,75,95,170,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Tate Rench,72.9,-75,75,-78,95,-100,-105,75,95,170,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Noah Bachmeier,66.3,65,69,72,90,94,97,72,97,169,0
+Minnesota State High School Championships,2015-03-07,Open Men's 105 kg,Emerson Pagel,102.7,68,71,-75,-97,-97,97,71,97,168,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,An Phan,55.1,-72,72,-75,95,-98,-98,72,95,167,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Jared Shearer,67.9,70,-72,73,90,93,-96,73,93,166,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Nicholas Rousemiller,79.7,-70,70,-78,85,90,-95,70,90,160,0
+Minnesota State High School Championships,2015-03-07,Open Men's 94 kg,Jacob Goerdt,93.1,68,70,-71,-88,90,-92,70,90,160,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,William Meacham,66.1,65,67,-69,85,88,90,67,90,157,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Alayna Theissen,83.5,64,67,-70,82,85,88,67,88,155,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Matthew Odegard,83.8,-62,62,65,84,87,-90,65,87,152,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Dante Fitzsimmons,66.2,63,-68,-68,80,85,-90,63,85,148,0
+Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Bryce Jorgensen,62,-60,61,63,80,82,84,63,84,147,0
+Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Logan Hofstedt,60.1,58,-62,-62,80,87,-90,58,87,145,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Daniel Glampe,74.3,60,63,65,-80,80,-84,65,80,145,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 75 kg,Natasha Rice,72.8,64,67,-70,-74,74,77,67,77,144,0
+Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Travis Agarano,58.6,59,62,65,-77,-79,79,65,79,144,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,Jacob Boatman,65.8,60,62,-65,-77,78,80,62,80,142,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Max Mallory,75.7,-62,-62,62,-75,75,78,62,78,140,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Alicia Vogel,83.7,60,63,-68,70,73,76,63,76,139,0
+Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Michael Fischer,60.6,55,58,-61,71,74,78,58,78,136,0
+Minnesota State High School Championships,2015-03-07,Open Men's 62 kg,Luke Simon,60.3,56,58,59,72,75,77,59,77,136,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Chase Schaefer,68.1,58,62,-65,73,-77,-79,62,73,135,0
+Minnesota State High School Championships,2015-03-07,Men's 14-15 Age Group 62 kg,Broderick Ulrich,60.6,53,57,60,70,74,-76,60,74,134,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Raezjine Merriweather,105,-59,60,62,67,69,72,62,72,134,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Yohanes Otto,55.1,60,-63,-67,70,73,-75,60,73,133,0
+Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Katrina Smith,85.3,48,-51,51,76,79,80,51,80,131,0
+Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Alyssa Smith,68.4,53,56,59,68,71,-74,59,71,130,0
+Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Geneva Brandt,82.9,53,55,-58,72,75,-78,55,75,130,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Jon McKeon,53,53,55,56,65,68,70,56,70,126,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 75 kg,Natalie Parker,70.3,47,50,52,64,68,70,52,70,122,0
+Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Madison Griffin,100.6,45,47,-49,70,73,75,47,75,122,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 63 kg,Cassidie Parker,62.3,44,46,48,67,70,73,48,73,121,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Michaela McIntosh,53,-50,50,52,-68,69,-71,52,69,121,0
+Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Claire Boatman,67.5,49,51,-54,65,66,69,51,69,120,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Eric Voxland,76.8,-90,-91,-91,115,118,120,0,120,120,0
+Minnesota State High School Championships,2015-03-07,Open Women's 48 kg,Destiny Young,46,49,51,53,63,66,-69,53,66,119,0
+Minnesota State High School Championships,2015-03-07,Open Women's 63 kg,Grace Peterson,59,49,52,-54,62,65,-67,52,65,117,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 63 kg,Theresa Hausmann,62.6,45,48,-50,62,66,-71,48,66,114,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Abdi Farah,55.9,45,48,-49,60,-63,64,48,64,112,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 69 kg,Mary Robertson,68,45,48,52,60,-65,-67,52,60,112,0
+Minnesota State High School Championships,2015-03-07,Open Women's 63 kg,Kallan Wenborg,62.3,-47,47,50,57,-61,61,50,61,111,0
+Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Karina Cisar,68.9,-43,43,45,61,63,66,45,66,111,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 75 kg,Erin Holman,71.9,44,47,49,56,60,-63,49,60,109,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Preston Hoffer,55.2,42,46,-49,55,60,61,46,61,107,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Jonas Hagen,84,-106,106,-109,-133,-133,-133,106,0,106,0
+Minnesota State High School Championships,2015-03-07,Open Men's 77 kg,Tanner Remlinger,73.1,-80,-83,-86,105,-109,-109,0,105,105,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Tramail Peterson,109.5,102,105,-108,-140,-140,-140,105,0,105,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Jennifer Antoine,112,40,-43,-44,57,61,65,40,65,105,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Jared Larsen,53.7,-44,-44,44,58,60,-63,44,60,104,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group +69 kg,Addie Saathoff,78.2,40,-44,46,55,58,-61,46,58,104,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group +75 kg,Jehdessa Borreson,78.6,45,-47,-49,-55,57,59,45,59,104,0
+Minnesota State High School Championships,2015-03-07,Open Women's 75 kg,Katie Kleinow,70.7,43,46,-48,57,-60,-60,46,57,103,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Erik Iversen,55.1,43,45,-47,54,57,-60,45,57,102,0
+Minnesota State High School Championships,2015-03-07,Men's 14-15 Age Group 50 Kg,Hadyn Anderson,49.1,42,-47,-49,55,58,-62,42,58,100,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Nathan Stein,55.3,42,-47,-47,-58,58,-63,42,58,100,0
+Minnesota State High School Championships,2015-03-07,Open Women's 58 kg,Taran Pickar,56.1,43,-46,-46,56,-59,-59,43,56,99,0
+Minnesota State High School Championships,2015-03-07,Men's 14-15 Age Group 56 Kg,Trenton Matthies,53.8,38,-43,43,50,-55,56,43,56,99,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,McKenzie Meyers,51.1,-43,43,-46,-55,55,-59,43,55,98,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Lauren Thielman,63.3,37,40,-44,51,56,-60,40,56,96,0
+Minnesota State High School Championships,2015-03-07,Open Women's 58 kg,Abigail Goerdt,56,-38,38,-41,52,55,57,38,57,95,0
+Minnesota State High School Championships,2015-03-07,Open Men's+105 kg,Nicholas Maslowski,120.7,90,-93,95,-120,-125,-125,95,0,95,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Erin Koestler,69,38,41,44,-50,51,-55,44,51,95,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 58 kg,Andrea Holtz,56.9,35,37,-39,-53,54,56,37,56,93,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Tatum Pickar,52.4,-42,42,-47,45,50,-55,42,50,92,0
+Minnesota State High School Championships,2015-03-07,Open Men's 69 kg,John Perry,68.6,-74,-74,-74,90,-95,-97,0,90,90,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Grahm Johnson,82,90,-93,-93,0,0,0,90,0,90,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 58 kg,Maddie Differding,56.1,35,37,-40,-53,-53,53,37,53,90,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 69 kg,Maia Johnson,68.6,-38,-38,38,-50,50,52,38,52,90,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 63 kg,Miah Keller,59.8,34,-36,38,47,-49,51,38,51,89,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 48 kg,Riley Meyers,46.9,33,36,-34,48,-52,52,36,52,88,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Julie Oman,52.1,34,-36,36,48,51,-54,36,51,87,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Brodie Hansen,49.2,27,32,35,45,-50,52,35,52,87,0
+Minnesota State High School Championships,2015-03-07,Open Women's 53 kg,Briana Berninghaus,51.3,32,35,-37,49,-51,52,35,52,87,0
+Minnesota State High School Championships,2015-03-07,Open Men's 85 kg,Gabino Rodriguez-Arguelles,81.4,-85,85,-88,-122,-122,-122,85,0,85,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 58 kg,Skylar Mielke,55,-35,-36,36,41,44,46,36,46,82,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 53 kg,Hannah Johnson,52.4,30,33,35,40,43,46,35,46,81,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 58 kg,Madison Bauer,56.6,31,33,36,41,-44,44,36,44,80,0
+Minnesota State High School Championships,2015-03-07,Open Women's 48 kg,Jackie Levvintre,45.6,33,35,-37,40,43,45,35,45,80,0
+Minnesota State High School Championships,2015-03-07,Men's 13 Under Age Group 50 Kg,Drew Otte,46,27,32,-35,40,45,-47,32,45,77,0
+Minnesota State High School Championships,2015-03-07,Open Women's +75 Kg,Dannick Boyogueno,118.6,-60,-60,-60,72,75,-78,0,75,75,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,David Hausmann,55,65,70,-73,-90,-90,-90,70,0,70,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 48 kg,Grace Knoll,46.1,25,-27,28,33,36,38,28,38,66,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 53 kg,Brooke Stanga,51.5,26,28,-30,34,36,38,28,38,66,0
+Minnesota State High School Championships,2015-03-07,Women's 14-15 Age Group 44 kg,Erin Bachmeier,42.2,23,25,26,33,35,37,26,37,63,0
+Minnesota State High School Championships,2015-03-07,Open Women's 58 kg,Anna Novak,57.8,-50,-52,-52,-56,56,58,0,58,58,0
+Minnesota State High School Championships,2015-03-07,Open Women's 69 kg,Avery Lillemoe,67,-45,-47,-48,55,-58,-60,0,55,55,0
+Minnesota State High School Championships,2015-03-07,Women's 16-17 Age Group 58 kg,Brea Watson,53.7,-42,-43,-43,53,-54,54,0,54,54,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Erich Hoffmann,44.5,22,23,25,26,0,0,25,26,51,0
+Minnesota State High School Championships,2015-03-07,Open Men's 56 kg,Jon Kuivinen,55.5,-43,-43,43,-53,-53,-53,43,0,43,0

--- a/event_data/US/5306.csv
+++ b/event_data/US/5306.csv
@@ -1,43 +1,43 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Zachary Sclater,143,-124,127,130,-165,165,170,130,170,300
-Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Bryan Gates,137.4,115,120,-125,160,-171,-171,120,160,280
-Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Jake Anderson,122.1,105,110,115,130,135,140,115,140,255
-Folsom Open 2 2022,2022-04-30,Open Men's 102kg,Patrick Craig,99.1,95,100,-105,125,130,135,100,135,235
-Folsom Open 2 2022,2022-04-30,Open Men's 96kg,Dayton  Sandobal,89.9,-93,93,96,-120,120,-123,96,120,216
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group +102kg,Mason Starkey,125,85,88,-90,110,-115,115,88,115,203
-Folsom Open 2 2022,2022-04-30,Open Men's 89kg,Ethan Ashton,83.2,-80,80,85,100,105,110,85,110,195
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 73kg,Daniel Chavez,72.98,80,83,86,108,-111,-112,86,108,194
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 96kg,Travis Knierim,90.1,-73,73,75,108,112,115,75,115,190
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group +89kg,Luke Sorensen,115,77,80,83,100,103,106,83,106,189
-Folsom Open 2 2022,2022-04-30,Open Men's 73kg,Anthony Duong,71,80,83,-86,105,-108,-108,83,105,188
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 102kg,Theodore Greule,96.7,73,76,78,100,103,105,78,105,183
-Folsom Open 2 2022,2022-04-30,Open Men's 61kg,Daniel Louie,60.3,70,75,80,90,95,100,80,100,180
-Folsom Open 2 2022,2022-04-30,Open Men's 73kg,Parmvir Sohal,71.5,70,73,-76,97,100,-103,73,100,173
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 81kg,Julian Vasquez,76.9,73,75,77,90,93,95,77,95,172
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 96kg,Samuel Mark,92,70,73,76,-90,90,93,76,93,169
-Folsom Open 2 2022,2022-04-30,Open Men's 89kg,Zhenxiong Jia,88.2,65,70,-75,82,87,91,70,91,161
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 61kg,David Zechowy,55.6,66,69,-72,87,91,-95,69,91,160
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group +89kg,Dominic  Matthews ,117.5,63,66,69,-88,90,-93,69,90,159
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 81kg,Lucas Grimes,73.6,63,66,69,84,87,90,69,90,159
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 73kg,Lazaro Paniagua-Enriquez,72.5,66,68,70,75,80,85,70,85,155
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 73kg,Isiah Williams,72.3,60,63,65,84,86,88,65,88,153
-Folsom Open 2 2022,2022-04-30,Junior Women's 64kg,Cadence Ricci,60.6,61,64,67,81,85,-87,67,85,152
-Folsom Open 2 2022,2022-04-30,Open Men's 81kg,Weishu Xu,74.2,62,66,-70,75,80,85,66,85,151
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 89kg,Tyler Mayne,87.4,-60,60,62,78,81,83,62,83,145
-Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 61kg,Lincoln Phelps,56.7,53,56,59,78,81,83,59,83,142
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 67kg,Timothy Brand,65.7,60,63,-66,70,73,76,63,76,139
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 73kg,Ryan Hardeman,72.9,55,57,59,70,73,76,59,76,135
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 81kg,Joseph Kushch,77.5,55,58,60,68,70,73,60,73,133
-Folsom Open 2 2022,2022-04-30,Open Women's 76kg,Danielle Hoddy,74.7,48,50,53,69,71,74,53,74,127
-Folsom Open 2 2022,2022-04-30,Women's 16-17 Age Group 59kg,Elle Hatamiya,57.4,50,52,54,62,65,68,54,68,122
-Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Scott Trujillo,129.1,-100,-100,-100,-120,-120,120,0,120,120
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 49kg,Ryan Cao,47.7,38,41,43,53,56,59,43,59,102
-Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 55kg,Elijiah Williams,52.9,33,35,37,45,47,49,37,49,86
-Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 55kg,Jaden Angel,49.4,32,34,36,42,44,46,36,46,82
-Folsom Open 2 2022,2022-04-30,Open Men's 109kg,Kenneth Swenson,106.6,30,33,36,35,39,43,36,43,79
-Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group +73kg,Aidan Levesque,79.7,23,26,28,33,36,38,28,38,66
-Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 89kg,Carter Levesque,86,24,26,28,30,33,36,28,36,64
-Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 44kg,Justice Nonoguchi,40.8,23,25,26,34,35,37,26,37,63
-Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 61kg,Blake Levesque,55.6,19,21,23,28,30,31,23,31,54
-Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 36kg,Samuel Kushch,32.5,16,18,19,24,26,28,19,28,47
-Folsom Open 2 2022,2022-04-30,Women's 13 Under Age Group 30kg,Brooklynn Vella,27.2,15,17,19,21,23,-25,19,23,42
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Zachary Sclater,143,-124,127,130,-165,165,170,130,170,300,0
+Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Bryan Gates,137.4,115,120,-125,160,-171,-171,120,160,280,0
+Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Jake Anderson,122.1,105,110,115,130,135,140,115,140,255,0
+Folsom Open 2 2022,2022-04-30,Open Men's 102kg,Patrick Craig,99.1,95,100,-105,125,130,135,100,135,235,0
+Folsom Open 2 2022,2022-04-30,Open Men's 96kg,Dayton  Sandobal,89.9,-93,93,96,-120,120,-123,96,120,216,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group +102kg,Mason Starkey,125,85,88,-90,110,-115,115,88,115,203,0
+Folsom Open 2 2022,2022-04-30,Open Men's 89kg,Ethan Ashton,83.2,-80,80,85,100,105,110,85,110,195,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 73kg,Daniel Chavez,72.98,80,83,86,108,-111,-112,86,108,194,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 96kg,Travis Knierim,90.1,-73,73,75,108,112,115,75,115,190,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group +89kg,Luke Sorensen,115,77,80,83,100,103,106,83,106,189,0
+Folsom Open 2 2022,2022-04-30,Open Men's 73kg,Anthony Duong,71,80,83,-86,105,-108,-108,83,105,188,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 102kg,Theodore Greule,96.7,73,76,78,100,103,105,78,105,183,0
+Folsom Open 2 2022,2022-04-30,Open Men's 61kg,Daniel Louie,60.3,70,75,80,90,95,100,80,100,180,0
+Folsom Open 2 2022,2022-04-30,Open Men's 73kg,Parmvir Sohal,71.5,70,73,-76,97,100,-103,73,100,173,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 81kg,Julian Vasquez,76.9,73,75,77,90,93,95,77,95,172,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 96kg,Samuel Mark,92,70,73,76,-90,90,93,76,93,169,0
+Folsom Open 2 2022,2022-04-30,Open Men's 89kg,Zhenxiong Jia,88.2,65,70,-75,82,87,91,70,91,161,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 61kg,David Zechowy,55.6,66,69,-72,87,91,-95,69,91,160,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group +89kg,Dominic  Matthews ,117.5,63,66,69,-88,90,-93,69,90,159,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 81kg,Lucas Grimes,73.6,63,66,69,84,87,90,69,90,159,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 73kg,Lazaro Paniagua-Enriquez,72.5,66,68,70,75,80,85,70,85,155,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 73kg,Isiah Williams,72.3,60,63,65,84,86,88,65,88,153,0
+Folsom Open 2 2022,2022-04-30,Junior Women's 64kg,Cadence Ricci,60.6,61,64,67,81,85,-87,67,85,152,0
+Folsom Open 2 2022,2022-04-30,Open Men's 81kg,Weishu Xu,74.2,62,66,-70,75,80,85,66,85,151,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 89kg,Tyler Mayne,87.4,-60,60,62,78,81,83,62,83,145,0
+Folsom Open 2 2022,2022-04-30,Men's 16-17 Age Group 61kg,Lincoln Phelps,56.7,53,56,59,78,81,83,59,83,142,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 67kg,Timothy Brand,65.7,60,63,-66,70,73,76,63,76,139,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 73kg,Ryan Hardeman,72.9,55,57,59,70,73,76,59,76,135,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 81kg,Joseph Kushch,77.5,55,58,60,68,70,73,60,73,133,0
+Folsom Open 2 2022,2022-04-30,Open Women's 76kg,Danielle Hoddy,74.7,48,50,53,69,71,74,53,74,127,0
+Folsom Open 2 2022,2022-04-30,Women's 16-17 Age Group 59kg,Elle Hatamiya,57.4,50,52,54,62,65,68,54,68,122,0
+Folsom Open 2 2022,2022-04-30,Open Men's +109kg,Scott Trujillo,129.1,-100,-100,-100,-120,-120,120,0,120,120,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 49kg,Ryan Cao,47.7,38,41,43,53,56,59,43,59,102,0
+Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 55kg,Elijiah Williams,52.9,33,35,37,45,47,49,37,49,86,0
+Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 55kg,Jaden Angel,49.4,32,34,36,42,44,46,36,46,82,0
+Folsom Open 2 2022,2022-04-30,Open Men's 109kg,Kenneth Swenson,106.6,30,33,36,35,39,43,36,43,79,0
+Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group +73kg,Aidan Levesque,79.7,23,26,28,33,36,38,28,38,66,0
+Folsom Open 2 2022,2022-04-30,Men's 14-15 Age Group 89kg,Carter Levesque,86,24,26,28,30,33,36,28,36,64,0
+Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 44kg,Justice Nonoguchi,40.8,23,25,26,34,35,37,26,37,63,0
+Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 61kg,Blake Levesque,55.6,19,21,23,28,30,31,23,31,54,0
+Folsom Open 2 2022,2022-04-30,Men's 13 Under Age Group 36kg,Samuel Kushch,32.5,16,18,19,24,26,28,19,28,47,0
+Folsom Open 2 2022,2022-04-30,Women's 13 Under Age Group 30kg,Brooklynn Vella,27.2,15,17,19,21,23,-25,19,23,42,0

--- a/event_data/US/702.csv
+++ b/event_data/US/702.csv
@@ -1,73 +1,73 @@
-meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Jake Novotny,87,93,-98,98,120,125,130,98,130,228
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Jalen Wuchko,99.2,84,88,94,130,-140,-140,94,130,224
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Nate Oelke,68.35,88,-93,93,118,122,124,93,124,217
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Adam Mehr,110,-96,-96,96,116,120,-124,96,120,216
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Michael Schiller,73.7,88,90,-92,-123,-123,123,90,123,213
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Jake Anderson,106.2,80,88,93,105,115,-125,93,115,208
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Douglas Molde,84.7,85,-88,-88,115,-116,116,85,116,201
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Michael Trettel,102,74,81,86,100,108,113,86,113,199
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,William Staska,94.1,80,85,-88,100,105,113,85,113,198
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Gerrit Olsen,82.8,75,78,-80,103,105,107,78,107,185
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Jonas Hagen,87.7,76,-79,81,-100,100,103,81,103,184
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Anders Grahn,128.8,-74,74,76,100,103,107,76,107,183
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Kevin Kucera,89.5,77,-80,80,95,98,101,80,101,181
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Matthew Mientkiewicz,83.5,70,73,-76,100,103,107,73,107,180
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Matthew Otto,99.1,72,74,-76,-90,90,92,74,92,166
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Benn Olson,114,70,72,-75,90,92,94,72,94,166
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 62 kg,Benjamin Nhan,60.9,65,68,71,-92,92,-93,71,92,163
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Eric Voxland,69.9,65,-68,68,90,93,-95,68,93,161
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Trevor Heagle,93.8,70,-75,-75,85,88,90,70,90,160
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Jacob Engel,87.5,65,-67,67,90,92,-95,67,92,159
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Tommy Haberlack,92.3,66,68,71,86,-88,88,71,88,159
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Matt McDavid,83.2,-65,65,67,85,87,90,67,90,157
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 62 kg,Dithdecha Soundara,59.7,-70,70,-72,80,82,86,70,86,156
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Ibrahim Mahmoud,74,65,-68,68,80,83,87,68,87,155
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Eric Hamlin,73.1,62,-65,65,85,-88,88,65,88,153
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Jackson Gilman,97.3,60,62,64,85,87,89,64,89,153
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Drew Ehlers,67.1,54,57,60,84,-87,87,60,87,147
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Andrew Lanhart,96.4,60,63,-67,80,81,83,63,83,146
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Maxwell Cantrell,70.7,58,60,-62,80,-82,83,60,83,143
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Armando Ramirez,102.6,54,56,59,80,82,84,59,84,143
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Michael Orr,67.35,55,-59,60,73,77,82,60,82,142
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Jacob Parrent,79.7,58,60,62,-79,-79,79,62,79,141
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Logan Bruce,92.5,-63,63,-66,68,71,75,63,75,138
-North Metro High School Weightlifting Meet,2013-12-14,Men's 14-15 Age Group +85 kg,Nick Burton,104,-54,54,56,78,-81,81,56,81,137
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Lucas Meredith,68.6,57,59,61,70,72,74,61,74,135
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Christopher Miller,75.6,-55,55,56,-75,75,77,56,77,133
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Andrew Manor,67.35,46,48,51,71,73,76,51,76,127
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Alexander Garlington,64.3,50,52,55,65,69,72,55,72,127
-North Metro High School Weightlifting Meet,2013-12-14,Men's 14-15 Age Group 69 kg,Noah Bachmeier,63.45,50,52,-55,-70,70,72,52,72,124
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group +75 kg,Abigail Monn,97.68,-50,50,53,62,66,70,53,70,123
-North Metro High School Weightlifting Meet,2013-12-14,Open Women's 63 kg,Erica Kesseh,62.14,-50,50,-52,64,67,70,50,70,120
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Jacob Baker,67.5,-50,52,-55,60,63,66,52,66,118
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Israel Persaud,92.3,40,42,44,70,71,73,44,73,117
-North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group 69 kg,Natasha Rice,67.93,47,49,52,56,59,63,52,63,115
-North Metro High School Weightlifting Meet,2013-12-14,Open Women's 63 kg,Payton Schulze,62.35,47,50,-53,60,62,64,50,64,114
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Joseph Brue,71.95,45,48,51,55,58,61,51,61,112
-North Metro High School Weightlifting Meet,2013-12-14,Open Women's 75 kg,Sierra Virnig,70,45,48,52,50,55,60,52,60,112
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 69 kg,Alyssa Smith,67.37,45,47,50,57,59,61,50,61,111
-North Metro High School Weightlifting Meet,2013-12-14,Men's 14-15 Age Group 77 kg,Trevor Liggett,73.1,40,43,46,60,-63,63,46,63,109
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 53 kg,Aneesa Ally,52.99,45,-48,48,53,56,59,48,59,107
-North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group 53 kg,Michaela McIntosh,50.83,-42,-44,44,62,-64,-64,44,62,106
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 75 kg,Katie Yorek,74.92,37,40,43,58,63,-67,43,63,106
-North Metro High School Weightlifting Meet,2013-12-14,Men's 13 Under Age Group 56 Kg,Joseph Heagle,55.8,40,42,43,53,55,57,43,57,100
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 48 kg,Destiny Young,45.89,40,-42,42,49,52,55,42,55,97
-North Metro High School Weightlifting Meet,2013-12-14,Open Women's 69 kg,Ariel Behnke,67.08,39,41,-43,52,54,56,41,56,97
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 63 kg,Renae Otto,59.2,38,40,-43,50,-52,53,40,53,93
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group +75 kg,Geneva Brandt,80,-35,35,37,50,53,55,37,55,92
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 62 kg,Jared Lozano,61.3,35,37,-40,48,51,54,37,54,91
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 56 kg,Quan Trang,53.4,30,32,34,50,53,56,34,56,90
-North Metro High School Weightlifting Meet,2013-12-14,Open Women's 69 kg,Taylor Kunkel,64.67,29,32,34,45,49,53,34,53,87
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 69 kg,Katie Kleinow,66.53,35,-37,-37,46,48,51,35,51,86
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 63 kg,Grace Peterson,60.01,32,34,36,45,47,49,36,49,85
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group +75 kg,Katrina Smith,77,30,32,34,45,48,51,34,51,85
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 56 kg,Quinn Engstrom,55.3,30,35,-38,48,49,-51,35,49,84
-North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group +69 kg,Raezjine Merriweather,97,-35,35,37,-45,45,47,37,47,84
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 69 kg,Claire Boatman,68.92,27,-29,29,40,43,45,29,45,74
-North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 63 kg,Tristen Zimmerman,60.48,-26,26,28,36,38,42,28,42,70
-North Metro High School Weightlifting Meet,2013-12-14,Open Women's 69 kg,Antonia Hopkins,65.7,25,28,30,35,37,39,30,39,69
-North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group 69 kg,Erin Koestler,67.08,24,-26,28,30,32,34,28,34,62
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Samuel Johnson,67,-52,-52,-52,52,55,60,0,60,60
-North Metro High School Weightlifting Meet,2013-12-14,Open Men's 56 kg,Erich Hoffmann,44.7,17,18,19,19,20,22,19,22,41
-North Metro High School Weightlifting Meet,2013-12-14,Women's 13 Under Age Group 44kg,Anabel Marotz,44,-25,-25,-25,30,32,35,0,35,35
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total,age_on_day
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Jake Novotny,87,93,-98,98,120,125,130,98,130,228,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Jalen Wuchko,99.2,84,88,94,130,-140,-140,94,130,224,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Nate Oelke,68.35,88,-93,93,118,122,124,93,124,217,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Adam Mehr,110,-96,-96,96,116,120,-124,96,120,216,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Michael Schiller,73.7,88,90,-92,-123,-123,123,90,123,213,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Jake Anderson,106.2,80,88,93,105,115,-125,93,115,208,16
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Douglas Molde,84.7,85,-88,-88,115,-116,116,85,116,201,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Michael Trettel,102,74,81,86,100,108,113,86,113,199,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,William Staska,94.1,80,85,-88,100,105,113,85,113,198,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Gerrit Olsen,82.8,75,78,-80,103,105,107,78,107,185,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Jonas Hagen,87.7,76,-79,81,-100,100,103,81,103,184,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Anders Grahn,128.8,-74,74,76,100,103,107,76,107,183,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Kevin Kucera,89.5,77,-80,80,95,98,101,80,101,181,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Matthew Mientkiewicz,83.5,70,73,-76,100,103,107,73,107,180,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Matthew Otto,99.1,72,74,-76,-90,90,92,74,92,166,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's+105 kg,Benn Olson,114,70,72,-75,90,92,94,72,94,166,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 62 kg,Benjamin Nhan,60.9,65,68,71,-92,92,-93,71,92,163,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Eric Voxland,69.9,65,-68,68,90,93,-95,68,93,161,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Trevor Heagle,93.8,70,-75,-75,85,88,90,70,90,160,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Jacob Engel,87.5,65,-67,67,90,92,-95,67,92,159,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Tommy Haberlack,92.3,66,68,71,86,-88,88,71,88,159,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Matt McDavid,83.2,-65,65,67,85,87,90,67,90,157,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 62 kg,Dithdecha Soundara,59.7,-70,70,-72,80,82,86,70,86,156,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Ibrahim Mahmoud,74,65,-68,68,80,83,87,68,87,155,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Eric Hamlin,73.1,62,-65,65,85,-88,88,65,88,153,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Jackson Gilman,97.3,60,62,64,85,87,89,64,89,153,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Drew Ehlers,67.1,54,57,60,84,-87,87,60,87,147,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Andrew Lanhart,96.4,60,63,-67,80,81,83,63,83,146,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Maxwell Cantrell,70.7,58,60,-62,80,-82,83,60,83,143,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 105 kg,Armando Ramirez,102.6,54,56,59,80,82,84,59,84,143,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Michael Orr,67.35,55,-59,60,73,77,82,60,82,142,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 85 kg,Jacob Parrent,79.7,58,60,62,-79,-79,79,62,79,141,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Logan Bruce,92.5,-63,63,-66,68,71,75,63,75,138,0
+North Metro High School Weightlifting Meet,2013-12-14,Men's 14-15 Age Group +85 kg,Nick Burton,104,-54,54,56,78,-81,81,56,81,137,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Lucas Meredith,68.6,57,59,61,70,72,74,61,74,135,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Christopher Miller,75.6,-55,55,56,-75,75,77,56,77,133,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Andrew Manor,67.35,46,48,51,71,73,76,51,76,127,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Alexander Garlington,64.3,50,52,55,65,69,72,55,72,127,0
+North Metro High School Weightlifting Meet,2013-12-14,Men's 14-15 Age Group 69 kg,Noah Bachmeier,63.45,50,52,-55,-70,70,72,52,72,124,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group +75 kg,Abigail Monn,97.68,-50,50,53,62,66,70,53,70,123,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Women's 63 kg,Erica Kesseh,62.14,-50,50,-52,64,67,70,50,70,120,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Jacob Baker,67.5,-50,52,-55,60,63,66,52,66,118,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 94 kg,Israel Persaud,92.3,40,42,44,70,71,73,44,73,117,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group 69 kg,Natasha Rice,67.93,47,49,52,56,59,63,52,63,115,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Women's 63 kg,Payton Schulze,62.35,47,50,-53,60,62,64,50,64,114,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 77 kg,Joseph Brue,71.95,45,48,51,55,58,61,51,61,112,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Women's 75 kg,Sierra Virnig,70,45,48,52,50,55,60,52,60,112,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 69 kg,Alyssa Smith,67.37,45,47,50,57,59,61,50,61,111,0
+North Metro High School Weightlifting Meet,2013-12-14,Men's 14-15 Age Group 77 kg,Trevor Liggett,73.1,40,43,46,60,-63,63,46,63,109,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 53 kg,Aneesa Ally,52.99,45,-48,48,53,56,59,48,59,107,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group 53 kg,Michaela McIntosh,50.83,-42,-44,44,62,-64,-64,44,62,106,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 75 kg,Katie Yorek,74.92,37,40,43,58,63,-67,43,63,106,0
+North Metro High School Weightlifting Meet,2013-12-14,Men's 13 Under Age Group 56 Kg,Joseph Heagle,55.8,40,42,43,53,55,57,43,57,100,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 48 kg,Destiny Young,45.89,40,-42,42,49,52,55,42,55,97,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Women's 69 kg,Ariel Behnke,67.08,39,41,-43,52,54,56,41,56,97,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 63 kg,Renae Otto,59.2,38,40,-43,50,-52,53,40,53,93,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group +75 kg,Geneva Brandt,80,-35,35,37,50,53,55,37,55,92,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 62 kg,Jared Lozano,61.3,35,37,-40,48,51,54,37,54,91,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 56 kg,Quan Trang,53.4,30,32,34,50,53,56,34,56,90,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Women's 69 kg,Taylor Kunkel,64.67,29,32,34,45,49,53,34,53,87,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 69 kg,Katie Kleinow,66.53,35,-37,-37,46,48,51,35,51,86,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 63 kg,Grace Peterson,60.01,32,34,36,45,47,49,36,49,85,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group +75 kg,Katrina Smith,77,30,32,34,45,48,51,34,51,85,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 56 kg,Quinn Engstrom,55.3,30,35,-38,48,49,-51,35,49,84,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group +69 kg,Raezjine Merriweather,97,-35,35,37,-45,45,47,37,47,84,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 69 kg,Claire Boatman,68.92,27,-29,29,40,43,45,29,45,74,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 16-17 Age Group 63 kg,Tristen Zimmerman,60.48,-26,26,28,36,38,42,28,42,70,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Women's 69 kg,Antonia Hopkins,65.7,25,28,30,35,37,39,30,39,69,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 14-15 Age Group 69 kg,Erin Koestler,67.08,24,-26,28,30,32,34,28,34,62,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 69 kg,Samuel Johnson,67,-52,-52,-52,52,55,60,0,60,60,0
+North Metro High School Weightlifting Meet,2013-12-14,Open Men's 56 kg,Erich Hoffmann,44.7,17,18,19,19,20,22,19,22,41,0
+North Metro High School Weightlifting Meet,2013-12-14,Women's 13 Under Age Group 44kg,Anabel Marotz,44,-25,-25,-25,30,32,35,0,35,35,0


### PR DESCRIPTION
Referencing #516 

Disambiguation by estimated age on inactive lifters is the approach we'll take here. Active lifters with the same name in the same region are highly unlikely.

@jakemanderson - Thoughts on this? I did momentarily expose age to disambiguate on the search function however, i'm going to show "last active" instead when I update the UI.