### PR TITLE
fix: add missing 2023 and 2024 North American Open Finals

### DIFF
--- a/event_data/US/6172.csv
+++ b/event_data/US/6172.csv
@@ -1,0 +1,839 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Aaron Williams,176.75,-175,-178,178,220,229,-238,178,229,407
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Jacob Herbert,165.4,151,158,163,185,191,-195,163,191,354
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Ryan Sester,101.83,155,160,-165,190,-200,-205,160,190,350
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Drake Thompson,107.53,149,155,161,-185,186,-192,161,186,347
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Cesar Flores,158.7,148,-152,-153,192,196,-200,148,196,344
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Dimitri Albury,180.1,-146,146,-151,-192,192,197,146,197,343
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Xavier Borde,109,143,148,152,180,-188,188,152,188,340
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Matthew Naugle,127.35,152,-156,-156,183,-188,188,152,188,340
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Daniel Dodd,95.27,143,-148,148,182,-188,190,148,190,338
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Zachary Huse,118.75,140,144,-148,185,-190,193,144,193,337
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Chrisanto D'Agostino,95.8,147,-151,-152,178,184,189,147,189,336
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Michael Bloomfield,133.8,142,148,153,175,183,-193,153,183,336
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Layne Palm,95.86,150,-153,153,-180,182,-187,153,182,335
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,James Tice,109,145,150,-156,173,-178,182,150,182,332
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Caleb Weakland,101.3,139,144,150,-173,175,180,150,180,330
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Benson Robles,95.78,142,-147,-148,180,188,-195,142,188,330
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Sung An,128.65,140,145,-150,-182,184,-191,145,184,329
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Colin Reis,107.45,137,-142,142,178,183,187,142,187,329
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Thomas Duer,110.2,142,147,-151,172,-177,180,147,180,327
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Jacob Mattrella,105.5,-142,142,-148,180,185,-191,142,185,327
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Alexander Chiang,101.66,140,-144,145,180,-185,-185,145,180,325
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Beau Brown,95.99,-143,144,-148,177,181,-187,144,181,325
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,David Jorge,119.8,143,-150,150,173,-182,-183,150,173,323
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,John Hosler,99.75,140,144,-147,172,177,-182,144,177,321
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Edward Ginnan,81,-141,141,-146,180,-185,-185,141,180,321
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Joshua Magee,98.63,150,-155,-156,170,-177,-178,150,170,320
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Jonathan Morrow,88.45,141,145,-149,-170,171,175,145,175,320
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Will Easley,88.95,136,-141,-143,177,-183,183,136,183,319
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Jaimerius Williams,93.03,143,-149,151,163,-173,-176,151,163,314
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 16-17 Age Group 89kg,Kyle Martin Jr.,87.85,137,143,-149,170,-178,-180,143,170,313
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Jimmy Marquez,95.22,-136,136,138,175,-180,-180,138,175,313
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Jean Laguerre Jr.,137.85,-135,135,-140,170,175,-182,135,175,310
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Huntington Hayes,94.69,-134,134,140,160,165,170,140,170,310
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Ryan Helton,100.72,130,-135,135,173,-177,-177,135,173,308
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Robert Durant,88.15,130,135,-140,167,-172,173,135,173,308
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Benjamin Brancaleon,105.4,133,140,145,-163,163,-170,145,163,308
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Zackary Burks,87.9,130,133,135,165,169,172,135,172,307
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Adam White,100.93,-130,130,137,170,-175,-175,137,170,307
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Troy Fries,80.81,130,135,-138,167,172,-176,135,172,307
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Andrew Guevara,107.25,137,-140,-140,170,-176,-176,137,170,307
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Hutton Boles,79.87,131,-136,139,160,164,167,139,167,306
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Mike Fleming,108.1,131,135,-140,157,163,170,135,170,305
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Patrick Whitmore,108.25,133,-137,-137,165,169,172,133,172,305
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Jacob Rebman,101.85,122,128,134,170,-176,-177,134,170,304
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Dylan Douglass,124.95,118,123,-130,172,-176,180,123,180,303
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Charles Shervheim,100.7,119,124,128,168,175,-182,128,175,303
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 102kg,Caleb Johnson,101.64,132,-136,138,165,-170,-171,138,165,303
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Noah Bradley,94.58,124,128,133,160,170,-172,133,170,303
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Jabo Nguyen,108.4,130,-135,-135,172,-182,-185,130,172,302
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,David Moehling,104.4,130,135,-137,165,-170,-170,135,165,300
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Denali Scoular,108.15,122,127,-132,168,-173,173,127,173,300
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,George Upmeyer,89,130,135,-140,160,-165,165,135,165,300
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Scott Harris,101.15,127,-132,135,165,-172,-175,135,165,300
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Mike Swift,107.95,125,132,137,-162,162,-170,137,162,299
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Wyatt Coffey,88.25,135,-139,-142,-162,163,-170,135,163,298
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Joshua Mayhew,101.18,123,-127,128,165,170,-175,128,170,298
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Kincaid Young,108.85,125,129,-133,-168,169,-179,129,169,298
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Chris Garvey,124.65,128,-133,-133,165,170,-175,128,170,298
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Gladimy Coffy,95.69,132,-137,-137,-165,165,-170,132,165,297
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Chase Durham,95.01,-131,131,-136,161,165,-170,131,165,296
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Trevor Scantling,99.1,130,-134,-136,160,163,166,130,166,296
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Devon Kell,107.2,131,-136,-137,165,-170,-170,131,165,296
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's +109kg,Jake Anderson,126.35,130,135,-140,155,161,-165,135,161,296
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Lucas Zelehowsky,86.6,125,129,133,155,-162,162,133,162,295
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Ajeet Seenivasan,108.15,125,130,-134,155,160,165,130,165,295
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Mason Whitehead,97.57,125,-130,-130,165,170,-175,125,170,295
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Conner Popielarz,80.54,127,-131,-131,163,168,-173,127,168,295
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Spencer Green,86.7,125,129,-133,160,166,-171,129,166,295
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 96kg,Christopher Branam,95.72,124,128,132,158,-162,162,132,162,294
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Andrew Gilcrest,94.28,127,-132,132,157,162,-167,132,162,294
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Dominique Laster,83.2,130,135,-140,158,-163,-165,135,158,293
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Jacob Tegeler,100.8,124,129,-133,158,163,-168,129,163,292
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Alexander Connery,95.46,127,132,-136,-160,160,-168,132,160,292
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Michael Sin,95.7,-126,-126,126,161,166,-170,126,166,292
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Marc Marquez,81,125,-130,130,162,-166,-167,130,162,292
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Deivy De La Hoz,95.67,132,136,-140,155,-160,-162,136,155,291
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Grant Pierson,88.6,125,129,-133,155,161,-164,129,161,290
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 96kg,Jabari Prince,94.23,-125,125,-130,155,-161,165,125,165,290
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,George Averitt,80.37,-122,124,128,-160,160,-169,128,160,288
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Nathan Prokop,94.63,123,-128,-128,161,165,-170,123,165,288
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Bronson Mintun,108.45,-130,133,-138,150,155,-163,133,155,288
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Nathan Moore,86.8,123,128,-133,160,-167,-167,128,160,288
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Alex Casey III,101.55,-125,-125,125,155,162,-168,125,162,287
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Timothy Clouatre,119.95,120,125,130,150,-157,157,130,157,287
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Cameron Fyffe,93.63,124,128,132,-154,154,-159,132,154,286
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Anthony DeCristofaro,88.4,125,-128,128,154,158,-162,128,158,286
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 16-17 Age Group 96kg,Lawrence Hooper,95.15,120,125,129,145,151,157,129,157,286
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 109kg,Ryan Hansen,107.81,125,-130,-131,-160,160,-171,125,160,285
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 109kg,Albert Chun,107.3,120,-124,125,-160,160,-164,125,160,285
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Kaison Uehara,88.45,-115,118,121,158,-161,163,121,163,284
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,James Battaglia,88.7,112,-117,118,160,166,-172,118,166,284
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 109kg,Aaron Torres,108.95,121,-125,-125,-153,155,163,121,163,284
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Dakota Hooper,88.3,-116,117,-121,164,-173,-174,117,164,281
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,KEVIN FRAME,87.95,-125,-125,125,151,156,-160,125,156,281
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Joseph Cosenza,85.75,120,-125,125,149,-155,155,125,155,280
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Arron Tate,88,120,-124,125,-152,155,-160,125,155,280
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,Grant Reed,97.8,122,-127,-127,156,-161,-162,122,156,278
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Morgan Rummel,72.4,120,123,126,-148,149,152,126,152,278
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Thomas Brown,88.4,118,122,-130,151,156,-160,122,156,278
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Trevor Owens,80.42,119,123,-126,155,-160,-162,123,155,278
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Matthew Bernier,87.9,120,124,-129,153,-157,-158,124,153,277
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Keith Hicks,123.25,124,-127,127,150,-155,-155,127,150,277
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Will Said,105.6,-125,-125,125,-152,-152,152,125,152,277
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Maximilian Califf,88.65,116,-121,-121,155,160,-165,116,160,276
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Joseph Axtell,81,-120,120,-125,150,155,-160,120,155,275
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) +109kg,Matthew Boyd,139.8,-125,125,-130,150,-155,-155,125,150,275
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) 109kg,John Smith,106.6,117,124,-130,145,151,-156,124,151,275
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Jack Walbye,80.35,115,120,123,147,-152,152,123,152,275
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Tyree Harris II,80.4,117,121,-125,146,153,-160,121,153,274
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Matthew Adamcheck,118.05,110,115,120,150,153,0,120,153,273
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Jacob OConnor,72.2,117,120,-123,148,152,-157,120,152,272
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Francisco Barrios,124.1,117,-123,-124,149,-155,155,117,155,272
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,Ryan McDonald,72.25,-115,115,119,148,152,-160,119,152,271
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Andrew Malec,80.6,-121,-121,123,-145,-146,147,123,147,270
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Javan Freyenberger,80.7,116,120,123,142,147,-152,123,147,270
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 61kg,gabe chhum,60.8,117,-122,125,145,-150,-152,125,145,270
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Thomas Bednar,80.66,122,-125,-125,147,-152,-155,122,147,269
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Primo Murillo,80.7,110,114,118,143,150,-157,118,150,268
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Ryan Walsh,80.7,117,121,-124,-145,145,-147,121,145,266
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) +109kg,Brandon Davis,113.25,115,120,123,143,-148,-150,123,143,266
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Joseph Gomez,86.6,-117,117,121,145,-150,-150,121,145,266
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's 16-17 Age Group +102kg,Junius Fullard,110,110,115,120,140,145,-151,120,145,265
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Benjamin Gabriel,79.85,-112,115,-118,150,-156,-156,115,150,265
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Jack Buis,78.6,110,-114,115,143,149,-155,115,149,264
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Ethan Bowen,72.75,110,115,-120,145,148,-152,115,148,263
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 102kg,Stephen Butcher,102,107,114,120,135,143,-150,120,143,263
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Cory Ebert,80.25,110,113,-115,145,-150,150,113,150,263
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) +109kg,Gavin Hough,132,113,118,-121,145,-150,-151,118,145,263
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Alexander Souvall,80.75,114,118,-122,143,-148,-148,118,143,261
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Garrett Hess,80.3,117,-121,-122,140,-144,144,117,144,261
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Domenic Aversa,80.45,113,116,118,-143,143,-147,118,143,261
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Samuel McGinnity,73,111,-113,-113,150,-157,-161,111,150,261
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 81kg,Kale Bunce,76.5,112,116,118,136,141,-146,118,141,259
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Jose Barajas,78.95,-112,-113,113,145,-149,-154,113,145,258
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Evan Fukuhara,66.37,111,-116,-116,141,-144,145,111,145,256
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Timothy Walker,80.7,111,-115,-115,145,-150,-150,111,145,256
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Greg Cook,73,114,117,120,131,136,-140,120,136,256
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,John Gilleland,80.75,114,-116,-116,-141,-141,141,114,141,255
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Pablo Castillo,139.75,105,110,-115,-145,-145,145,110,145,255
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Concepcion Cruz-Rodriguez,72.15,108,112,-116,139,-143,143,112,143,255
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Cory O'Connor,72.05,110,-113,-115,140,145,-150,110,145,255
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Jacob Elder,84.9,105,110,-115,145,-150,-150,110,145,255
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Michael Espinosa,87.1,109,116,-122,133,138,-141,116,138,254
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Justin Tebedo,88.65,109,-112,-115,135,-140,143,109,143,252
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 16-17 Age Group 89kg,Ethan Janssen,86.95,108,112,115,-130,130,137,115,137,252
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's 16-17 Age Group 102kg,nathan varney,96.7,102,-107,-107,133,140,150,102,150,252
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) 102kg,Jordan Jacobs,100.15,-110,110,-115,140,-147,-154,110,140,250
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Nathan Gonzaga,71.9,102,105,110,135,140,-145,110,140,250
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) +109kg,Aaron Scott,135.85,110,115,-119,130,134,-138,115,134,249
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,David Young,81,114,-118,-119,-134,134,-140,114,134,248
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,Kevin Hill,72.65,106,110,-113,138,-141,-142,110,138,248
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Jacob Flores,72.6,-102,103,108,135,139,-143,108,139,247
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Jonathan Hayes,72.65,-108,108,-111,135,139,-143,108,139,247
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 102kg,Jose Cruz Richardson,101.15,110,114,-117,123,127,133,114,133,247
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Noah Ranno,72.55,106,-110,-112,136,140,-145,106,140,246
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Ross Twanmoh,72.55,106,-109,-110,135,140,-143,106,140,246
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Justin Barber,70.7,108,112,-115,128,133,-138,112,133,245
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (50-54) +109kg,Gregory Vallee,113.9,95,-98,102,130,136,142,102,142,244
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,alec coulter,72.95,104,110,-116,134,-141,-144,110,134,244
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) 109kg,Charlie Spry,108.45,100,105,-109,130,-135,139,105,139,244
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (40-44) 81kg,juan leo baltierra,79.9,108,-112,-112,130,135,-140,108,135,243
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (40-44) 109kg,Brandon Duffner,105.95,104,108,-114,130,135,-140,108,135,243
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Jeffrey Suarez,66.56,-105,-105,106,135,-140,-142,106,135,241
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Stewart Ragan,73,105,108,-111,124,128,132,108,132,240
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Angelo Kelly,67,99,-102,-103,-135,-138,141,99,141,240
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Jacob Lynch,71,96,99,-103,135,140,-145,99,140,239
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Ruchit Patel,65.6,-102,103,107,-132,132,-136,107,132,239
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (40-44) 89kg,William Bromley,88.35,100,104,-108,130,134,-139,104,134,238
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (40-44) 81kg,Timothy Johnson,78.25,102,105,107,125,130,-134,107,130,237
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Christopher Camenares,65.47,100,105,-109,125,-130,132,105,132,237
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Jacob Cadieux,72.05,101,105,-108,127,132,-134,105,132,237
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Gregory Malnassy,89,96,-100,104,-128,128,132,104,132,236
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (55-59) 96kg,Robert Arroyo,93.06,103,106,108,-123,125,128,108,128,236
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Jason Ryu,72.15,98,-102,102,-134,-134,134,102,134,236
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 16-17 Age Group 89kg,Dylan Satkunam,84.8,98,-102,-103,128,131,138,98,138,236
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (50-54) +109kg,Charles Arcario,109.75,105,-110,-110,-130,130,-135,105,130,235
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Evan Gehret,66.06,102,106,108,126,-131,-131,108,126,234
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Chase Dolfi,73,103,106,-109,125,128,-131,106,128,234
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,cameron williams,84.8,-106,106,-109,124,128,-130,106,128,234
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 73kg,Steve Yanda,72.9,100,104,-106,125,130,-135,104,130,234
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 81kg,Joshua Canet,77,-103,103,108,125,-130,-132,108,125,233
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (40-44) 81kg,Tim Geiman,81,95,100,-106,125,-130,133,100,133,233
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Sarah Barnett,86.3,98,101,-103,126,130,132,101,132,233
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (40-44) 89kg,Jonathan Halbreich,85.24,100,-104,104,120,-125,128,104,128,232
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 73kg,Moses Corbell,71.9,-98,98,101,124,-128,131,101,131,232
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Kayla Kass,82.38,99,102,-105,122,126,130,102,130,232
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Nicholas Lee,85.9,-98,98,102,125,129,-133,102,129,231
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (40-44) 96kg,Matthew Kaplan,95.7,94,98,-101,129,133,-137,98,133,231
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Caitlin Thilges,138.85,85,-90,90,130,132,140,90,140,230
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 102kg,Craig Cirillo,100.65,94,98,-102,122,127,132,98,132,230
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Zachary Leach,87.69,96,-100,102,122,128,-130,102,128,230
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 16-17 Age Group 89kg,Isaque Costa,88.21,-100,100,105,124,-128,-128,105,124,229
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 73kg,onan marroquin,72.3,93,97,101,123,127,-131,101,127,228
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Martin Glenn-Adams,71.4,98,-102,-103,125,130,-135,98,130,228
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Estelle Rohr,73.65,93,96,100,122,-126,127,100,127,227
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Mariah Park,75.8,95,100,-102,123,-126,127,100,127,227
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Telesforo Dacanay,80,-96,-96,96,-125,125,130,96,130,226
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (45-49) 96kg,Kurby Brown Jr,95.02,-93,93,100,120,-123,125,100,125,225
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (50-54) +109kg,Anthony Walker,115.05,95,99,-103,126,-132,-132,99,126,225
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 14-15 Age Group 89kg,Jeremy Gillihan,87.84,97,-100,100,120,125,-130,100,125,225
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 14-15 Age Group 73kg,Roy  Maher,71.3,95,100,-103,125,-134,-134,100,125,225
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's 16-17 Age Group 96kg,Edward Quillin,93.77,98,104,-111,120,-127,-131,104,120,224
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (45-49) 102kg,Jonathan Herrera,98.95,95,100,-105,115,123,-130,100,123,223
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Chris Funderburk,80.75,95,98,100,115,120,123,100,123,223
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Erlando James Abilo,77.95,86,89,91,123,127,131,91,131,222
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Katlin Kallmeyer,124.05,92,-96,96,125,-130,-130,96,125,221
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (40-44) 89kg,Datton Nguyen,85.35,100,-105,-105,-120,120,-129,100,120,220
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Romeo Thompson,66.49,100,-104,-106,120,-124,-124,100,120,220
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 14-15 Age Group 81kg,Rucker Johnson,76.5,-91,91,95,115,120,125,95,125,220
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (40-44) 73kg,Carlos Hernandez,72.9,93,97,100,-110,111,119,100,119,219
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Stephanie Gousse,99.95,93,96,-100,117,-122,123,96,123,219
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Victoria Jefferson,83.69,88,92,96,114,118,122,96,122,218
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 73kg,Benjamin Cockshott,69.45,90,95,-100,113,118,122,95,122,217
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 14-15 Age Group 81kg,Tevin Austell,79.85,-96,96,-100,116,121,-126,96,121,217
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (50-54) 96kg,Robert Fezza,94.47,85,90,94,115,120,123,94,123,217
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Lily Turner,80.2,-92,96,-100,111,115,120,96,120,216
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,Kieven Fischer,71.8,93,-99,-100,115,-122,122,93,122,215
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 81kg,Owen Jones,79.85,91,94,97,-117,117,-121,97,117,214
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Shala Giardini,80.75,96,-100,-101,117,-121,-121,96,117,213
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Darci Molina,74.9,88,91,95,114,118,-121,95,118,213
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Emily Rodriguez,110.45,90,94,98,115,-120,-120,98,115,213
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Alexa Snyder,74.55,89,92,95,116,-119,-120,95,116,211
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Justin Flores,80.2,90,-95,95,115,-120,-123,95,115,210
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (40-44) 89kg,Ryan Bock,88.92,-92,93,97,113,-117,-118,97,113,210
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Jordyn Bush,71.3,88,92,95,108,112,115,95,115,210
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,Angel Quintero,66.1,90,94,-97,110,115,-120,94,115,209
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Danielle Gunnin,60.83,93,-96,-96,110,115,-120,93,115,208
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Shay Carlock,75.15,87,-90,90,110,114,117,90,117,207
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (45-49) 96kg,Jeven Sloan,89.27,-82,-84,85,117,121,-124,85,121,206
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,Lincoln Dana,64.55,91,-96,-96,115,-125,-125,91,115,206
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Amerie Daniels,73.2,84,-87,-87,118,122,-125,84,122,206
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 61kg,Braden Winslow,60.4,91,96,-100,-110,-110,110,96,110,206
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Thomas Smalley,86.56,-90,90,-94,-115,115,-120,90,115,205
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Marina Tuono,75.5,85,89,-93,110,115,-120,89,115,204
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,William Draper,65.3,86,-89,-89,114,118,-122,86,118,204
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Shelby Pflug,63.8,88,-91,-92,112,116,-121,88,116,204
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's Masters (50-54) 67kg,Brad Baldwin,66.25,90,94,-97,110,-114,-114,94,110,204
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (40-44) 81kg,Danny Ear,74.7,-85,85,-88,110,114,118,85,118,203
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (45-49) 81kg,Fred Macaraeg,79,85,88,-92,105,110,115,88,115,203
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 14-15 Age Group 73kg,Robert Whitlock,71.3,-80,81,85,110,115,118,85,118,203
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Nicole Caamano,70.15,90,93,-96,110,-114,-115,93,110,203
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Julie Brown,83.17,90,93,-97,109,-114,-118,93,109,202
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Rebecca Rouse,63.12,-88,88,91,108,110,-112,91,110,201
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Kat Carter,74.55,83,87,-90,110,114,-117,87,114,201
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Charley Leonard,58.8,81,83,86,-110,110,114,86,114,200
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (45-49) 81kg,Cory Aun,74.25,85,-90,-90,110,115,-120,85,115,200
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 14-15 Age Group 73kg,Gabriel Couilloud,72.6,86,89,-92,106,111,-115,89,111,200
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Laura Barito,84.3,83,86,89,105,108,111,89,111,200
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Brittany Latham,86.54,-80,80,84,112,116,-121,84,116,200
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Sophia DiGregorio,69.4,86,89,92,-105,105,108,92,108,200
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Harley Creech,80.6,88,-92,-93,111,-116,-117,88,111,199
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (45-49) 81kg,Douglas Desatnik,78.5,80,83,-86,111,116,-121,83,116,199
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 61kg,Taveon Sanders,60.85,-85,85,87,105,109,112,87,112,199
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 61kg,Daniel Marquez,61,84,87,-90,108,112,-120,87,112,199
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Victoria Fries,70.8,-86,86,89,109,-113,-113,89,109,198
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Madison Atwood,96.5,81,85,-91,102,107,112,85,112,197
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Addie Anderson,67.8,-84,84,-90,108,113,-117,84,113,197
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Jamelle Apolinar,120.65,75,81,86,100,110,-115,86,110,196
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Donisha Traver,69.1,87,89,-92,107,-111,-112,89,107,196
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (55-59) 89kg,Robert O'Day,86.5,80,83,86,-101,101,110,86,110,196
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,LeKiesha White,94.25,81,84,-86,-112,112,-116,84,112,196
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Ava Biesterfeld,69,86,89,-92,106,-110,-112,89,106,195
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Miranda Ulrey,58.6,88,-91,-93,102,105,107,88,107,195
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (50-54) 96kg,Matthew Sipos,95.6,85,-89,-90,110,-115,-115,85,110,195
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Victoria Caruso,73.92,72,76,80,105,110,115,80,115,195
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Nairobi Romero,69.1,83,85,87,108,-112,-115,87,108,195
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Siera Schuster,63.25,83,-86,87,104,108,-111,87,108,195
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,jace fox,64.8,80,84,88,-101,101,106,88,106,194
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Halle Kotchman,79.95,88,92,-96,98,102,-108,92,102,194
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Analise Kirby,73.4,80,-84,84,105,110,-114,84,110,194
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Deborah Doran,74.4,79,82,85,104,109,-113,85,109,194
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,haley trinh,63.63,81,84,-87,105,109,-112,84,109,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Haley McDaniel,86.08,-85,85,-90,105,108,-111,85,108,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Alyssa Ballard,75.3,83,85,-88,108,-110,-110,85,108,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Emma Hester,70.85,78,82,85,102,105,108,85,108,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Jamie Hegg,62.91,83,-86,86,-107,107,-112,86,107,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (45-49) 81kg,Greg Karas,80.7,82,85,-88,105,108,-110,85,108,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Monica Knowlton,63.3,80,83,-86,-110,110,-115,83,110,193
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Lily Damron,61.5,78,81,-83,-106,107,111,81,111,192
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's Masters (45-49) 67kg,Martin Palma,66.55,-86,-86,86,105,-109,0,86,105,191
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 55kg,Michael Ziss,53.85,80,-84,84,98,102,107,84,107,191
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 67kg,Haston Hill,65.95,-75,75,81,-105,105,110,81,110,191
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Michelle Yiznitsky,69.2,76,79,-82,104,108,112,79,112,191
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Bailey Ebben,68.3,80,-84,-85,110,-114,-115,80,110,190
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Nadia Yangui,64,81,84,-87,106,-109,-110,84,106,190
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Allie Jarvis,69.6,84,87,90,100,-105,-105,90,100,190
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Lily Farmer,65.1,-80,80,-83,105,110,-114,80,110,190
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (40-44) 73kg,Lionel Bravo,73,78,-81,-81,107,-110,111,78,111,189
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Heather Mentone,73.05,81,84,-86,102,105,-108,84,105,189
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Jennifer Galemmo,105.5,88,-91,-93,101,-107,-107,88,101,189
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Brianna Chu,73.15,79,82,-87,99,-103,106,82,106,188
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Kailey Papas,58.65,81,84,-86,-100,100,104,84,104,188
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Ashlie Pankonin,74.01,79,-82,84,100,103,-106,84,103,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,David Evans,73,82,87,90,97,-104,-110,90,97,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Brittany Landers,80.75,77,-80,80,107,-110,-110,80,107,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Erin Patchey,78.05,80,85,-89,-101,102,-108,85,102,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Ireland Colson,70.2,81,83,-85,101,104,-106,83,104,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Kiara Earle,80.05,82,-85,-87,105,-108,-108,82,105,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Meghan Karlik,75.45,80,-83,-83,107,-110,-110,80,107,187
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Nicole Rucker,63.05,-78,78,-80,102,105,108,78,108,186
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Asia Gonzalez,54.04,80,83,-85,100,103,-105,83,103,186
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Cristine Schiavello,69.7,81,83,-85,100,103,-104,83,103,186
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 81kg,Teresa Kiel,80.95,-84,84,-87,102,-106,-107,84,102,186
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Tyra Kinloch-Bailey,71.9,80,-83,83,-100,100,103,83,103,186
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Jessica Jones,70.6,71,73,75,105,110,-112,75,110,185
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Gretchen Stolte,66.25,78,-81,83,98,102,-105,83,102,185
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Leila Cook,55,80,-82,-82,105,-107,-107,80,105,185
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Grace Bustamante,85.77,-82,-82,82,100,103,-106,82,103,185
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 71kg,Samantha Kuhles,70.4,80,82,84,98,101,0,84,101,185
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Ariah Groves,75.85,81,-85,-85,103,-110,-110,81,103,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,Caden Yacavone,65.1,81,-84,84,94,-98,100,84,100,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (50-54) 81kg,Darren Scott,79.6,74,77,-80,104,107,-110,77,107,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Sydney Collins,80.5,77,81,-85,95,99,103,81,103,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Alicia Fernandez,74.85,78,81,84,100,-103,-106,84,100,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 55kg,Sebastian Rose,54.65,-78,78,-81,102,106,-110,78,106,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Erica Laraine Sergeant,75.67,78,82,-85,-98,99,102,82,102,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,Harrison Phelps,62.65,74,78,82,98,102,-106,82,102,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Julia Daniel,69.45,80,83,86,98,-102,-102,86,98,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Madeline Storms,64,78,-82,82,98,102,-105,82,102,184
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Katie Jones,58.9,-80,80,-82,103,-107,-108,80,103,183
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Aleigh Moore,69.9,78,-81,-82,105,-108,-108,78,105,183
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (50-54) 81kg,Rustico Mirasol,77.8,77,-82,-82,100,106,-111,77,106,183
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Natalie Hart,68,70,73,76,100,106,-112,76,106,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Jamie Maffeo,73.05,80,83,86,93,96,-100,86,96,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,Josh Alper,63.95,-83,83,-86,99,-102,-103,83,99,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Morgan Johnson,78.05,82,85,-88,93,-97,97,85,97,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Haylie Helbig,63.65,74,77,80,102,-105,-107,80,102,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,SOPHIA McClendon,74.95,72,75,77,100,103,105,77,105,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Rachel Clemmer,70.15,78,82,-85,100,-104,-104,82,100,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Carly Puzacke,74.15,82,-84,-84,-100,100,-103,82,100,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Amanda Roberts,95.05,77,-81,-81,-104,105,-108,77,105,182
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Megan Brasee,75.52,80,-84,-85,97,101,-105,80,101,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Jennifer Tobeson,114.75,70,74,78,93,98,103,78,103,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 67kg,Israel Alvarez,62.65,75,78,-81,98,103,-107,78,103,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Ruby Shepard,76,-76,76,79,98,-102,102,79,102,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Kaija Bramwell,62.35,78,-81,-82,97,100,103,78,103,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 71kg,Amy Pierce,70.1,77,80,-82,95,99,101,80,101,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Mary Quigley,82.6,70,73,76,97,101,105,76,105,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Laura Cochran,68.6,78,82,-86,95,99,-103,82,99,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Sarah Kajdasz,79.15,-78,-78,78,-100,100,103,78,103,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Jenesis Fonder,70.37,74,77,80,97,101,-104,80,101,181
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's Masters (40-44) 61kg,Daniel Louie,59.6,-78,80,-85,100,-105,-105,80,100,180
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Alexandra Hedges,73.55,74,-78,80,95,100,-105,80,100,180
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Stefani Warnick,84.6,82,-85,-85,95,98,-101,82,98,180
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Madison Duvall,66.2,74,78,81,93,96,99,81,99,180
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Reba Lewis,73.7,-80,-80,80,100,-103,-103,80,100,180
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Lucie Gehringer,72.21,-78,78,81,-98,98,-102,81,98,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Carley Graham,75.83,-79,-79,79,-96,96,100,79,100,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Jordyn Cooley,58.29,71,74,77,99,102,-105,77,102,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (50-54) 81kg,Anthony McKee,79.55,75,78,-82,95,101,-105,78,101,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 71kg,Victoria Chmura,71,78,-81,-81,95,98,101,78,101,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Laura Caggiano,58.75,81,-84,-84,95,98,-101,81,98,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's 16-17 Age Group 71kg,Kimberly Wiese,66.8,76,-79,79,90,95,100,79,100,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Brianna Leverenz,63.35,78,80,82,94,97,-100,82,97,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Kelly Slaven,80.15,78,-81,-81,98,-101,101,78,101,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Alexis Alexander,69.7,71,74,-78,100,105,-111,74,105,179
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,Tristan Moeller,71.25,85,-88,88,90,0,0,88,90,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 55kg,Chase Zilcosky,55,75,-81,-81,-100,-103,103,75,103,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Angelina Dabney,59,-78,80,-83,-95,98,-101,80,98,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 59kg,Christine Reilly,58.2,76,-79,-81,99,102,-106,76,102,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Kayla Cocker,55,78,-81,81,97,-101,-101,81,97,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Carole Nasrallah,70.59,78,81,-83,93,97,-100,81,97,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Erica Hope,71,77,80,-82,95,98,-100,80,98,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Melissa Odorisio,69.89,75,78,-81,95,100,-104,78,100,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (60-64) 109kg,Randall Lewis,105.75,77,-80,-81,98,-101,101,77,101,178
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Anna Rucker,61.65,74,77,-80,-99,-99,100,77,100,177
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Challen Pressley Schleh,74.65,77,-80,-80,97,-100,100,77,100,177
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 61kg,William Drake,60.5,72,77,-80,90,95,100,77,100,177
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Nicole Shipos,112,75,-78,-80,95,98,102,75,102,177
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Leanne Watson,78.9,75,78,-80,-99,-99,99,78,99,177
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Heather McBride,65,73,77,80,93,96,-100,80,96,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Jocelyn Ocon,97.55,70,74,77,95,-99,99,77,99,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Kaitlyn O’Connor,70.15,77,80,-83,-96,-96,96,80,96,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Alyssa Martinez,70.6,80,-83,-83,-95,-96,96,80,96,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Morgan Huppenthal,64,71,74,77,95,99,-103,77,99,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Stephanie Ross,58.73,-72,-72,73,98,-102,103,73,103,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 64kg,Christina Richards,63.7,78,-80,-80,98,-101,-103,78,98,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Crystal Coppersmith,75.25,75,78,81,-95,95,-100,81,95,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Camille Capeles,63.85,78,-82,-85,98,-101,-101,78,98,176
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Alyssa Denno,67.57,75,80,-84,95,-101,-101,80,95,175
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Veronica Bagundes,54.95,71,73,-75,99,102,-106,73,102,175
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,M. Claire Akin,74.6,70,73,-76,94,98,102,73,102,175
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's Masters (40-44) 61kg,Jason Windley,60.9,75,-78,-78,100,-104,-104,75,100,175
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Elena Schorr,58,-78,78,-82,97,-99,-99,78,97,175
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Brianna Maxwell,74.32,70,74,-78,-100,-101,101,74,101,175
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 81kg,Erin Nelson,78.9,77,-80,-82,97,-101,-102,77,97,174
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Olivia Warrington,70,73,76,78,92,94,96,78,96,174
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Nicole Bradford,70.25,74,77,-80,94,97,-100,77,97,174
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 67kg,Dryden Yates,65.7,68,72,76,88,93,98,76,98,174
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Georgia Cameron,58.98,73,75,77,93,-97,97,77,97,174
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,MATTIE FLICKINGER,70.6,-73,73,77,92,96,-103,77,96,173
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (60-64) 81kg,Scott Obici,80.25,72,-75,76,95,97,-100,76,97,173
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Belia rodriguez rivera,70.45,72,-76,76,90,94,97,76,97,173
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Karlee Strong,75.15,76,-79,-80,96,-99,-99,76,96,172
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Bailee Pharris,75.85,75,78,-81,94,-97,-98,78,94,172
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Audrey Hoffmann,112.45,63,66,68,-95,97,104,68,104,172
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Katherine Miranda,61.95,73,75,77,91,93,95,77,95,172
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Makiyah  Nickerson,58.65,75,80,-84,-92,92,-95,80,92,172
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Samantha Ellison,63.3,73,76,-78,95,-100,-101,76,95,171
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Jaimee Linehan,64,-76,77,-80,-90,90,94,77,94,171
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Colbie Chinowsky,85.78,76,80,-84,91,-94,-95,80,91,171
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Chelsey Tharp,80.6,73,76,-80,-95,95,-99,76,95,171
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Devin Welker,63.5,-79,79,-87,-92,-92,92,79,92,171
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Erica Sheagley,61.65,75,-77,-77,96,-99,-99,75,96,171
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 55kg,Michael Tucciarone,55,-70,70,75,95,-100,-100,75,95,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Carlyn Winston,74.45,69,72,75,89,92,95,75,95,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Morgan Beattie,60.4,74,77,-80,93,-96,-97,77,93,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Gwen Rivero,59,71,-74,75,-89,91,95,75,95,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Jeanna Onishi,62.8,74,-77,77,-92,93,-95,77,93,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 59kg,Aysia Hill,58.6,70,73,76,87,91,94,76,94,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Jessica Rodriguez,58.15,-72,72,75,93,95,-98,75,95,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Erica Norgren,75.8,77,-80,81,85,-89,89,81,89,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 59kg,Emma Heck,58.83,74,-77,-77,93,96,-99,74,96,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Tess Bierl,70.85,75,-77,-77,95,-98,-98,75,95,170
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Lauren Fuhrman,63.6,-75,-76,76,90,93,-95,76,93,169
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 61kg,James Lessley,59.93,-74,74,-80,95,-99,-102,74,95,169
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,Connor Hwang,66.65,70,-75,76,93,-98,-100,76,93,169
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Alicia DiSpaltro,59.45,74,-77,-80,94,-97,-97,74,94,168
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Agata Santana,70.25,78,-81,-82,90,-94,-95,78,90,168
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Elise Caron,68.29,70,73,76,86,89,92,76,92,168
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Jade Morales,54.82,69,72,75,90,93,-96,75,93,168
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Lauren DeLong,58.7,72,-74,-76,95,-98,-99,72,95,167
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Megan Haymaker,158.65,69,72,-75,92,95,-98,72,95,167
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Rebecca Rivera,84.95,68,71,74,88,92,-95,74,92,166
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 61kg,Chase Coomer,60.19,68,71,-77,87,90,95,71,95,166
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 64kg,Autumn Sands,63.05,-70,70,72,88,91,94,72,94,166
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Ava Oteri,63.65,64,67,-71,94,-97,99,67,99,166
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 61kg,Kason Luu,60.48,68,71,-74,90,95,-100,71,95,166
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,D. Irizarry,54.07,68,71,-75,90,94,-98,71,94,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Paige Chardavoyne,64,-71,71,-74,94,-98,-98,71,94,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (45-49) 76kg,Amy Hovan,75.35,70,73,-76,-88,89,92,73,92,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Tracy Chase,67.55,74,-77,77,88,-90,-91,77,88,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Sarah Wright,57.95,72,75,-77,-90,90,-93,75,90,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Rebecca Liu,60.85,68,71,74,86,89,91,74,91,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Olivia Piacentini,84.1,-68,-68,68,89,93,97,68,97,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Yvgeni Henderson,86.05,70,-73,-73,90,95,-97,70,95,165
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 71kg,Lillian Spry,67.65,-72,-72,72,92,-96,-97,72,92,164
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Lucille Murphy,69.16,70,72,74,89,-92,-92,74,89,163
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Kristin Roskowick,76,69,-71,71,89,92,-95,71,92,163
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Jordan Nantz,55.52,67,70,72,85,88,90,72,90,162
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Alyssa Kwast,70.08,71,74,-78,82,85,88,74,88,162
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 13 Under Age Group +73kg,Sidney Porter,102.1,66,-70,71,83,88,91,71,91,162
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Kaylin White,48.35,68,71,73,-88,-88,89,73,89,162
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) 81kg,Amy Tunis,80.05,-70,70,74,-88,88,-91,74,88,162
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (45-49) 81kg,Katherine Brown,77.6,65,-69,69,86,89,92,69,92,161
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 64kg,Brooke Buzzell,62.05,65,68,-70,89,93,-94,68,93,161
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Melissa Boguslawski,93.4,63,-67,68,88,91,93,68,93,161
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Sharon Tran,54.75,66,69,72,-88,89,-91,72,89,161
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Kris Gonzalez,70.09,66,68,-70,-89,89,92,68,92,160
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Courtney Shoemaker,67.85,72,75,-78,85,-90,-92,75,85,160
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Lillian Glueck,101.6,67,-70,70,86,89,-92,70,89,159
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's 14-15 Age Group +76kg,Reese Butler,90.8,66,-71,-71,85,89,93,66,93,159
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Karina Velez,58.25,68,71,75,80,84,-89,75,84,159
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Katherine Lee,54.6,68,-71,71,85,-88,88,71,88,159
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Elaine Kempf,54.66,64,67,-70,89,92,-95,67,92,159
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Addison Smith,63,73,75,-77,84,-87,-87,75,84,159
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Stephanie Jefferson,64,70,-74,-74,88,-92,-94,70,88,158
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's 16-17 Age Group +81kg,Ansley Amore,99.7,70,-74,-74,-88,88,-92,70,88,158
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Lauryn Ginsburg,68.72,65,68,-71,90,-93,-93,68,90,158
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's 14-15 Age Group +76kg,Kaia Jacobs,101,68,-70,70,85,88,-90,70,88,158
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Felicia Sifers,84.25,-63,63,-67,-94,-94,94,63,94,157
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 64kg,Adelyn Jones,61.1,61,65,-69,84,88,91,65,91,156
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Zoe Pasetsky,58.34,-68,68,-70,82,85,88,68,88,156
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Olivia Duran,54.01,69,-72,-72,87,-91,-94,69,87,156
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 71kg,Ayla Sevilleno,70,-65,65,68,84,-87,87,68,87,155
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 59kg,Daniele Beeler,59,66,69,-72,86,-89,-92,69,86,155
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 55kg,Desmond Myles,54.45,60,64,67,80,84,88,67,88,155
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 61kg,Maddux Hernandez,59.31,63,66,68,83,86,-90,68,86,154
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 61kg,Davontai Bell,60.98,-70,70,-73,78,-83,84,70,84,154
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Rachel Conaway,48.6,62,65,68,83,86,-89,68,86,154
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 81kg,Catharine Messersmith,80.15,70,-74,74,80,-85,-86,74,80,154
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Sarah Arnett,73.75,-65,68,-72,85,-89,-90,68,85,153
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Marjorie Gottier,136.45,66,69,73,75,80,-84,73,80,153
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Alexa  Woodman ,63.45,62,65,67,81,84,86,67,86,153
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (55-59) 73kg,Tom Cadden,71.6,-68,68,-71,82,85,-88,68,85,153
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Jamie Boulos,66.82,64,-67,-68,83,86,89,64,89,153
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Sarah Emmert,69.4,65,68,-71,79,82,84,68,84,152
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 61kg,Lawson Berardi,60.63,68,70,-72,78,-81,82,70,82,152
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 81kg,Tanya Watson,77.15,65,68,-71,81,84,-86,68,84,152
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 59kg,Cari Griffin,58.4,63,-66,67,81,-84,85,67,85,152
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Katherine Cirone,74.39,60,63,-65,85,88,-91,63,88,151
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Ryan Metzger,49,62,65,-68,80,83,86,65,86,151
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 71kg,Ameli Patrick,70.62,57,60,64,81,-84,86,64,86,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Keri Lindquist,76,66,-69,-70,-80,80,84,66,84,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Lacey Fema,54.66,62,-64,65,82,-84,85,65,85,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Lindsey Knight,54.42,63,66,69,81,-85,-87,69,81,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Michelle Wagner,64,-64,64,67,81,-83,83,67,83,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Marena Morales,48.8,62,64,66,80,82,84,66,84,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Jocilyn Girouard,71,63,66,69,77,81,-85,69,81,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 55kg,Nicolas Martinez,54.7,-61,61,64,80,84,86,64,86,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Megan Wood,126.65,64,67,-70,83,0,0,67,83,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Emily Prostko,61.4,-67,67,-71,-83,-83,83,67,83,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 81kg,Jennifer Miller,79.25,62,64,-66,80,83,86,64,86,150
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Stephanie Kennedy,53.52,64,-68,-70,85,-88,-88,64,85,149
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 81kg,Riki Napiorkowski,80.75,65,68,-71,77,81,-83,68,81,149
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's 16-17 Age Group 76kg,Hayden Brandon,74.82,65,-69,-70,79,-84,84,65,84,149
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 64kg,Jennifer Frati,62,58,-62,62,81,84,87,62,87,149
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Kelly DeLear,66.69,64,67,70,79,-84,-84,70,79,149
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Elyce Gilliand,111.35,61,64,66,83,-86,-86,66,83,149
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Abby Boon,85.4,62,65,67,77,81,-83,67,81,148
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Jessi Oehler,58.45,66,-68,-69,80,82,-84,66,82,148
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Nikole Such,54.45,61,-63,64,81,84,-87,64,84,148
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (65-69) 81kg,hank berger,79.25,59,61,-64,82,84,87,61,87,148
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Amanda Cann,93.25,58,62,66,77,82,-88,66,82,148
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group +64kg,Ireland Manor,64.8,59,62,65,75,79,83,65,83,148
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Laurel Smoak,69.6,65,68,-70,75,79,-82,68,79,147
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 81kg,Jaclyn Bosworth,79.35,58,61,-64,81,85,-89,61,85,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Mary Chatriwala,71,60,63,-65,77,-80,83,63,83,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Sarah Welsh,73.72,59,-61,62,84,-86,-87,62,84,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 76kg,Ella Crane,73.01,65,68,-70,78,-81,-81,68,78,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Elaine Tsay,55.85,66,-69,69,77,-80,-80,69,77,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Heather Zrebiec,65.9,56,59,63,78,-82,83,63,83,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Angelica Rosales,75.3,-63,63,-66,-80,-83,83,63,83,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Nia Black,61.45,62,65,68,76,-78,78,68,78,146
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (50-54) +87kg,Kristina Teel,103.65,60,-63,63,75,78,82,63,82,145
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Gracie Rice,54.68,-62,-62,62,81,-83,83,62,83,145
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 81kg,Marie McNair,77.04,62,64,66,79,-82,-82,66,79,145
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Crystal Wrubel,58.6,65,-67,67,-75,75,78,67,78,145
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Laney Yost,48.9,63,65,-68,-75,75,80,65,80,145
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's 16-17 Age Group 81kg,Raven Lovencin,78.15,-61,61,65,75,80,-85,65,80,145
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Leyla Sakrisson,63.05,59,62,-65,76,79,82,62,82,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Kara Keith,62.2,59,61,-63,-78,79,83,61,83,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 71kg,A. Isabelle Miller,70.89,60,63,67,73,77,-80,67,77,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 67kg,Rowdy Cearley,61.4,60,-62,62,79,82,-84,62,82,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Selena Cearley,75.9,63,-65,-65,75,78,81,63,81,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (45-49) 81kg,Cara Phillips,78.3,61,-64,64,75,80,-86,64,80,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Kate Painter,63.45,62,-65,-65,77,79,82,62,82,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's 14-15 Age Group 76kg,Addison Bell,75.88,-65,65,68,76,-82,0,68,76,144
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 64kg,Valerie Greenslade,63.3,63,65,-67,73,76,78,65,78,143
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Erin Mena,84.7,-56,56,59,-82,83,-86,59,83,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Olga Pisarskiy,61.9,62,-65,-65,80,-83,-85,62,80,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Jessica Cummings,63.8,-65,67,-70,-73,-75,75,67,75,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Andrea Wilson,65.35,59,62,-65,-77,77,80,62,80,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Brynn Cupp,47.95,-63,-63,63,77,79,-83,63,79,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 71kg,Jessica Johns-Green,69.95,57,60,63,75,-78,79,63,79,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group +64kg,Chassity Del Balso,66.98,55,58,61,72,77,81,61,81,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Angie Monterroso,54.29,60,-62,62,77,80,-82,62,80,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group 64kg,Gianna Van Hofwegen,61.25,58,60,62,74,77,80,62,80,142
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 76kg,Ibis Loya Aguirre,73.66,62,65,-68,76,-79,-80,65,76,141
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Ayana Parker,55,-62,62,-65,79,-82,-83,62,79,141
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Leann Freeman,62.85,63,-66,-67,75,78,-80,63,78,141
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 55kg,jordan castro,54.3,61,64,-67,-75,-77,77,64,77,141
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Elizabeth Paller,99.94,50,53,-56,81,85,88,53,88,141
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 64kg,Samantha Love,63.85,60,63,65,74,-76,76,65,76,141
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Michelle Woogen,62.1,58,61,63,71,74,77,63,77,140
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 67kg,Keegan McHale,65.95,51,54,-57,76,81,86,54,86,140
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Jana Whiteaker,68.43,-59,-60,60,75,80,-87,60,80,140
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Summer de la Cruz,63.55,57,60,-63,74,78,80,60,80,140
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 49kg,Jennifer Fullhart,48.95,57,59,-61,77,-80,80,59,80,139
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Lisa Guadagnolo,53.88,58,60,63,-76,76,-79,63,76,139
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Amanda Scrementi,73.13,59,-62,62,71,74,77,62,77,139
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 45kg,Virginie Beljour,45,61,-64,-65,78,-82,-85,61,78,139
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) 87kg,Lindsay Watson,84.9,58,-61,61,70,74,78,61,78,139
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 67kg,Nathanael Maher,66.5,59,62,-65,68,73,77,62,77,139
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (45-49) 87kg,Shelley Gast,81.5,57,60,63,75,-80,-80,63,75,138
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 64kg,Zoe Rangel,63.9,58,60,-63,72,75,77,60,77,137
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (45-49) +87kg,Kelli Wells,131.52,58,60,62,72,-75,75,62,75,137
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Paula Mogollon,54.17,57,-60,60,74,77,-80,60,77,137
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 71kg,Angela Weidman,69.16,55,58,60,70,74,77,60,77,137
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 49kg,April Noska,49,60,-62,-62,-77,-77,77,60,77,137
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (50-54) 64kg,Michelle Picking,62.15,-61,-61,62,71,74,-76,62,74,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Kathleen Marquez,73.99,55,58,60,74,76,-78,60,76,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,maria shesiuk,73.55,52,55,58,70,74,78,58,78,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (45-49) +87kg,Delores Hill,92.55,55,58,61,69,72,75,61,75,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Alexis Figurski,48.65,58,61,-63,75,-80,-80,61,75,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Ashlee Edwards,70.29,61,-63,-64,-75,75,-77,61,75,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Nicole Trimble,69.08,56,59,62,74,-77,-78,62,74,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Christina Brockington,145,53,57,-60,75,79,-83,57,79,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Lucy Nguyen,49,56,-59,59,-76,77,-80,59,77,136
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (50-54) 76kg,Elisa Leporini,72.79,56,59,61,71,-73,74,61,74,135
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Lauren Abadie,56.8,57,-60,60,-65,75,-80,60,75,135
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Amanda Whiting,63,51,54,57,75,78,-81,57,78,135
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Lilla Heath,55,59,-62,62,68,72,-75,62,72,134
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Natasha Wunderlich,111.82,-57,57,-59,77,-81,-83,57,77,134
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 76kg,Alba Fortuna,74.12,58,60,-62,71,74,-77,60,74,134
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (35-39) +87kg,Nicole Jokola,100.32,-55,55,58,-74,75,-78,58,75,133
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Dana Kelly,57.5,54,56,58,71,73,75,58,75,133
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Elizabeth Skwarecki,68.71,56,59,-62,-72,73,-75,59,73,132
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Kathleen Black,62.3,57,-59,-60,-74,-75,75,57,75,132
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 45kg,Amerie Timmons,44.85,53,56,58,70,74,-77,58,74,132
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Natalie Frey,74.2,56,-58,58,74,-76,-76,58,74,132
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Amanda Serapiglia,48.9,56,59,-62,-70,70,73,59,73,132
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Elizabeth Wenzel,69.96,-60,60,-62,69,71,-73,60,71,131
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 87kg,Vladislava Davydova,83.75,52,55,58,68,70,73,58,73,131
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Claire Ungashick,70.82,56,59,61,67,-70,70,61,70,131
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Aria Zayed,49,54,56,58,68,70,72,58,72,130
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Stormy Weather,73.8,56,-58,60,65,68,70,60,70,130
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 49kg,Nile Franklin,48.6,-58,58,-61,72,-75,-76,58,72,130
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Audrey Tancini,70.59,55,-60,60,70,-75,-75,60,70,130
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Mahealani Mason,53.6,54,56,58,64,69,72,58,72,130
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Sandra Paladino,67.56,52,55,58,66,69,72,58,72,130
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Amanda Dziawura,62.8,54,56,-58,68,71,73,56,73,129
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 45kg,Sarah Morris,44.95,-54,54,57,72,-76,-76,57,72,129
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 59kg,Jara MacDermott,56.15,52,54,56,70,73,-75,56,73,129
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 59kg,Jordan Schwenneker,56.37,54,57,-60,66,69,72,57,72,129
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Cheryl D. Capadocia,49,51,54,57,68,72,-75,57,72,129
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (45-49) 87kg,Elizabeth Korchnak,85.15,55,57,-59,70,72,-74,57,72,129
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 61kg,Cody Anderson,57.19,52,-55,-55,68,72,76,52,76,128
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Juliana Flynn,48.85,-57,-57,57,68,71,-74,57,71,128
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (55-59) 76kg,Larisa Miranda,75,53,-58,58,65,70,-75,58,70,128
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Sophia Milian,53.41,52,55,-58,70,73,-76,55,73,128
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 64kg,Jessica King,63.3,50,53,56,66,69,72,56,72,128
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Gabriela Delgadillo Sarabia,49.7,53,-56,-56,-73,75,-78,53,75,128
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Annette Smith,122.2,52,-54,55,67,70,72,55,72,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Tracy Wong,75.1,-53,53,56,68,71,-74,56,71,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 59kg,Brooklynn Hoover,57.7,54,-57,57,64,67,70,57,70,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,tiffany leung,48.4,-57,57,-60,70,-73,-73,57,70,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Rachel Bryla,58.95,52,-54,-54,72,75,-78,52,75,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Erin Madden,62.45,55,57,-59,68,70,0,57,70,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Eva Young,54.46,52,55,58,69,-72,-73,58,69,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Chloe Merritt,57.75,52,55,57,65,70,-72,57,70,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (50-54) 76kg,Loretta Scott,76,53,55,-57,-72,72,-75,55,72,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Kaitlin Lacey,48.2,55,-58,-60,72,-76,-76,55,72,127
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Courtney Ihlenfeld,63.35,56,-59,-59,68,70,-72,56,70,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 71kg,Ashley Burnell,71,53,55,58,68,-71,-71,58,68,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 59kg,pamela gagnon,56.15,-50,53,-57,67,70,73,53,73,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Eleanor Otis,57.7,53,56,58,68,-72,-73,58,68,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (45-49) 87kg,Lindsay Pitzer,85.05,52,55,60,66,-70,-70,60,66,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Wynter Montgomery,61.9,51,53,55,65,68,71,55,71,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Alessandra Arias,55.75,-50,53,56,70,-73,-73,56,70,126
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (55-59) +87kg,pamela brooks,106.82,45,48,50,68,72,75,50,75,125
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Alaina Prewitt,75,50,52,54,68,71,-73,54,71,125
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Katelyn Tkacik,68.72,50,53,55,65,70,-74,55,70,125
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Kawena Mason,56.04,53,55,57,61,64,67,57,67,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 64kg,Allie Nichols,63.4,47,50,-53,68,71,74,50,74,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) 87kg,Sara Soto,86.1,-53,53,-57,64,68,71,53,71,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Erica Chard,58.85,54,55,-57,67,69,-70,55,69,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Karen O'Donnell,69.64,50,-53,53,68,71,-74,53,71,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 55kg,Maryam Grafton,54.17,-50,50,54,-65,65,70,54,70,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Laura Dionisio,67,51,54,-57,64,67,70,54,70,124
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Stephanie Geer,58.05,53,-55,55,65,-67,68,55,68,123
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Katie Koontz,74.55,-55,55,-58,68,-71,-71,55,68,123
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (50-54) 55kg,Rosanna Sansone,54.38,50,53,-56,70,-74,-74,53,70,123
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 64kg,Samantha Goodman,62.65,54,-57,57,66,-69,-69,57,66,123
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 49kg,Amelia Phillips,48.35,-52,52,-54,66,71,-74,52,71,123
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Megan Patton,56.2,50,-53,-53,70,73,-75,50,73,123
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Erin Thomson,53.3,50,52,54,64,66,68,54,68,122
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 61kg,Noah Booth,60.73,46,47,51,65,68,71,51,71,122
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Jenny King ,62.75,48,51,54,57,61,68,54,68,122
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Raquel Barreto,71.55,53,56,-58,58,62,66,56,66,122
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 71kg,Samantha Artiga,65.9,52,54,56,63,66,-69,56,66,122
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 81kg,TIA VANCE,77.1,53,-55,-56,66,69,-71,53,69,122
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Tacora Beasley,103.8,52,55,-59,63,-66,66,55,66,121
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group 64kg,Hadley Parsons,61.1,47,50,53,64,-68,68,53,68,121
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,HarleyJane Carter,53.1,50,53,-56,66,68,-70,53,68,121
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 14-15 Age Group 71kg,Stevie Majoros,67.16,47,-50,50,66,70,-73,50,70,120
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (50-54) 59kg,Tiffany Redwine,58.9,50,52,-54,65,-68,68,52,68,120
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Kristin  Leet,61.3,52,-55,55,-65,65,-67,55,65,120
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Debra Woods,65.95,55,-57,-57,65,-68,-68,55,65,120
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (60-64) 64kg,Kelly Garber,64,51,53,-55,-64,64,67,53,67,120
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Lynnette Hull,58.05,50,-52,-52,70,-74,-74,50,70,120
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Lize Buitendach,55.54,50,53,-55,62,64,66,53,66,119
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Jaycee  Cobb ,53.15,48,-51,53,-66,-66,66,53,66,119
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 55kg,Denee Wolf,54.77,45,48,51,65,68,-71,51,68,119
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 64kg,Abigail Prichard,59.35,52,-55,-55,63,-67,67,52,67,119
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Hanna Estevez,76.01,51,-54,-54,65,68,-71,51,68,119
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (80+) 102kg,Richard Sipos,100.25,47,50,52,63,66,-68,52,66,118
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 81kg,Deborah Fountain,76.45,-55,-55,55,63,-67,-67,55,63,118
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 55kg,Lauren Storck,52.91,50,-52,-54,-66,66,68,50,68,118
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 55kg,Karen Agena,54.09,-47,47,49,67,69,-71,49,69,118
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 59kg,Moira Fauth,58.9,44,47,50,65,68,-71,50,68,118
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Anne Powell,69.37,47,50,52,63,66,-69,52,66,118
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group +64kg,Alyssa Hines,65.46,51,-53,-55,61,64,66,51,66,117
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Jessica Cruse,63.4,49,52,-55,-62,62,65,52,65,117
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Tiffany Black,56.05,-54,-55,55,59,62,-65,55,62,117
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Nicki Ingram,58.2,-50,50,-53,66,-71,-72,50,66,116
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Adrienne Li,55.82,-49,50,53,60,63,-66,53,63,116
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (65-69) 87kg,Deborah Strobel,84.3,45,-48,-48,65,68,71,45,71,116
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Clementina Russo,63,-45,45,47,68,-70,-70,47,68,115
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 45kg,Melissa Sue Jutras Kamphake,45,50,-52,52,60,63,-65,52,63,115
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Isabella Tadique,57.8,47,50,52,57,60,63,52,63,115
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Laura Kaveney,57.3,45,48,-50,60,64,67,48,67,115
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 71kg,Allyson Cochran,67.64,52,55,-58,60,-63,-63,55,60,115
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Ireland OBrien,49,52,55,-58,59,-62,-62,55,59,114
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 49kg,Sally French,46.85,47,49,51,63,-66,-69,51,63,114
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Mischa Jemionek,57.55,44,47,49,61,63,65,49,65,114
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (50-54) 76kg,Lisa Talcott,74.2,-53,53,-55,58,61,-65,53,61,114
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (45-49) 71kg,Pennye Stansel,71,46,-48,48,-66,66,-69,48,66,114
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Christina Barajas,65.45,-50,50,-52,60,63,-65,50,63,113
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (45-49) 76kg,Heather Krause,72.4,48,50,52,55,58,61,52,61,113
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 59kg,Alexandra Hamilton,55.72,48,51,53,60,-63,-63,53,60,113
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 55kg,ALEXANDRIA Zikoyanis,55,47,49,-51,63,-66,-66,49,63,112
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 59kg,Lucy Korn,58.65,45,47,49,57,60,63,49,63,112
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 13 Under Age Group 73kg,Aidan Curry,69.55,47,50,-53,59,62,-65,50,62,112
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 59kg,Catherine Galli,58.25,48,50,52,-57,57,60,52,60,112
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (80+) 96kg,Barry Lewis,90.84,45,48,50,58,62,-65,50,62,112
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 45kg,Isabella Rice,44.75,45,-47,48,60,-63,63,48,63,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group +64kg,Fiona Paul,64.55,-45,45,49,57,62,-64,49,62,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Kimmy Fung,55.34,51,-53,-53,57,60,-63,51,60,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group +64kg,Andie Kephart,90.21,47,49,51,58,-60,60,51,60,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Ashley Aun,48.65,45,-49,-49,62,66,-70,45,66,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Desiree Gonzalez,58.7,48,50,-52,58,61,-63,50,61,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Piper Jones,49.75,44,46,48,60,62,63,48,63,111
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 55kg,Sabrina Liu,51.47,46,48,-50,58,62,-64,48,62,110
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 64kg,Jennifer Fite,63.75,-45,-45,45,61,63,65,45,65,110
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Bianca Leone,57.9,48,50,52,58,-61,-61,52,58,110
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (55-59) 71kg,Sheryl Soule,68.27,44,-47,47,56,-60,62,47,62,109
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 67kg,Taylor Page,66.1,40,44,49,53,57,60,49,60,109
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Sunrise de la Cruz,54.35,42,45,48,55,58,61,48,61,109
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 45kg,haley earnest,44.4,42,45,-48,-62,63,-66,45,63,108
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (55-59) 87kg,Leanda Bevans,83.35,45,48,-51,-60,-60,60,48,60,108
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (50-54) 64kg,Lauren Herrmann,61.45,42,-45,-45,62,65,-68,42,65,107
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 55kg,Jennifer Moberly,52.15,-40,40,43,60,62,64,43,64,107
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Ellen Lehman,53.12,44,48,-51,53,-56,58,48,58,106
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (50-54) 64kg,Melanie Lendis,61.1,45,47,-49,56,-59,59,47,59,106
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 13 Under Age Group +64kg,Olivia Blatt,70.13,38,42,45,50,55,60,45,60,105
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Emaan Qayyum,53.72,39,41,44,53,57,60,44,60,104
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (50-54) 71kg,Tatiana Nikitina,68.13,42,44,46,56,58,-61,46,58,104
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Luna Perez,52.42,46,49,-51,-55,55,-58,49,55,104
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 59kg,Annelisa Pessetto,57.55,39,-43,44,55,59,-61,44,59,103
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 49kg,Weston McGrath,46.05,42,44,-46,53,56,58,44,58,102
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Ella Gamache,48.95,43,45,-47,57,-60,-60,45,57,102
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 49kg,Laura Woodward,48.3,38,41,-43,55,58,61,41,61,102
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (45-49) 59kg,Shannon Strzynski,58.45,43,45,47,53,55,-57,47,55,102
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (40-44) 76kg,Renee Michelle Burnette,71.35,40,42,44,52,56,-60,44,56,100
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 49kg,Allison Avalos,48.35,40,-45,45,45,50,55,45,55,100
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 49kg,Lyla Sharp,47.8,42,-44,44,52,55,-57,44,55,99
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Mia Murphy,52.8,40,42,-44,52,54,56,42,56,98
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 55kg,Liz Waddell,52.43,40,43,-45,47,50,55,43,55,98
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Gabrielle Gutierrez,46.15,-41,-42,42,54,56,-60,42,56,98
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 49kg,Nora Paoloni,47.8,-40,40,42,51,54,56,42,56,98
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (40-44) 55kg,Joanne Sanders,54.61,-40,40,-43,52,55,57,40,57,97
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Emily Paoloni,54.24,-43,-43,44,50,-53,53,44,53,97
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 55kg,Reece Robinson,53.26,38,40,-43,51,54,57,40,57,97
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (50-54) 71kg,Jennifer Powers,68.87,40,42,44,46,49,52,44,52,96
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 49kg,Maya Litt,48.5,42,-44,-44,52,54,-56,42,54,96
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 45kg,Kaya Malia Henn,44.7,35,37,39,50,53,56,39,56,95
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 55kg,Korban Alderman,52.9,36,38,41,45,48,53,41,53,94
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 49kg,Ivy Weiss,47.4,38,40,-42,48,51,53,40,53,93
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 55kg,Desirae Phoenix,52.21,40,-42,-42,53,-56,-57,40,53,93
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (55-59) 76kg,Vicki Myers,72.45,36,39,-42,48,51,54,39,54,93
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 49kg,Kendall Williams,45.75,-40,-40,40,51,53,-55,40,53,93
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (60-64) 81kg,Margaret binzer,78.25,35,38,-41,50,53,55,38,55,93
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 49kg,Ezekiel Macias,48.65,36,38,41,46,48,51,41,51,92
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (60-64) 49kg,Lauren Goldenberg,48.65,38,40,-42,50,-52,52,40,52,92
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 55kg,Neil Fountain,51.5,33,36,40,43,47,52,40,52,92
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 45kg,Alani Rose,42.05,-40,-40,40,48,51,-54,40,51,91
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 49kg,Ansley Ebert,47.15,36,38,40,45,49,-51,40,49,89
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 59kg,Grace Gibson,57.63,36,38,40,43,46,49,40,49,89
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 49kg,Parker Nilson,48.65,33,35,37,45,48,51,37,51,88
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (55-59) 71kg,Helen Shiver,66.72,35,38,40,45,48,-50,40,48,88
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (50-54) 59kg,Wendi Lubinus,57.7,38,-41,-41,-50,50,-53,38,50,88
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (65-69) 76kg,DOLORES TRIVIZ,76,40,-42,-42,48,-51,-52,40,48,88
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 55kg,Mateo Zikoyanis,52,-35,35,38,46,49,-51,38,49,87
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 45kg,Mackenzie  Carlson,43.35,33,-35,-36,46,49,53,33,53,86
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 55kg,Danika Lorenzo,52.73,30,33,36,45,48,50,36,50,86
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (60-64) 49kg,Beth Lamoreaux,48.6,34,36,-38,-47,47,-50,36,47,83
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 45kg,Danielle Do,44.45,32,35,-38,40,44,48,35,48,83
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 40kg,Jasmin Trinh,39.1,34,-37,37,-43,43,-45,37,43,80
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (55-59) 64kg,Deanna Johnson,60.8,-34,34,36,41,-44,44,36,44,80
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (60-64) 87kg,Doncella Young,83.85,32,34,36,40,43,-46,36,43,79
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 44kg,Jordan Hernandez,41.4,29,31,34,39,42,45,34,45,79
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 36kg,Annalee Seek,35.1,29,32,-35,38,43,45,32,45,77
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (60-64) 59kg,Kellie Moylan,58.65,31,33,-36,41,43,-46,33,43,76
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (55-59) 49kg,Akiko Stojek,48.95,32,34,-36,-42,42,-44,34,42,76
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 44kg,Archer Praetorius,41.5,28,31,34,35,38,40,34,40,74
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 45kg,Sofia Giron,43.95,28,30,32,36,39,-42,32,39,71
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 36kg,Lila Mangan,35.25,28,30,-32,38,41,-44,30,41,71
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 55kg,Kellan Brown,49.75,27,29,-32,33,36,40,29,40,69
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (65-69) 64kg,Carrie Thompson,61.5,28,30,-32,35,-37,38,30,38,68
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 36kg,Maui Mason,34.45,27,-29,29,33,36,38,29,38,67
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 36kg,TIERANY LALLY,32.85,27,-29,30,33,35,-36,30,35,65
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 39kg,Kayden Doherty,38.3,23,25,26,32,34,36,26,36,62
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (70-74) 55kg,Susan Gunther,53.21,23,25,-26,-32,32,35,25,35,60
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 45kg,Ava Gibson,40.85,-23,-23,24,34,-36,-36,24,34,58
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (70-74) 59kg,Marcy Seymour,55.64,22,24,25,29,-32,32,25,32,57
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 39kg,Anthony Poulos,37.3,22,-24,24,30,32,-34,24,32,56
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 40kg,Stella Robles-Pimentel,39.9,20,22,-27,28,-30,30,22,30,52
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 32kg,David Grafton,30.55,20,22,-24,-28,28,-31,22,28,50
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 30kg,Layla Johnson,29.2,18,20,-21,27,29,-31,20,29,49
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 13 Under Age Group 32kg,Jaxson Lessley,31.35,18,20,-23,24,26,-28,20,26,46
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Derien Pratt,70.46,52,-55,-55,-68,-69,-69,52,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 13 Under Age Group 30kg,Rayya Howard,22.15,20,22,-23,-27,-28,-28,22,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Emily Kessler-Lewis,85.81,82,-85,-85,0,0,0,82,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Nicole Citera-Juarez,61.4,-71,71,-74,-100,-101,-101,71,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Angelica Christopher,74.44,-79,79,81,-93,0,0,81,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Andrew Raudabaugh,72.6,-107,-107,-108,132,137,-142,0,137,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (35-39) 59kg,Rebecca Chow,58.95,-50,-50,-50,-65,65,67,0,67,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,Thomas Kniss,69.45,-84,-84,-85,113,-117,-117,0,113,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 49kg,Jagarii Gardner,48.85,70,74,77,-95,-95,-95,77,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Julie Mizak,63.6,61,-64,64,-81,-81,-81,64,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Lisa Ho,62.8,-78,79,-82,-102,-104,-105,79,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 64kg,Melissa Suarez,64,75,-78,-79,-95,-95,-96,75,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Molly Dorrance,61.45,-44,-44,-44,60,-62,-62,0,60,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 13 Under Age Group +73kg,Asher Fountain,74.35,63,66,70,-82,-83,-83,70,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 55kg,Liliana Eastes,53.67,45,-50,50,-61,-63,-63,50,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Kenneth Ordway,85.5,125,-130,-132,-153,-153,-154,125,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) 109kg,Daniel Russell,109,125,-130,-130,-155,0,0,125,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Mason Palmer,89.98,-132,-133,-133,161,-165,-167,0,161,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Colby Mapps,93.47,126,-131,-132,-153,-157,-158,126,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,David Bray,88.85,-125,-125,-126,-146,-148,-148,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (35-39) 71kg,Chelsea Rebholz,66.62,61,63,-65,-75,-76,-77,63,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Luke MacLennan,89,140,-145,-145,-180,-180,-183,140,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Chris Wong,88.8,-95,-100,-100,-128,-129,-129,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Taylor Lucas,64,-91,-92,-93,0,0,0,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Men's 67kg,Dominik Polverini,66.8,-113,-113,-113,-143,-144,146,0,146,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Janelle Shafer,63.63,-88,-88,-88,108,111,-115,0,111,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 61kg,Jaden Youmans,59.5,-73,-74,-74,-84,85,-87,0,85,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's 16-17 Age Group 73kg,Colin Manning,72.7,112,116,-120,-139,-139,-139,116,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Brandon Victorian,88.55,146,-151,-151,-185,-185,-185,146,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Erin Huss,58.37,73,-75,-76,-91,-91,-92,73,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 109kg,Kenderic McMillian,106.4,125,130,-135,-165,-165,-165,130,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Women's Masters (35-39) 76kg,Carly Best,75.2,75,-78,78,-102,-102,-102,78,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Leigh-Ann Trepanier,57.9,-81,-81,-82,102,-105,106,0,106,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Carly Lansley,117.65,83,-86,86,-105,-105,-105,86,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 76kg,Kristina Robinson,71.95,84,-87,-87,-108,-109,-109,84,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 67kg,evan bond,65.15,-84,-84,-84,100,-102,-102,0,100,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 87kg,Kelsey Koontz,87,82,-86,-86,-103,-103,-105,82,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's 81kg,Anna McElderry,81,-99,-100,-100,118,-121,121,0,121,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (40-44) +87kg,Monica Tokarsky,99.02,-56,-56,-56,63,-66,66,0,66,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's Masters (40-44) 64kg,Jessica Taylor,63.8,-56,-56,-56,-62,62,65,0,65,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 14-15 Age Group 67kg,Carter Sing,66.9,-95,-95,-96,-110,110,0,0,110,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Men's Masters (35-39) +109kg,Kyle Wilp,141.1,-128,-128,-130,170,-181,-182,0,170,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 16-17 Age Group 59kg,Emily Green,58.15,-63,-63,-63,75,77,-80,0,77,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 89kg,Phillip Ragan,87.85,-127,-128,-130,162,-165,-167,0,162,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 81kg,Alexander Arquilla,81,116,-120,120,-150,-150,-150,120,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Allison Handel,55,74,77,-80,-94,-96,-96,77,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Men's 102kg,evan reinhart,98.16,-132,-132,-135,-165,167,-170,0,167,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's 14-15 Age Group 45kg,Jaedyn Orton,45,-55,-55,-55,-76,-76,0,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Men's Masters (35-39) 73kg,Willie Day,73,-115,-115,-115,143,147,-151,0,147,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,STEVEN MARCUS,72.1,-102,-102,102,-133,-134,-138,102,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Men's Masters (35-39) 89kg,Cody Limas,87.9,-115,-116,-116,0,0,0,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 73kg,Mateo Montelongo,72.8,-107,-107,-107,130,-136,-136,0,130,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,carly audia,63.93,90,-95,95,-110,-111,-111,95,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Michael Tancini,93.42,-130,-130,-130,-162,0,0,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 71kg,Meredith Alwine,70.55,102,-105,-105,-134,-138,-138,102,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,Tyler Siefke,91.81,125,-128,-131,-170,-170,-170,125,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Men's 96kg,John Setting,95.33,-141,-142,-142,0,0,0,0,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Men's 81kg,Connor Houghton,80.54,-121,-122,-122,152,-157,-157,0,152,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 59kg,Monica Parucho,59,67,-70,70,-90,-91,-91,70,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Open Women's +87kg,Katherine Ford,97.4,-83,-84,-84,103,107,-111,0,107,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Women's 16-17 Age Group 64kg,Peyton Muth,63.7,64,-67,-67,-82,-83,-83,64,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-09,Open Women's 64kg,Brie Gomez,63.85,-83,-85,-85,-91,91,94,0,94,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-10,Women's Masters (50-54) +87kg,Tracy Harris,97.81,-55,-55,-55,72,-73,-78,0,72,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Women's Masters (65-69) 49kg,Linda Foess,48,-23,23,-24,-27,-27,-27,23,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Men's 16-17 Age Group 61kg,Henry Ludbrook,60.85,-85,85,-90,-106,-108,-109,85,0,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-08,Open Women's 71kg,Kayli Kullos,70.05,-74,-74,-74,95,-100,100,0,100,0
+"The 2023 Nike North American Open Finals, powered by Rogue",2023-12-07,Open Women's 55kg,Sayuri Yoshimura,54.79,-64,-65,-65,80,-83,-83,0,80,0

--- a/event_data/US/6656.csv
+++ b/event_data/US/6656.csv
@@ -1,0 +1,800 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Xavier Borde,108.8,152,-157,158,195,201,207,158,207,365
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Cesar Flores,159.06,148,152,156,193,-197,200,156,200,356
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Russell Bowman,104.99,150,155,-160,188,196,-201,155,196,351
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Kaleb Wendricks,160,-144,144,148,186,192,197,148,197,345
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Dimitri Albury,161.9,-141,142,-148,188,194,203,142,203,345
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Matthew Naugle,130.53,-152,-152,152,188,192,-196,152,192,344
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Kyle Schulman,120.76,142,147,150,185,191,-195,150,191,341
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Chrisanto D'Agostino,95.95,148,153,-158,183,-188,-190,153,183,336
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Zachary Huse,129.85,-142,-142,142,188,193,-200,142,193,335
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,James Tice,108.99,144,149,-156,-175,179,185,149,185,334
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Joshua Magee,101.73,150,155,-160,177,-182,-185,155,177,332
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Jacob Brenza,128.13,-138,141,146,178,-182,183,146,183,329
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Caleb Goodman,85.61,-136,136,-141,179,187,192,136,192,328
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Layne Palm,95.91,-145,145,149,177,-181,-183,149,177,326
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Benson Robles,100.21,138,142,146,180,-187,-187,146,180,326
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Christopher Marquez,107.11,140,145,-150,-170,173,181,145,181,326
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Tyler Schade,95.74,-137,137,-141,181,-187,187,137,187,324
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Jaimerius Williams,93.63,148,-153,-157,175,-182,-184,148,175,323
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 96kg,Yomar Andres Lopez Cameron,94.95,135,140,145,161,168,175,145,175,320
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Luke MacLennan,96,-140,140,-145,-175,180,-184,140,180,320
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Charles Shervheim,101.6,125,131,136,178,184,-191,136,184,320
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,carlos gonzalez,147.35,130,135,-138,172,180,-185,135,180,315
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 109kg,Colin Reis,107.82,135,140,-145,-172,174,-182,140,174,314
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Troy Fries,80.5,135,139,-142,170,-175,175,139,175,314
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Will Easley,95.86,-135,-136,137,177,-182,-184,137,177,314
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Timur Kusov,80.7,138,142,-145,170,-175,-175,142,170,312
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Andrew Guevara,105.37,136,138,-140,168,174,-178,138,174,312
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Jimmy Marquez,94.74,130,136,-140,170,175,-180,136,175,311
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Dustin Baranowski,116.67,130,135,140,160,165,170,140,170,310
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,Jabo Nguyen,121,130,-135,-135,180,-185,-186,130,180,310
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Ryan McDonald,80.62,132,136,-140,167,172,-179,136,172,308
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Wyatt Coffey,88.42,135,-140,-142,-168,169,173,135,173,308
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Kyle Martin Jr.,89,136,-141,141,166,-171,-171,141,166,307
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Adam White,96,-135,135,-140,160,168,172,135,172,307
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 109kg,Daniel Russell,109,-130,131,135,160,166,170,135,170,305
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Jacob Cluff,107.98,130,-134,-136,-170,170,175,130,175,305
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 96kg,Colby Mapps,92.7,130,135,-140,160,-165,167,135,167,302
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Brian Smarsh,95.91,135,-140,-140,166,-170,-172,135,166,301
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Jordan Berroteran,101.57,-135,-135,135,166,-172,-175,135,166,301
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Conner Sparks,84.5,125,128,-131,160,165,172,128,172,300
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Michael Banks,100.7,135,-140,-143,165,-171,-175,135,165,300
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Denali Scoular,108.74,-130,130,-135,170,-175,-177,130,170,300
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Cameron Fyffe,99.65,133,137,-142,160,-171,-171,137,160,297
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Calvin Lackey,88.17,118,121,126,159,165,170,126,170,296
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Dominique Laster,87.47,134,-137,138,158,-163,-164,138,158,296
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Teddy Perez,94.36,128,131,-134,165,-169,-170,131,165,296
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Scott Harris,99.68,130,-135,-135,166,-171,-172,130,166,296
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,CJ Fernandez,85.12,125,-132,132,150,-157,163,132,163,295
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 109kg,Mateo Villa,108.51,128,133,-138,-160,-161,162,133,162,295
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Jacob Marks,88.51,131,-135,135,155,160,-164,135,160,295
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Justin Perry,95.97,-125,125,130,155,160,165,130,165,295
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) +109kg,Norman Carreiro,110.03,127,132,-137,157,162,-168,132,162,294
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Samuel Wainwright,87.05,124,130,-133,-158,158,163,130,163,293
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg,Jason Pendergraph,101.34,124,128,-132,160,165,-169,128,165,293
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 102kg,William Wainwright,97.88,120,-125,-127,160,166,172,120,172,292
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Valera ` Djaghouri,88.37,-127,128,-132,158,163,-168,128,163,291
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Jabari Prince,94.96,120,125,-130,-154,155,165,125,165,290
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) +109kg,Kyle Wilp,140.45,115,120,-126,161,-162,170,120,170,290
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Dakota Hooper,87.8,115,118,-121,162,167,172,118,172,290
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Nicolas Munro,88.52,-125,125,-129,165,-170,-172,125,165,290
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 96kg,Jackson  Leonard,90.92,115,120,125,152,159,164,125,164,289
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 96kg,Spencer Dent,94.32,-129,129,-143,153,159,-165,129,159,288
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Marc Marquez,72.46,123,127,-131,153,157,161,127,161,288
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 102kg, Luke Shamberger,98.68,131,136,140,148,-153,-156,140,148,288
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Michael Davidge,88.93,120,125,130,147,152,157,130,157,287
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Chase Durham,94.9,127,130,-135,-155,-157,157,130,157,287
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) +109kg,Gavin Hough,136.71,112,117,122,144,151,160,122,160,282
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 102kg,Jason Dinius,101.65,120,125,-129,145,151,156,125,156,281
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Jacob Johnsson,87.33,124,-128,129,145,152,-161,129,152,281
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,David Bray,95.83,-127,127,-132,148,153,-156,127,153,280
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Trevor Owens,80.18,120,125,-132,-155,155,-165,125,155,280
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,William Palumbo,96,118,-123,-125,161,-165,-166,118,161,279
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 89kg,John Gilleland,89,125,-128,128,150,-157,-157,128,150,278
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Connor Houghton,80.86,119,123,-126,-155,155,-160,123,155,278
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Dominik Polverini,70.96,118,-122,125,148,152,-156,125,152,277
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Cameron Lee,80.99,117,122,-125,147,152,155,122,155,277
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Alexander Connery,95.68,-125,-126,126,-150,150,-160,126,150,276
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's +109kg,Manuel Kimmons,160.94,120,-125,-128,140,146,155,120,155,275
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Brayden Edman,80.88,120,123,-125,148,152,-156,123,152,275
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Jeffy Li,80.96,120,123,-126,148,152,-157,123,152,275
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 81kg,Bryce Eberhardt,80.88,115,118,-123,142,146,155,118,155,273
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Kevin Sheehan,71.69,121,126,-131,146,-151,-153,126,146,272
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Morgan Rummel,72.98,120,-124,-126,152,-155,-155,120,152,272
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 89kg,Bryann Turner,88.15,110,-115,118,146,152,-157,118,152,270
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Christopher Hernandez,80.97,117,118,120,-150,150,-154,120,150,270
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Alexander Souvall,80.62,117,120,-122,145,150,-154,120,150,270
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,James Sayger,95.42,108,111,114,152,156,-159,114,156,270
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 81kg,Kevin Hill,79.65,114,119,122,142,147,-152,122,147,269
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group +102kg,Jaeden Capito,111.57,117,120,-123,144,-147,147,120,147,267
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) +109kg,Pablo Castillo,141.47,-112,112,117,150,-155,-160,117,150,267
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 109kg,Blake Foltz,108.01,113,-117,117,140,145,150,117,150,267
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Malaquias Coronado,86.17,114,118,-122,143,148,-152,118,148,266
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) +109kg,Ryan Hansen,110.62,-125,125,-130,140,-155,-160,125,140,265
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Andrew Raudabaugh,72.92,110,115,-118,140,145,150,115,150,265
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Javan Freyenberger,80.51,-118,118,-122,142,147,-150,118,147,265
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,Jacob Elder,83.4,113,117,120,-143,144,-148,120,144,264
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 109kg,Jeffrey Gerlach,106.72,107,110,113,143,148,151,113,151,264
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Ethan Bowen,72.58,-118,-118,118,146,-151,-152,118,146,264
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Justin Frimmel,96,110,-114,-115,145,150,153,110,153,263
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 102kg,Zachary Leach,101.09,108,112,115,140,147,-151,115,147,262
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Isaac Cruz,85.72,114,117,120,-140,-140,142,120,142,262
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 67kg,Logan Lockwood,66.47,110,113,116,143,146,-151,116,146,262
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Nathan Gonzaga,72.3,113,-116,-119,141,145,148,113,148,261
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 81kg,Christopher Douglas,76.09,110,113,116,135,138,140,116,140,256
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 67kg,Angel Quintero,66.12,-112,112,116,-137,-140,140,116,140,256
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 81kg,Marcus Sweet,79.77,100,105,110,137,-143,145,110,145,255
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 109kg,Chris Johnson,105.97,110,115,120,130,135,-141,120,135,255
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 96kg,Holton Lowrie,91.25,110,-114,116,-135,138,-140,116,138,254
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Rucker Johnson,79.81,110,115,-120,138,-143,-144,115,138,253
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Cameron Dowling,72.51,105,110,-116,138,143,-150,110,143,253
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Martin Glenn-Adams,72.66,112,-116,-116,138,-141,141,112,141,253
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 81kg,Robert Whitlock,79.93,110,113,-115,140,-145,-145,113,140,253
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 67kg,Evan Gehret,67,110,114,-117,137,-143,-143,114,137,251
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Romeo Thompson,72.26,113,120,-123,-130,-130,130,120,130,250
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Carter Sing,73,107,111,-115,138,-142,-143,111,138,249
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Roy  Maher,72.32,105,108,-110,137,141,-144,108,141,249
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Jacob Flores,72.86,103,106,-109,135,139,143,106,143,249
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 89kg,Kaden Quick,86.49,101,106,-111,-140,-140,140,106,140,246
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,Dominic Montoya,88.26,108,-111,-112,138,-142,-143,108,138,246
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Oscar Fernandez,95.75,105,-110,111,130,135,-140,111,135,246
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Eugene Shem,93.32,100,106,111,135,-140,-140,111,135,246
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Cory O'Connor,72.34,103,106,-109,132,137,140,106,140,246
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Ross Twanmoh,72.41,106,-110,110,-135,136,-140,110,136,246
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Bobby Hill,71.81,105,-110,110,135,-138,-138,110,135,245
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 89kg,Owen Jones,87.64,-104,105,110,132,135,-141,110,135,245
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 102kg,Christian  Figueroa ,99.82,97,101,105,127,133,140,105,140,245
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 67kg,John Ellison,67,107,110,-113,135,-140,-140,110,135,245
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Brendan Giddings,72.39,104,-108,110,134,-139,-141,110,134,244
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,cameron williams,85.65,106,109,112,128,132,-136,112,132,244
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Noah Ranno,72.88,107,-111,111,133,-137,-137,111,133,244
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 73kg,Jesse Vezina,72.76,110,-115,115,128,-135,-136,115,128,243
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 109kg,Daniel Brown,108.16,-102,102,-105,140,-143,-145,102,140,242
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Caitlin Thilges,140.61,92,97,100,133,-140,142,100,142,242
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Jason Ryu,72.44,101,105,-107,-133,133,137,105,137,242
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 89kg,Ciprian luna,84.82,103,106,-110,130,135,-140,106,135,241
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 96kg,Thomas Dubay,94.25,-112,-113,113,128,-136,-138,113,128,241
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 67kg,Christopher Camenares,63.89,102,106,-111,130,135,-140,106,135,241
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Joshua Claravall,72.57,100,-104,105,128,132,135,105,135,240
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 81kg,Aaron Denney,79.12,104,107,110,-128,130,-137,110,130,240
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group +102kg,Chase Dooley,120.78,85,92,98,-133,133,141,98,141,239
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 89kg,Jonathan Raymond,87.75,107,-111,-114,132,-135,-136,107,132,239
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Samuel Lind,71.33,-95,101,-105,131,135,138,101,138,239
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 67kg,Andre Sanchez,67.05,100,103,-106,130,135,-140,103,135,238
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Bryce Antonelli,71.95,98,102,-105,128,132,135,102,135,237
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Haston Hill,71.92,97,-103,-103,133,138,-143,97,138,235
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,Bryant Thomas,88.22,105,-108,-108,-130,130,-135,105,130,235
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 61kg,Quinn Kashishian,60.52,102,106,-110,123,128,-133,106,128,234
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Hunter Piasecki,71.22,100,-104,105,123,128,-132,105,128,233
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Rafael Oliver,88.1,103,-107,-111,130,-134,-135,103,130,233
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Daniel Marquez,66.34,-97,97,-103,130,135,-140,97,135,232
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 102kg,Frank Jimenez,101.86,98,102,106,120,-125,125,106,125,231
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 89kg,Tim Geiman,81.72,95,101,-104,125,-130,130,101,130,231
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Victoria Jefferson,82.18,94,97,100,122,126,131,100,131,231
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,Brian Hernandez,88.12,100,-103,103,-124,124,127,103,127,230
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 102kg,Geoffrey Martin,99.77,98,102,105,-125,-125,125,105,125,230
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Juliana Riotto,86.71,98,102,-105,124,128,-132,102,128,230
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Lily Turner,83.16,100,102,105,-120,122,125,105,125,230
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Eric Chen,72.58,95,100,-105,125,130,-135,100,130,230
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Connor Chan,72.61,-98,98,101,120,125,128,101,128,229
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Nicholas Deshaies,66.33,99,103,-106,117,121,125,103,125,228
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 81kg,David Cormier,80.55,98,-102,103,125,-130,-131,103,125,228
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,Nicholas Lee,87.45,100,-103,-103,-128,128,-131,100,128,228
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Brad Medley,95.49,-98,98,102,-125,126,-130,102,126,228
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 89kg,osagie iyamu,87.8,97,101,-106,120,127,-136,101,127,228
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 102kg,Jonathan Herrera,96.75,94,-100,102,120,126,-133,102,126,228
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Kellan Bulman,95.13,-99,-99,99,-126,-126,127,99,127,226
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Anna McElderry,80.98,-99,99,-103,122,127,-130,99,127,226
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 89kg,James Braun,82.84,93,96,-100,120,125,130,96,130,226
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,James Boesch,72.01,95,98,-103,123,127,-131,98,127,225
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 81kg,Victor Igtiben,78.95,100,-104,-105,125,-127,-127,100,125,225
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 89kg,Michael Burr,88.02,93,97,-100,123,128,-131,97,128,225
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Darci Molina,74.67,93,97,100,120,125,-130,100,125,225
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 81kg,Telesforo Dacanay,80.94,95,98,-101,126,-130,-130,98,126,224
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Henry Ludbrook,67,98,-102,-104,125,-131,-131,98,125,223
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Sebastian Stodel,65.99,93,-97,-98,-124,125,130,93,130,223
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Nathan Cohen,72.73,100,103,-106,120,-125,-125,103,120,223
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Damian Guzman,78.48,-102,-103,103,114,-119,120,103,120,223
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 89kg,Ryan Cunningham,87.81,94,-97,97,117,121,126,97,126,223
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group +102kg,Elijah Rivera,118.61,96,100,-105,-123,123,-127,100,123,223
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 81kg,Brian Leung,78.37,96,-99,99,117,120,123,99,123,222
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 67kg,Nahshon Paul,66.1,90,95,-102,120,125,-130,95,125,220
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Bryson Brown,61.57,90,94,-99,118,123,126,94,126,220
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Estelle Rohr,71,-94,95,-98,120,124,-128,95,124,219
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 67kg,Antonio Marcus,65.66,-94,96,-98,-120,122,-126,96,122,218
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Gabriel Couilloud,72.7,95,99,-102,116,119,-123,99,119,218
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 89kg,Eugene McDougall,88.82,-95,95,98,116,-119,120,98,120,218
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 61kg,Samuel Lewis,59.61,86,90,-93,117,123,127,90,127,217
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 96kg,Brandon Hocke,93.15,90,94,-100,118,-122,122,94,122,216
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 89kg,Evan  Kniss ,87.83,-93,-93,93,118,-123,123,93,123,216
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (55-59) 102kg,Steve Nicholls,101.09,100,-107,-107,-115,115,-121,100,115,215
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Rebecca Walker,98.93,90,-95,-98,118,122,125,90,125,215
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 61kg,Timothy Luistro,60.6,-100,-100,100,-115,115,-118,100,115,215
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 89kg,Jack Green,85.19,91,94,100,111,115,-118,100,115,215
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Antonino Micela,70.96,80,85,92,110,115,122,92,122,214
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 89kg,Shane Welter,87,-96,96,-100,113,118,-123,96,118,214
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,David Evans,80.1,-95,-100,101,112,-120,-120,101,112,213
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Jeremy Gillihan,79.58,93,-98,-98,120,-124,-124,93,120,213
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Thea Wall,78.83,93,97,-100,-110,112,116,97,116,213
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 67kg,Dryden Yates,66.6,94,97,-100,116,-120,0,97,116,213
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Marc Tumamak,72.78,-91,91,-94,114,117,121,91,121,212
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 61kg,Michael Tucciarone,60.58,84,88,92,110,115,120,92,120,212
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Jaime Inigo Flor,72.39,90,93,-95,-118,118,-122,93,118,211
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Jamelle Apolinar,119.86,82,86,90,-114,117,121,90,121,211
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Ava Biesterfeld,71,94,-97,-97,113,116,-118,94,116,210
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 96kg,Jason Bolton,92.78,94,-97,-97,116,-120,-120,94,116,210
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 67kg,Brad Baldwin,65.19,-94,95,-100,114,-118,-118,95,114,209
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 89kg,Robert Malkin,87.22,94,-97,-97,112,115,-118,94,115,209
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Jacob Howard,72.71,-90,90,-95,112,118,-124,90,118,208
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Harley Creech,80.86,-93,93,-96,110,115,-121,93,115,208
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Lane Stewart,78.27,90,94,-100,-113,-113,113,94,113,207
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Blake Dickison,77.51,81,85,-90,118,-121,121,85,121,206
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Nicole Caamano,69.71,94,-97,-97,112,-116,-117,94,112,206
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 89kg,James Dantoni,83.6,88,92,-96,-114,114,0,92,114,206
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Kristen Erickson,99.64,91,95,98,108,-112,-112,98,108,206
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 61kg,Kaiden Mima,60.84,88,91,94,112,-116,-121,94,112,206
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Shay Carlock,74.92,88,91,93,112,-115,-117,93,112,205
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Emma Hester,75.85,84,87,90,105,110,115,90,115,205
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 73kg,Sid Florendo,72.3,88,92,-95,109,-112,113,92,113,205
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Katelyn Curtis,107.02,-84,84,87,118,-123,-126,87,118,205
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Francesca Dooris,73.99,93,96,-99,-106,-107,108,96,108,204
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Megan Brasee,80.57,90,-93,-93,105,111,114,90,114,204
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Kailey Papas,67,85,90,93,105,110,-115,93,110,203
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 87kg,Kaylee Landa,84.28,89,92,94,-109,-109,109,94,109,203
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Allie Jarvis,70.55,90,93,-96,106,-109,110,93,110,203
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 81kg,Fred Macaraeg,80.19,85,-88,89,108,111,114,89,114,203
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 87kg,Laura Barito,85.04,84,87,90,106,110,113,90,113,203
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Gavin Beach,67.77,89,-92,94,108,-112,-115,94,108,202
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Bryn Odberg,62.25,85,88,91,108,111,-114,91,111,202
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) +87kg,Kimberlee Douglas,139.76,84,-88,-88,113,118,-121,84,118,202
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 67kg,Desmond Myles,65.67,85,90,-95,108,112,-116,90,112,202
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 76kg,Grace Montgomery,75,-85,85,89,107,-112,112,89,112,201
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Christopher  MCDONALD,70.65,84,-91,91,104,-109,109,91,109,200
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Madeline Staniszewski,58.51,87,90,-92,110,-114,-115,90,110,200
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Shelby Pflug,64,84,87,-90,105,108,113,87,113,200
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Leah Smith,68.52,75,80,85,103,108,115,85,115,200
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Deanna McGillivray,97.69,82,85,88,105,109,112,88,112,200
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Victoria Fries,70.87,85,-88,-88,107,111,114,85,114,199
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 73kg,Josh Purcell,71.85,85,89,-92,105,107,110,89,110,199
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Alex Rose,72.49,-91,93,-95,100,105,-110,93,105,198
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 76kg,Kat Carter,71.28,80,83,86,108,112,-116,86,112,198
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Erin Amos,71,87,-90,-92,107,111,-115,87,111,198
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Julia Ryan,85.15,86,89,-91,-106,106,109,89,109,198
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,LeKiesha White,97.11,82,-86,86,112,-117,-118,86,112,198
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Jamie Hegg,62.99,78,-82,82,109,112,114,82,114,196
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Alexandria Fillmore,84.95,88,91,-94,101,-105,105,91,105,196
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Kelsey Koontz,86.58,86,89,-91,107,-110,-115,89,107,196
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's +87kg,Madison Atwood,100.42,-82,82,-85,113,-116,-116,82,113,195
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 73kg,Andrew Robinson,71.73,83,85,87,108,-111,-113,87,108,195
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Deborah Doran,74.97,80,84,-87,108,111,-114,84,111,195
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 96kg,Christopher Gregg,96,85,-88,88,-107,-107,107,88,107,195
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's +87kg,Lexi Thomas,98.57,73,77,83,105,-110,111,83,111,194
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Nairobi Romero,70.6,80,82,84,-110,110,-114,84,110,194
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Emily Kessler-Lewis,85.78,85,88,-90,-106,106,-109,88,106,194
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 61kg,Sebastian Rose,60.4,-83,83,-86,104,106,111,83,111,194
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Kason Luu,65.2,76,79,82,104,108,111,82,111,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Tiffany Roberts,63.11,83,86,90,103,-107,-108,90,103,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Brianna Chu,75.52,-83,83,-89,105,110,-114,83,110,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Heather Mentone,72.14,81,85,-87,101,105,108,85,108,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 73kg,Derrick Lee,72.56,-84,-84,85,100,-105,108,85,108,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Christine Yee,77.71,82,85,87,106,-109,-110,87,106,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 73kg,Reginald Mays,72.03,85,88,93,-100,100,-105,93,100,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 89kg,david tundel,88.71,82,85,-87,105,108,-111,85,108,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 89kg,Greg Karas,87.71,80,83,-85,104,108,110,83,110,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 76kg,Robin Leafblad,74.79,78,82,84,104,-108,109,84,109,193
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Harrison Phelps,66.53,-86,-86,86,106,-111,-111,86,106,192
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Marina Tuono,69.86,-83,83,86,-105,-106,106,86,106,192
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Emily Boyich,78.76,83,-86,-87,-107,-107,109,83,109,192
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Laura Cochran,63.56,79,85,-89,101,-105,106,85,106,191
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 81kg,Jurgen Martens,80.9,82,85,88,103,-107,-110,88,103,191
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Sydney Collins,79.84,85,-88,-88,102,106,-109,85,106,191
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (55-59) 96kg,Troy Stange,94.04,85,-90,-94,100,106,-112,85,106,191
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Jenna McClain,86.18,76,80,-84,106,111,-115,80,111,191
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Jessica Tatman,63.57,79,82,85,98,102,105,85,105,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 67kg,Eric Siegel,66.13,82,-84,-84,108,-111,-111,82,108,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Ashlie Pankonin,75.17,79,-82,82,104,108,-112,82,108,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 67kg,Tony Lau,66.39,81,83,-87,101,107,-117,83,107,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Haley McDaniel,86.06,83,85,-87,101,105,-107,85,105,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Trisha Mank,106.52,74,77,79,-108,111,-116,79,111,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Rachel Brindley,119.78,80,-83,-84,110,-113,-113,80,110,190
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 76kg,Ruby Shepard,76,82,-85,-85,107,-110,-114,82,107,189
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Melody Adair,70.76,-84,84,-87,101,105,-109,84,105,189
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Danielle Abusow,69.41,-80,80,83,103,-106,106,83,106,189
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 73kg,Scott Gonzalez,72.66,86,-89,90,99,-102,-102,90,99,189
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Carly Lansley,120,84,-87,-88,102,-105,105,84,105,189
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group +89kg,Asher Fountain,91.84,78,83,86,90,98,103,86,103,189
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 67kg,Shamil Parbhoo,64.87,81,84,-86,104,-108,-110,84,104,188
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Rachael Skinner,69.28,82,85,87,101,-103,-104,87,101,188
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Gretchen Stolte,68.35,79,82,85,99,103,-106,85,103,188
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Rebecca Dublin,109.64,78,-81,-81,110,-114,-116,78,110,188
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 73kg,Spencer Davern,71.8,78,-82,83,-100,100,105,83,105,188
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 61kg,William Drake,58.87,80,83,-86,95,100,105,83,105,188
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Flynn King,66.28,84,-87,-87,97,100,103,84,103,187
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Tiffany Beaupré,58.3,-80,80,-83,104,107,-110,80,107,187
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 73kg,Josue Castaneda Pisano,72.14,-84,84,87,97,100,-105,87,100,187
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Megan Kudrick,79.7,-84,85,-88,102,-107,-108,85,102,187
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) +87kg,Sarah Tyler,96.66,79,82,85,98,102,-105,85,102,187
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 76kg,Ella Bays,75.14,78,82,-85,98,99,105,82,105,187
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Anna Rucker,60.29,-78,78,-82,104,108,-111,78,108,186
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Leigh-Ann Trepanier,59,78,-81,-82,100,104,108,78,108,186
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Melissa Salazar,70.87,78,81,84,98,-101,102,84,102,186
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 87kg,Marion Meunier,81.63,-83,83,-87,-103,103,-108,83,103,186
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group +73kg,Walker Stanley,107.23,74,77,80,103,106,-108,80,106,186
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,Brooke Buzzell,70.52,79,-82,82,100,104,-108,82,104,186
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,Angelina Dabney,57.19,81,-84,-85,100,-103,104,81,104,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Erica Sheagley,62.49,-75,75,80,100,105,-110,80,105,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Analise Kirby,74.53,74,77,80,98,102,105,80,105,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,M. Claire Akin,74.23,74,-79,79,106,-110,-113,79,106,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Stefani Warnick,80.47,83,86,-88,95,-99,99,86,99,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Sarah Kajdasz,78.77,80,-84,-84,105,-109,-109,80,105,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 55kg,Lourence Cabantog,55,78,82,-87,99,103,-107,82,103,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's +87kg,Jamie Pearce,93.58,73,77,80,95,100,105,80,105,185
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Makiyah  Nickerson,63.87,84,-88,-88,-100,100,-107,84,100,184
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Madison Johnston,62.97,81,-84,-86,-100,100,103,81,103,184
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 89kg,Armando Ordonez,87.64,75,80,84,95,100,-106,84,100,184
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Kaia Jacobs,104.18,78,-81,81,98,-102,103,81,103,184
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 55kg,Jagarii Gardner,54.01,75,78,-81,95,101,106,78,106,184
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,Quinn Corcoran,72.18,83,-87,-88,100,-105,-107,83,100,183
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Stephanie Ross,58.74,74,77,80,-102,103,-108,80,103,183
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Carly Best,80.5,75,78,-81,100,105,-110,78,105,183
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 89kg,freddie villanueva,86.63,83,-86,86,97,-100,-101,86,97,183
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,Issi Massei Agrait Calo,58.57,79,-83,-83,98,101,103,79,103,182
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Laura Caggiano,59,81,-84,-84,98,101,-104,81,101,182
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 67kg,Jonathan Willmoth,65.92,-80,80,82,98,-100,100,82,100,182
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group +81kg,Aleah Baron,118.07,70,-74,74,100,105,108,74,108,182
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Kimberly Wiese,62.94,-80,-80,80,94,97,101,80,101,181
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Mariah merkle,66.9,75,78,81,97,100,-102,81,100,181
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Kayli Kullos,70.82,78,-81,81,100,-104,-105,81,100,181
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Brianna Leverenz,63.43,79,-81,81,99,-102,-102,81,99,180
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 87kg,Tristain Atwood,85.71,74,-76,-78,100,103,106,74,106,180
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Karlie Zumbro,73.89,74,78,81,95,99,-102,81,99,180
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (50-54) 81kg,Darren Scott,79,71,74,-78,106,-110,-111,74,106,180
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (55-59) 102kg,Charles Janicki,97.33,75,80,-83,90,95,100,80,100,180
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,McKenzie Hatcher,69.94,76,80,85,91,95,-99,85,95,180
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Amanda  Feist ,74.95,77,-80,81,-94,95,98,81,98,179
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,MATTIE FLICKINGER,75.8,77,-80,-82,97,102,-107,77,102,179
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Carley Graham,80.75,71,78,81,-98,-98,98,81,98,179
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 67kg,Preston Sparks,62.06,79,82,-85,93,95,97,82,97,179
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Georgia Cameron,58.82,74,77,-80,98,101,-104,77,101,178
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Lisa Ho,63.21,77,80,-83,98,-102,-103,80,98,178
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Alexis Wolfe,66.3,-76,76,80,95,98,-100,80,98,178
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 81kg,Douglas Desatnik,79.53,65,75,83,95,-105,-107,83,95,178
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Kinsley Rodden,126.61,76,80,82,96,-100,-103,82,96,178
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group +81kg,Ansley Amore,98.26,74,77,80,91,94,98,80,98,178
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Isaiah Cunningham,63.5,70,74,78,-95,95,99,78,99,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,emma sabini,63.35,73,-77,-77,96,100,104,73,104,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Brittany Panerali,63.28,74,-77,79,95,98,-100,79,98,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Morgan Beattie,61.78,78,81,84,93,-98,-98,84,93,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Alisha Thresher,75.68,74,77,80,-95,97,-100,80,97,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Carly Puzacke,72.68,76,-78,79,-97,98,-101,79,98,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Jessica Bachkora,74.66,80,-84,-84,97,-99,-100,80,97,177
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Ivy Gunn,69.42,76,78,-82,93,95,98,78,98,176
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 81kg,Catessa Guadagnoli,76.68,74,78,80,93,96,-100,80,96,176
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Alexis Boutchie,70.43,73,77,81,91,-95,95,81,95,176
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Faith Cooke,79.54,68,73,75,96,99,101,75,101,176
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (55-59) 81kg,Gary Alinea,80,78,80,84,-92,92,-94,84,92,176
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 81kg,Keegan McHale,73.35,71,-75,-76,101,105,-108,71,105,176
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Lauren DeLong,58.54,73,-76,-77,98,-101,102,73,102,175
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Gracy Johnson,69.13,72,76,80,86,91,95,80,95,175
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Emily Shih,75.77,72,75,78,94,97,-100,78,97,175
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (60-64) 81kg,Kent Neuerburg,79.23,70,73,-76,98,102,-106,73,102,175
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Eve Goldsher,61.54,82,-86,-86,92,-96,-96,82,92,174
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Charis Chan,60.92,-79,-79,79,93,95,-97,79,95,174
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Ava Giorgi,63.96,75,78,80,90,93,-96,80,93,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Yuliana Lopez,64,73,-76,-76,-100,100,-106,73,100,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Brena Andrews,63.77,75,78,-81,95,-98,-100,78,95,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,anna maguire,63.62,74,77,-80,93,-96,96,77,96,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Alicia DiSpaltro,62.42,77,-80,80,93,-97,-97,80,93,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Joelle Emery,59,-78,78,-83,95,-100,-101,78,95,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Nyah Namisnak,69.52,-78,78,81,88,-91,92,81,92,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Christine Reilly,58.59,75,-78,-78,-98,-98,98,75,98,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 61kg,Santos Torres,59.82,-75,75,-79,-95,95,98,75,98,173
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Alice McBroom,53.72,71,74,77,90,-95,95,77,95,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Rachel Clemmer,63.61,73,76,-78,91,94,96,76,96,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Megan Munsell,70.43,-73,73,75,93,-95,97,75,97,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Karisa Rossman,70.84,76,79,-81,93,-96,-96,79,93,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Carlyn Winston,74.08,73,76,-79,92,96,-99,76,96,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 76kg,Chelsea Nieves,74.67,-78,78,-81,94,-98,-98,78,94,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Olivia Piacentini,79.74,71,74,-77,89,94,98,74,98,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Amanda Roberts,97.2,68,72,-76,100,-106,0,72,100,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) +87kg,Sarah Campos,107.79,69,72,75,93,97,-100,75,97,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 81kg,Amy Hovan,77.79,73,76,79,90,93,-96,79,93,172
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 55kg,Jaycee Mann,53.7,75,-77,78,90,93,-95,78,93,171
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Claire Vahary,59,-74,-74,74,94,97,-100,74,97,171
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Ava Oteri,63.67,70,-73,74,93,97,-100,74,97,171
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,Allison Rebustillo,68.36,-71,71,75,96,-107,-107,75,96,171
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Mikerline  Apollon,58.51,69,73,76,-94,94,-97,76,94,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Jasmine He,59,-69,70,73,89,93,97,73,97,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Samantha Ellison,63.93,71,74,-77,92,96,-100,74,96,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 61kg,Daniel Louie,60.14,75,-80,-82,95,-100,-100,75,95,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Talley Halvorson,69.27,75,-78,-80,95,-99,-102,75,95,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Jennifer Gerasimos,79.2,-72,72,-75,90,94,98,72,98,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 64kg,Chassity Del Balso,64,70,-72,72,91,-96,98,72,98,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Kristin Roskowick,80.07,71,74,-77,92,96,-100,74,96,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Autumn Sands,64,72,75,77,-89,90,93,77,93,170
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,Alexa  Estevez ,58.22,73,-77,-78,87,92,96,73,96,169
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Kha-Nhu Lam,62.47,74,-77,-77,-95,-95,95,74,95,169
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,LISA BAETE,66.14,70,74,76,86,-91,93,76,93,169
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 61kg,Jayden Whittaker,59.89,67,71,-73,88,93,98,71,98,169
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 67kg,Rowdy Cearley,66.73,69,72,75,89,93,-97,75,93,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,danila tuazon,59,74,78,-81,90,-94,-95,78,90,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Jeanna Onishi,63.98,74,-77,-77,94,-97,-98,74,94,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Hayley Bell,70.25,75,-78,-78,93,-96,-96,75,93,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Alexis Danchak,70.49,68,-72,-74,92,96,100,68,100,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Tracy Chase,65.93,75,78,-81,87,90,-93,78,90,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (55-59) 73kg,Kevin Dittler,72.95,-78,78,-84,90,-96,-96,78,90,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 87kg,Elyssabeth Beers,85.22,73,76,-78,87,90,92,76,92,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 87kg,Beth Whaley,87,70,73,-77,95,-100,-102,73,95,168
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Kimberly Andrew,74.4,72,75,77,88,90,-94,77,90,167
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Jennifer Houghton,92.43,68,72,75,85,89,92,75,92,167
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 71kg,Gianna Van Hofwegen,66.07,-70,70,73,88,91,94,73,94,167
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Juliet Aguilar,63.94,-74,-74,74,-92,92,-96,74,92,166
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,norelle justice,61.47,71,74,-76,85,89,92,74,92,166
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Emma Heck,62.79,73,-77,-77,93,-97,-97,73,93,166
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Kaziah Jones,54.5,-74,74,77,88,-91,-93,77,88,165
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Angela Gallegos,54.75,65,-70,70,90,-93,95,70,95,165
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Elouise Schultz,62.68,66,69,72,85,89,93,72,93,165
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Hayden Mentzer,71,64,67,70,88,-92,95,70,95,165
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 81kg,Rubie Dobbins,77.76,67,71,-77,87,94,-96,71,94,165
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 49kg,Kaylin White,48.63,-68,68,70,90,-94,94,70,94,164
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Katherine Lee,54.48,70,73,76,82,85,88,76,88,164
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Ana Kelly,59,71,-73,-73,90,93,-95,71,93,164
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) +87kg,Chelsea Hopkins,107.02,61,66,69,89,92,95,69,95,164
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Jessica Rodriguez,57.97,70,-72,72,91,-94,-94,72,91,163
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Lauryn Ginsburg,69.84,-68,69,72,88,91,-94,72,91,163
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Lindsay Perrizo,74.57,70,73,-75,85,-89,90,73,90,163
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) +87kg,Anna martin,104.16,67,-70,70,89,91,93,70,93,163
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 61kg,Cody Anderson,59.02,65,68,-72,90,95,-102,68,95,163
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 76kg,Hayden Brandon,75.17,69,72,-75,-88,90,-94,72,90,162
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Elise Caron,63.51,65,68,71,85,88,91,71,91,162
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Sara Donis,70.64,69,-72,-74,-92,-93,93,69,93,162
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (60-64) 89kg,Stephen Powell,87.62,73,75,-77,87,-90,-91,75,87,162
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 55kg,Derick Puff,55,70,73,75,-80,80,86,75,86,161
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Tanya LaBell,58.72,67,70,-73,91,-94,-96,70,91,161
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Naoko Miyamoto,73.52,65,68,71,87,90,-92,71,90,161
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Amanda Cann,86.36,66,70,74,82,87,-90,74,87,161
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 73kg,Nathanael Maher,71.93,69,72,-75,85,89,-94,72,89,161
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Alexa  Woodman ,62.89,65,68,70,85,88,90,70,90,160
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Katherine Brown,70.58,67,70,-72,87,88,90,70,90,160
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,Jordan Nantz,57.43,70,-72,72,84,87,-90,72,87,159
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Melinda Golden,61.79,70,-72,-73,-88,88,-93,70,88,158
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,Alyssa Jordan,59,67,69,-71,82,86,88,69,88,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Courtney Hanson,79.79,68,-72,72,85,-88,-90,72,85,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Eunice Rho,89.6,66,68,-71,89,-92,-93,68,89,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Samantha Chucka,107.66,-67,67,-70,85,-88,90,67,90,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Brynn Catalano,53.83,67,70,72,80,85,-88,72,85,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Amy Tunis,82.8,69,72,-75,85,-88,-89,72,85,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Isabella Wray,96.47,64,66,68,82,85,89,68,89,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Jessica Walters,68.18,67,69,-72,85,88,-90,69,88,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Allie Nichols,63.51,64,67,69,85,-88,88,69,88,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 55kg,Andrew Weymer,50.63,65,67,70,82,85,87,70,87,157
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Victoria Carter,70.73,68,-70,70,86,-88,-89,70,86,156
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 64kg,Julie Bachman,63.35,67,69,-71,81,84,87,69,87,156
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Selena Cearley,76,67,69,-71,82,-85,87,69,87,156
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Monica Parucho,58.88,65,-69,-69,86,90,-93,65,90,155
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Desirae Lyall,70.52,63,-66,-68,86,89,92,63,92,155
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Stephanie Rosario,73.46,63,66,69,82,86,-91,69,86,155
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Julie Felix,78.79,65,68,-70,85,87,-90,68,87,155
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Eva Windsor,102.44,65,70,-75,85,-90,-93,70,85,155
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 67kg,Matias Navarrete,65.7,-65,65,70,80,85,-91,70,85,155
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 71kg,Nina Pollack,70.05,63,67,71,83,-87,-89,71,83,154
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Ashley Dvorin,58.4,72,-75,-75,-82,82,-85,72,82,154
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Cherisse Taylor,75.63,70,-72,-72,80,-83,84,70,84,154
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Sarah Welsh,78.88,58,60,63,86,-89,91,63,91,154
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Eleanor Cler,107.2,-65,65,68,83,86,-89,68,86,154
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Jenny Hwa,54.84,64,-68,68,-82,82,85,68,85,153
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Taylor Hedke,60.83,63,-67,-67,82,86,90,63,90,153
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Katherine Cirone,74.2,65,-68,-69,85,88,-92,65,88,153
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 64kg,Keilana Brewer,61.57,-65,65,68,79,82,85,68,85,153
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 49kg,Rachel Conaway,49,-65,66,-69,83,-86,86,66,86,152
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Jasmine Suguitan,70.69,65,69,-72,83,-87,-89,69,83,152
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,maria shesiuk,74.46,62,65,-68,83,87,-92,65,87,152
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Catharine Messersmith,80,64,70,-73,77,80,82,70,82,152
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Emily Green,63.08,65,-67,68,80,84,-86,68,84,152
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 81kg,Brenda Espinoza,78.84,62,64,-67,82,85,88,64,88,152
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,DanaMarie Movsessian,69.79,-67,67,69,82,-85,-85,69,82,151
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 45kg,Virginie Beljour,45,60,63,65,81,85,-89,65,85,150
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Jennifer Miller,79.51,65,-67,67,80,83,-86,67,83,150
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) +87kg,Marjorie Gottier,134.25,65,69,-72,77,81,-85,69,81,150
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 49kg,Lucy Lapane,48.1,64,-66,66,80,83,-86,66,83,149
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Crystal Ball,69.98,-61,62,-65,81,84,87,62,87,149
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 64kg,Kat Bogers,63.54,66,-70,-71,79,83,-87,66,83,149
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,Wynter Montgomery,66.59,57,60,65,78,81,84,65,84,149
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Makayla Cogan,54.97,66,68,-70,77,80,-82,68,80,148
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Lindsey Knight,54.68,60,63,65,80,83,-86,65,83,148
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (60-64) 89kg,William McClure,86.51,-57,58,60,80,85,88,60,88,148
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 61kg,Jackson Crane,59.04,64,-68,-68,84,-88,-88,64,84,148
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Christa Degidio ,54.01,-62,62,65,82,-85,-85,65,82,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Abby Boon,91.32,65,68,-70,75,79,-82,68,79,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Amy West,68.68,57,-60,61,78,83,86,61,86,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Kristina Mohn,69.66,60,63,68,74,79,-87,68,79,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 59kg,Mahealani Mason,58.07,65,67,-70,80,-85,-85,67,80,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,madeline francescone,52.85,64,-66,-66,79,-82,83,64,83,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 87kg,Paula Habel,86.23,59,62,-65,78,82,85,62,85,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,Samantha Goodman,64.29,60,-63,64,77,80,83,64,83,147
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,Lindsey Yeom,57.85,-66,66,-69,80,-85,-85,66,80,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Chelsea Rebholz,67.68,-67,67,-70,79,-82,-82,67,79,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Elizabeth Hernandez,98.84,61,64,67,65,76,79,67,79,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 64kg,Kristin Maselli,63.58,-62,62,-65,78,81,84,62,84,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Daisy May Gutierrez,68.28,61,64,-66,78,82,-86,64,82,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Ayah Muhammad,57.77,59,62,65,75,78,81,65,81,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) +87kg,Megan Mathias,102.81,63,-65,65,78,-81,81,65,81,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 73kg,Erubey Garcia,73,60,63,65,75,-81,81,65,81,146
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 55kg,Jessica Gianardi,54.26,60,-63,-63,85,-88,-88,60,85,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 64kg,Carli Houston,61.6,65,-67,-67,80,-83,-83,65,80,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Talia Waugh,57.66,60,63,65,-80,80,-83,65,80,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Natalie Smith,80.35,64,-67,68,77,-81,-82,68,77,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Rebecca Murdoch,79.76,60,63,-66,-77,79,82,63,82,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Colleen Maring,57.24,60,63,-65,78,-81,82,63,82,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Rachel Reiboldt,80.3,64,-67,-67,81,-84,-85,64,81,145
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 49kg,Laney Yost,48.9,63,-65,-65,81,-83,-85,63,81,144
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 45kg,Gretchen Villa,44.78,61,64,-66,80,-83,-84,64,80,144
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 59kg,Kareema Salah,58.26,61,64,-67,80,-85,-85,64,80,144
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 64kg,Flo Ursua,62.13,58,-60,62,79,82,-85,62,82,144
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) +87kg,Delores Hill,99.7,62,-65,-66,77,-80,82,62,82,144
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 81kg,Nevaeh Kellerman,79.58,58,62,65,75,79,-83,65,79,144
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 55kg,Madi Muse,54.82,-62,62,-65,81,-83,-83,62,81,143
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Olga Krzyszton,76.74,60,62,-64,79,81,-83,62,81,143
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Kathryn Flores,74.49,62,-65,-65,78,81,-84,62,81,143
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Urbana Sepulveda,85.59,60,-63,-63,80,83,-85,60,83,143
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Natalie Jean Vezina,58.35,56,59,61,78,-81,81,61,81,142
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Lindsey  Kujawski,58.8,59,62,64,78,-81,-83,64,78,142
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Julie Mizak,65.41,61,-64,-65,-80,81,-84,61,81,142
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Heather Zrebiec,67.22,-62,62,-65,80,-84,-85,62,80,142
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Lisa Bagby,83.54,-50,50,53,83,86,89,53,89,142
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 76kg,Ava Jackson,75.84,58,62,-65,75,80,-83,62,80,142
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Kathleen Marquez,72.15,58,60,62,73,76,79,62,79,141
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Jessica Cummings,66.93,-68,68,-70,73,-75,-75,68,73,141
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 61kg,Ashton McAllister,57.28,58,60,-63,75,78,81,60,81,141
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 87kg,Erin Mena,84.15,60,-63,-64,-80,80,-85,60,80,140
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 87kg,Marissa Sterrett,84.63,59,-61,-61,79,-81,81,59,81,140
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 49kg,Amelia Phillips,48.78,58,60,62,77,-80,-81,62,77,139
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Maryam Grafton,54.69,58,-61,61,75,78,-80,61,78,139
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Eleanor Otis,59,60,63,-66,68,72,76,63,76,139
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 76kg,Addison Bell,72.01,60,-63,63,73,76,-79,63,76,139
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 76kg,Penelope Desjardins,71.47,57,60,-63,-79,-79,79,60,79,139
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 55kg,Caitlyn Ogami,54.5,-60,60,-63,78,-81,-82,60,78,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 49kg,Aria Zayed,48.54,61,-63,-63,73,75,77,61,77,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Amanda Williams,51.71,56,59,62,73,76,-79,62,76,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Samantha Love,64,59,61,63,73,-75,75,63,75,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Bethany Farrar,78.69,57,-59,-60,75,78,81,57,81,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 71kg,Chloe Desjardins,68.79,58,61,64,68,71,74,64,74,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Alexandra Hibbs,61.43,60,63,-66,72,75,-79,63,75,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Melina Rivera,64,57,60,-63,75,78,-81,60,78,138
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 49kg,Lisa Guadagnolo,49,57,60,-62,74,-77,77,60,77,137
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Kelly Nichols,63.19,57,59,61,-72,73,76,61,76,137
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 61kg,Ezekiel Macias,58.59,57,60,-63,70,74,77,60,77,137
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 14-15 Age Group 61kg,liam gargan,60.55,55,-58,58,73,76,79,58,79,137
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 49kg,Reagan Best,48.94,-58,58,60,72,-76,76,60,76,136
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Ashley Helton,69.68,61,-64,-65,71,75,-78,61,75,136
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Libby Elias,58.42,60,62,-65,70,74,-77,62,74,136
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 49kg,Diego Cordero,48.41,58,-60,-60,70,-75,78,58,78,136
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Elaine Tsay,53.57,58,-61,-62,74,77,-81,58,77,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Natalie Jonsson,58.77,58,-60,60,70,75,-78,60,75,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Kristin Curd,57.3,54,57,60,75,-79,-80,60,75,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 71kg,Alyssa Hines,70.33,59,-62,62,70,73,-75,62,73,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Colleen Moon,78.71,50,53,55,75,78,80,55,80,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Bristol Dixon,80.68,55,58,61,70,74,-78,61,74,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Natalia  Frumker ,57.45,-55,58,-62,69,74,77,58,77,135
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 49kg,Nile Franklin,48.13,57,-60,61,-73,73,-75,61,73,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Kendele Miyasaki,57.78,55,58,61,69,73,-76,61,73,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Eun jung Koh,67.54,58,-60,60,70,72,74,60,74,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Brigitte Bieyro,74.79,58,60,-62,70,72,74,60,74,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 71kg,Stevie Majoros,67.51,54,57,-60,74,77,-80,57,77,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 64kg,Crysta Parkin,59.88,56,58,-60,73,76,-80,58,76,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,Marianna  Marchese,54.04,55,58,-61,68,72,76,58,76,134
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Emily Lau,54.72,53,55,57,69,72,76,57,76,133
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Amanda York,62.56,58,61,-64,65,69,72,61,72,133
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 87kg,Christina Lam,84.18,55,-58,-58,73,75,78,55,78,133
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Jen Segadelli,83.9,-57,57,-62,73,76,-79,57,76,133
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group +73kg,Ryan  Murphy,142.82,50,-53,53,70,75,80,53,80,133
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,Anastasia  Jimenez,69.6,-57,-57,57,-73,73,76,57,76,133
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,brittany venzke,74.92,53,55,57,71,73,75,57,75,132
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Sarah Sarff,96.64,60,-63,-64,68,72,-76,60,72,132
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Emily Hubbard,82.72,58,-62,-62,70,-73,74,58,74,132
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 64kg,A. Isabelle Miller,63.62,56,-59,61,67,71,-75,61,71,132
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Addison Ruocco,58.02,54,-57,-57,75,78,-81,54,78,132
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 64kg,Shannalyn West,63.81,-58,-58,59,69,-71,72,59,72,131
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Brynli McBride,63.79,55,-58,58,-71,73,-76,58,73,131
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 71kg,Mya Lagares Cascio,68.37,53,-56,56,-75,75,-78,56,75,131
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 76kg,Vicki Piper,75.75,56,59,61,70,-75,-75,61,70,131
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 49kg,Jacqueline Viola Moulton ,49,57,59,-61,71,-74,0,59,71,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Martha Crain,68.5,55,-57,-58,70,72,75,55,75,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Derien Pratt,72.57,53,56,-58,71,74,-77,56,74,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (65-69) 89kg,Douglas Herder,88.01,50,55,-58,70,75,-78,55,75,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 45kg,Jaedyn Orton,45,54,58,-61,72,-76,-76,58,72,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Kathleen Hafeli,69.98,58,61,-64,69,-72,-72,61,69,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 87kg,Elizabeth Korchnak,82.47,54,57,-60,70,73,-75,57,73,130
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,Jayleen Sanchez,54.72,53,-55,56,67,70,73,56,73,129
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 49kg,Amanda Serapiglia,48.91,57,-60,-60,71,-74,-74,57,71,128
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Jessica Heberlein,74.75,51,53,-55,72,75,-77,53,75,128
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Erica Blanton,70.49,56,58,-60,70,-73,-74,58,70,128
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Rebekah Horn,67.65,57,60,-63,68,-72,-73,60,68,128
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) +87kg,Natasha Wunderlich,103.81,50,53,-57,70,-75,75,53,75,128
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 76kg,Peyton Gunn,73.38,-57,57,60,68,-70,-70,60,68,128
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Anne Core,63.18,52,56,-58,71,-73,0,56,71,127
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Ashley Cronin,61.76,49,-52,52,70,-74,75,52,75,127
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Kathryn North,75.67,54,57,-60,66,-69,70,57,70,127
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Ashley Yates,73.87,55,57,-60,70,-73,-75,57,70,127
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 76kg,Lisa Talcott,75.99,55,58,62,-64,-64,65,62,65,127
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Karisa Hoke ,62.43,53,-56,-56,70,73,-76,53,73,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Casandra Krier,68.46,50,53,-55,67,70,73,53,73,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (80+) 81kg,glenn shull,75.66,53,55,57,65,67,69,57,69,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 64kg,Courtney Ihlenfeld,63.51,55,-57,-57,65,68,71,55,71,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Kaydence  Moss,98.66,50,53,56,70,-75,-76,56,70,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) +87kg,Diana Thorne,113.55,51,-53,53,70,73,-76,53,73,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Jessica King,65.41,52,55,-57,68,71,-74,55,71,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 81kg,Nadine Jones,80.85,49,54,-57,62,67,72,54,72,126
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Tara Mann,62.81,59,61,-63,-64,64,-66,61,64,125
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Ellen Lehman,54.44,53,56,59,63,66,-70,59,66,125
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 59kg,Vanessa Cabantog,59,57,-59,-60,65,-68,68,57,68,125
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 55kg,Lauren Storck,52.8,48,51,53,65,68,71,53,71,124
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Samantha Artiga,69.07,54,56,58,63,66,-69,58,66,124
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 71kg,Christine Moore,67.33,52,55,57,64,67,-69,57,67,124
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 49kg,Piper Jones,48.42,52,54,-57,-69,69,-72,54,69,123
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Meghan Campion,79.88,53,-56,-57,65,-70,70,53,70,123
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 49kg,Zoey Morelli,48.28,53,-56,57,63,66,-70,57,66,123
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Anne Powell,70.04,50,53,55,65,68,-71,55,68,123
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 81kg,Jennifer Valosek,79.59,52,-55,-57,66,69,71,52,71,123
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 87kg,Vladislava Davydova,82.15,55,-58,-58,64,67,-70,55,67,122
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 64kg,Stacy Harrison,63.32,-53,53,55,-64,64,67,55,67,122
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) +87kg,Tracy Harris,98.87,-50,50,-53,72,-75,-75,50,72,122
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 49kg,Reagan Herchold,49,52,55,-57,-65,66,-70,55,66,121
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 49kg,Kaya Malia Henn,47.87,49,52,54,63,-66,66,54,66,120
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 76kg,Abigail Wunderlich,72.15,50,-53,54,61,66,-68,54,66,120
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 76kg,Madeleine Maher,73.99,50,52,-54,-65,65,68,52,68,120
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 71kg,Payton Kramer,66.84,50,-53,53,62,66,-70,53,66,119
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,Angie Cornejo,79.33,48,52,-55,58,62,67,52,67,119
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Michaela Flaherty,63.31,49,52,-55,63,66,-68,52,66,118
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 49kg,Noelle Sallaz,47.72,49,52,-54,62,64,66,52,66,118
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 76kg,Jamie Ancewicz,74.01,50,-53,-54,65,68,-70,50,68,118
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 64kg,Delaney Brown,61.93,50,-52,52,60,63,66,52,66,118
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (70-74) 81kg,Alvin Matthews,80.41,48,50,52,-60,60,65,52,65,117
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 64kg,Janetta Lavender,62.88,47,50,52,-62,62,65,52,65,117
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Rachel Jackson,69.1,44,47,-50,63,67,70,47,70,117
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Christabel Lily Graton,57.77,-52,54,-56,63,-66,-69,54,63,117
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Gwendolyn Montgomery,70.94,55,57,-59,56,58,60,57,60,117
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Lindsey Moynihan,61.75,-46,-47,47,-66,66,69,47,69,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Amber Lavigne-Bulman,75.34,45,48,-51,64,68,-70,48,68,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 55kg,Karen Agena,55,47,-49,49,65,67,-69,49,67,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Maya Litt,51.94,-49,-49,49,64,67,-70,49,67,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 64kg,Nicoly Dos santos,60.82,44,-47,50,57,61,66,50,66,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 49kg,Heather Thrush,47.85,49,52,-55,61,64,-67,52,64,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Jane Levy,58.65,45,47,49,63,-67,67,49,67,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Kelly Burrows,70.52,50,-52,-52,-66,66,-69,50,66,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 76kg,Heather Krause,74.26,50,-52,53,60,63,-65,53,63,116
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Ashley Burnell,68.72,50,51,-53,62,64,-66,51,64,115
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Rebecca Chow,59,-51,-51,51,64,-67,-67,51,64,115
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 64kg,Dahlia Sokolow,62.6,48,51,-54,61,64,-68,51,64,115
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Alyson Weidmann,53.99,46,48,50,62,64,-69,50,64,114
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 59kg,Sunrise de la Cruz,58.85,45,48,-51,63,66,-69,48,66,114
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,ALEXANDRIA Zikoyanis,58.45,-47,48,50,61,63,-65,50,63,113
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group +64kg,Lily Ontiveros,78.7,47,49,51,56,59,62,51,62,113
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,Ella Gamache,53.47,45,48,-51,62,65,-67,48,65,113
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,Elizabeth Klinge,54.16,50,52,55,55,58,-61,55,58,113
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 81kg,Brandi Herring,79.33,45,-47,47,60,63,65,47,65,112
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Amy Livingston,54.94,-46,-46,46,63,-66,66,46,66,112
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 64kg,Genessee Quizon,61.7,47,50,-54,57,61,-65,50,61,111
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 61kg,Gavin Burrows,57.43,46,48,50,55,58,61,50,61,111
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Jessica Cruse,61.69,42,46,49,55,58,61,49,61,110
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Desiree Gonzalez,58.49,48,-50,-50,60,62,-64,48,62,110
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 64kg,Madison Hatcher,64,41,44,47,59,63,-68,47,63,110
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 81kg,Krista Dornbush,78.1,43,45,-47,60,63,65,45,65,110
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Meagan Chisholm,58.09,40,43,-45,61,66,-70,43,66,109
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Rayna Matsuno,57.69,42,44,-46,-65,65,-68,44,65,109
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group +64kg,Mikaella Bowens,85.31,45,49,-52,57,60,-63,49,60,109
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 76kg,Joanna Mangiante,75.21,43,45,47,61,-63,-64,47,61,108
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 55kg,Danielle Do,52.8,43,45,47,-57,57,60,47,60,107
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 81kg,Kelley Howell,79.59,43,45,47,57,60,-63,47,60,107
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 71kg,Ellie Kichler,65.98,46,-50,-53,60,-64,-65,46,60,106
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 49kg,Areeya Draper,48.94,47,49,-52,55,57,-59,49,57,106
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 59kg,Susannah Perez,58.47,43,47,49,54,57,-60,49,57,106
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 55kg,Scarlet Ruiz,54.02,41,44,47,50,53,58,47,58,105
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 49kg,Nora Paoloni,48.5,43,45,-47,57,-60,60,45,60,105
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 67kg,Neil Fountain,63.98,40,43,45,50,55,60,45,60,105
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 59kg,Molly Dorrance,58.83,42,44,46,58,-61,-61,46,58,104
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Kloe Beardsley,49.1,-41,41,44,-56,56,59,44,59,103
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 59kg,Reagan Case,58.79,44,46,-48,54,-57,57,46,57,103
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 45kg,Gabrielle Gutierrez,45,43,46,-50,53,57,-60,46,57,103
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Brinlee Huber,51.81,42,44,46,53,56,-59,46,56,102
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 49kg,Liliana  Ray,48.66,42,45,-48,53,-56,57,45,57,102
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,Makenna Walker,53.97,46,-49,-49,56,-59,-59,46,56,102
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 71kg,Lisa Barrow,68.08,44,46,-47,54,-56,56,46,56,102
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group +64kg,Macie Boast,66.06,-40,40,-44,53,57,61,40,61,101
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group +64kg,Lei Prescott,74.34,39,41,43,52,-54,57,43,57,100
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 71kg,Torie Mathis,68.54,-45,-45,45,55,-61,-62,45,55,100
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 59kg,Susan Gerhard,58.96,42,-45,47,53,-56,-58,47,53,100
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 81kg,Margaret binzer,79.35,39,41,-43,55,-57,57,41,57,98
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 55kg,Kaiya Blackhurst,49.68,40,42,45,53,-56,-59,45,53,98
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 49kg,Ivy Weiss,49,41,43,-45,52,55,-58,43,55,98
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 59kg,Josie Stenstrom,58.05,42,44,-46,51,54,-56,44,54,98
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 59kg,Emily Paoloni,58.22,42,44,46,52,-55,-56,46,52,98
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 64kg,Shannon Strzynski,63.38,43,45,-47,51,53,-55,45,53,98
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,shayla strickland,52.63,-43,43,-49,-54,54,-57,43,54,97
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 55kg,Tovah Kjolsrud,54.45,38,41,-44,52,56,-60,41,56,97
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 49kg,Tiffany Gutknecht,47.06,40,42,44,50,52,-55,44,52,96
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 64kg,Maddi Landers,61.96,34,36,39,51,54,57,39,57,96
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 45kg,Alani Rose,41.21,40,-43,44,-48,48,52,44,52,96
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 64kg,Amy Herrera,59.5,40,-42,-44,-55,-55,55,40,55,95
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Zoe Macias,53.43,40,42,-44,52,-55,-55,42,52,94
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 55kg,Krisanne Driscoll,53.75,35,37,40,50,52,54,40,54,94
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 55kg,Ryland Dutton,50.28,35,38,41,47,-50,53,41,53,94
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 55kg,Raghad (Ray Ray) Alshwikhat,53.39,33,-36,37,50,53,56,37,56,93
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 59kg,Denise Hopkins,55.29,35,39,42,45,48,51,42,51,93
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (65-69) 76kg,DOLORES TRIVIZ,73.27,-42,42,-45,-50,-50,50,42,50,92
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 40kg,Jasmin Trinh,39.42,37,40,-42,47,50,52,40,52,92
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (45-49) 49kg,Huyen-Lam Nguyen,47.59,43,-45,-46,48,-51,-51,43,48,91
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 45kg,Sophia Hippelheuser,44.63,39,-41,-41,48,49,51,39,51,90
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 40kg,Lila Mangan,40,35,37,39,44,47,50,39,50,89
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 81kg,Lenore Grijalva,80.6,36,38,40,48,-52,-52,40,48,88
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 55kg,Suzanne Evans,54.69,37,-39,39,47,49,-51,39,49,88
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 71kg,Vicki Myers,69.77,36,38,40,45,-48,48,40,48,88
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 55kg,Sandra Guterres,54.02,33,-36,36,43,46,50,36,50,86
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 45kg,Kyla Byron,43.92,35,37,-39,45,47,49,37,49,86
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group +64kg,Hailey Ehlers,65.12,37,39,-41,42,44,46,39,46,85
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 45kg,Thevini Withana,44.21,35,37,-39,45,47,-50,37,47,84
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (55-59) 55kg,Beth DiFelice,54.04,36,-38,-39,46,-48,48,36,48,84
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 59kg,Donna Peters,58.85,35,-37,-37,47,-49,-50,35,47,82
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 71kg,Miriam Smith,67.7,34,35,36,43,45,46,36,46,82
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 55kg,Vivian Murray,52.73,32,34,36,42,44,46,36,46,82
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (65-69) 87kg,Jaime Gale,84.44,30,-33,33,42,-45,45,33,45,78
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 59kg,Deanna Johnson,56.23,32,34,-35,41,-43,43,34,43,77
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 64kg,Kelly Garber,62.43,35,0,0,42,0,0,35,42,77
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 40kg,TIERANY LALLY,36.37,34,-37,-37,39,42,-45,34,42,76
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 36kg,David Grafton,35.09,30,32,34,38,40,42,34,42,76
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 44kg,Roman Costa,43.17,31,34,35,39,-41,41,35,41,76
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (50-54) 59kg,Danielle Jorda,57.84,-32,32,-34,40,42,44,32,44,76
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 64kg,Kathy Telfer,61.94,28,30,32,38,40,43,32,43,75
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (75-79) 55kg,Ronald Johnson,55,31,33,35,35,38,40,35,40,75
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 40kg,Charlotte Sullivan,40,28,30,32,38,41,43,32,43,75
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 55kg,Preston  Chatman,52.04,32,-35,-36,36,39,42,32,42,74
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 44kg,Kayden Doherty,42.14,29,31,-33,40,42,-46,31,42,73
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 49kg,Hector Garcia,44.32,27,30,32,35,39,41,32,41,73
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (60-64) 59kg,Jill Schuster ,56.65,28,-30,31,39,-41,-41,31,39,70
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 45kg,Taylor Fife,43.71,-26,27,30,38,-40,40,30,40,70
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 36kg,Lilly Mullenaux,34.65,27,29,30,35,37,39,30,39,69
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 30kg,Rayya Howard,25.16,27,30,31,34,-37,37,31,37,68
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 55kg,Eesha Pallath,54.14,24,26,28,35,38,40,28,40,68
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 40kg,Aurora Garland,36.96,25,28,30,32,35,36,30,36,66
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 44kg,Xander Boese,43.2,24,26,28,34,37,-39,28,37,65
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 36kg,Layla Johnson,33.41,26,-28,-28,33,35,37,26,37,63
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 45kg,Paloma Milian,42.37,20,23,26,29,32,35,26,35,61
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 36kg,Brooklynn Vella,34.73,23,25,-28,-32,32,-36,25,32,57
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 40kg,Evelyn Otis,38.93,-26,27,-31,-30,-30,30,27,30,57
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 32kg,Nixon  Catalano,26.12,19,21,24,28,-31,31,24,31,55
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 32kg,Grayson Ibrahim,29.91,19,21,-23,29,-31,-31,21,29,50
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 13 Under Age Group 36kg,Dominic Sanchez,32.6,19,21,-23,26,-28,-28,21,26,47
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Kendrick Parideu,71.78,-96,96,-101,-118,-118,-118,96,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 73kg,Kieven Fischer,72.17,-101,-101,-101,126,-131,0,0,126,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 55kg,Aimee Causby,54.45,56,59,61,-77,-77,-77,61,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 55kg,Violeta Fernandez Martino,53.83,73,-76,76,-90,-91,-92,76,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 49kg,tiffany leung,49,-56,57,-60,-71,-72,-72,57,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 73kg,James-David Dendy,69.97,90,96,-102,-125,-130,-130,96,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Cody Monsevais,88.52,-119,-119,120,0,0,0,120,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 89kg,Elias Hamp,88.04,130,-135,-135,-163,-163,-163,130,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 81kg,Luke Twardy,75.01,105,110,115,-136,-139,-139,115,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Men's 102kg,Aaron Nice,102,-140,-140,-142,-190,0,0,0,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Jonathan McHale,73,-110,-110,-111,137,142,146,0,146,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Bryan Jow,72.71,105,109,112,-137,-137,-137,112,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 73kg,Moses Corbell,72.51,101,-103,-103,-127,-127,-127,101,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 59kg,gretchen messner,59,-72,-72,73,-86,-86,-86,73,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Junior Women's 76kg,Jane Miller,73.47,-72,-72,-72,85,-91,92,0,92,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 81kg,Douglas Perusso,77.53,-96,-96,-96,-113,113,-116,0,113,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Marissa Reeves,54.39,-49,-51,-51,60,63,-65,0,63,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 55kg,Stephanie Langdon,54.83,-48,-49,-49,58,-63,-63,0,58,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Chieh-Hsin You,95.41,-115,-116,-116,135,140,-147,0,140,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (35-39) 96kg,Andrew Pensko Jr.,93.41,-112,-112,-112,151,-156,-156,0,151,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Nicole Rucker,62.92,-78,-78,-78,0,0,0,0,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 64kg,Chereese Creel,63.51,-77,-77,-77,90,-94,94,0,94,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 59kg,Patricia Bennett,57.69,-65,-65,-65,-82,82,85,0,85,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 64kg,Alise Enriquez,63.75,-71,-71,-72,88,-90,92,0,92,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 71kg,Aleigh Moore,70.15,65,74,-77,0,0,0,74,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (40-44) 109kg,Nick DeShane,107.52,134,-140,-140,-166,-166,-166,134,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 71kg,Stephanie Jefferson,69.13,72,-75,-75,-92,-92,-93,72,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's Masters (45-49) 73kg,Michael Tucciarone,71.84,90,95,-100,-112,-112,-114,95,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 76kg,Katrina Rasmussen,74.1,-86,-86,-86,110,-113,-116,0,110,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Women's 81kg,Leanne Watson,80.17,80,-83,83,-99,-99,-99,83,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) 81kg,Teresa Kiel,80.13,-77,-78,78,-102,-103,-103,78,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (35-39) +87kg,Lillian Glueck,97.11,-74,-74,-74,91,-94,-94,0,91,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 13 Under Age Group 49kg,Charlee Meyer,46.56,29,31,33,-36,-36,-36,33,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 73kg,Jacob OConnor,73,120,123,-127,-145,-150,-152,123,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 81kg,Jack Walbye,80.94,120,124,-126,-155,-155,-155,124,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Christian Tsakanikas,87.81,125,-130,130,-160,-164,-164,130,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 89kg,Austin Davis,86.74,-125,-125,-125,155,162,-168,0,162,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 71kg,Ibis Loya Aguirre,70.78,-65,65,67,-80,-80,-80,67,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Arron Tate,95.45,-127,-128,-130,0,0,0,0,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 96kg,Josh Brinkworth,94.54,128,131,-135,-168,-172,-172,131,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's Masters (40-44) 81kg,TIA VANCE,77.4,-56,-56,-57,70,0,0,0,70,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group 76kg,Kodi McBride,71.46,-63,-63,-63,70,73,-76,0,73,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 14-15 Age Group +76kg,Mackenzie Gaye',79.11,63,66,-69,0,0,0,66,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's 109kg,Joshua Cruz,108.05,-128,-128,-128,-155,155,160,0,160,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 49kg,Ireland OBrien,48.66,-56,56,-59,-63,-65,-66,56,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 49kg,Adia Tomlinson,49,-63,-63,-63,-73,-73,73,0,73,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Open Men's +109kg,David Jorge,125.66,140,-147,-150,0,0,0,140,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 55kg,Desirae Phoenix,54.5,-47,-48,-48,56,-59,-59,0,56,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 59kg,Paige Hanchett,57.55,57,59,61,-70,-72,-72,61,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 64kg,Payton Mangay-ayam,63.33,-70,-70,-70,-90,90,-94,0,90,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 76kg,Ireland Grimes,74.37,-73,73,-75,-95,-95,-95,73,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Women's 16-17 Age Group 81kg,Isabel Zach,78.84,78,83,-86,-104,-104,-104,83,0,0
+"The 2024 Nike North American Open Finals, powered by Rogue",2024-12-05,Men's 16-17 Age Group 55kg,Michael Ziss,54.46,91,-95,-96,-111,-112,-112,91,0,0


### PR DESCRIPTION

Both AO Finals events are sitting on the USAW Sport80 portal with full results, but neither one made it into the database.

- event 6172, The 2023 Nike North American Open Finals, 2023-12-07 to 2023-12-10, 838 results
- event 6656, The 2024 Nike North American Open Finals, 2024-12-05, 799 results

## Potential Root Cause

Sport80 assigns event IDs in the order results get uploaded, not in event date order. USAW posted both Finals late, after a batch of mid and late December local meets had already been entered, so the Finals ended up behind IDs the scraper had already walked past.

It shows up cleanly in the commit history:

- 8b6a9069 (2023-12-27) ingested through 6170, then stopped
- f02acf1a (2024-01-14) picked back up at 6177

6171 through 6176 were never revisited, and 6172 is the Finals. Same story a year later: b2e3ec0e (2024-12-18) added 6655 and then jumped to 6658, which orphaned 6656 and 6657.

The pattern I think is behind it: once the calendar year rolls over, the previous year never gets swept again, so anything that lands behind the last run of that year is stuck for good. The script that writes these CSVs isn't in this repo, so that part is inferred from the commit history and the ID ordering rather than read off the code. Happy to be corrected on the mechanism.

## Scope

I diffed the full USAW event index against event_data/US. There are 102 other events with published results that aren't in the database, and they bunch up in December (17 from 2024, 7 from 2023, 7 from 2019, 4 from 2025).

This PR only adds the two Finals. I can do the other 97 in a follow-up if that's useful, or leave it alone. Let me know!

Edit: corrected the count from 99 to 102. The listing endpoint paginates without a deterministic sort, so my first sweep was undercounting. Details in #537.
