### PR TITLE
fix: add 97 missing US events

### DIFF
--- a/event_data/US/125.csv
+++ b/event_data/US/125.csv
@@ -1,0 +1,24 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Zachary Karlins,81.1,-115,115,120,145,151,-156,120,151,271
+First Of the Year Open,2015-01-17,Open Men's 94 kg,Anthony Villanueva,87.7,100,106,111,140,146,151,111,151,262
+First Of the Year Open,2015-01-17,Open Men's 105 kg,Isaiah Pellot,104.9,113,-116,-117,140,146,-150,113,146,259
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Elio Sanchez,85,105,108,-111,135,140,144,108,144,252
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Troy Boettner,83.5,103,108,111,135,140,-144,111,140,251
+First Of the Year Open,2015-01-17,Open Men's 77 kg,Nathan Reyes,76.3,101,-106,106,128,133,-137,106,133,239
+First Of the Year Open,2015-01-17,Open Men's 94 kg,Kevin Wright,93.4,100,-104,-104,122,127,131,100,131,231
+First Of the Year Open,2015-01-17,Open Women's +75 Kg,Ranjii Chung,88.6,93,97,101,118,-122,123,101,123,224
+First Of the Year Open,2015-01-17,Open Men's 69 kg,Isaac Gonzalez,69,-77,77,84,120,125,132,84,132,216
+First Of the Year Open,2015-01-17,Open Men's 77 kg,Anthony Marinola,69.5,85,-100,-100,-125,125,-135,85,125,210
+First Of the Year Open,2015-01-17,Open Men's 94 kg,Ryan Beckman,92.7,75,78,81,108,113,117,81,117,198
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Alex Garcia,77.1,71,75,80,101,105,-107,80,105,185
+First Of the Year Open,2015-01-17,Open Men's 94 kg,Kristofor Richter,91.9,70,74,77,95,100,104,77,104,181
+First Of the Year Open,2015-01-17,Open Women's 69 kg,Megan Murphy,68.3,-71,71,-75,85,88,-90,71,88,159
+First Of the Year Open,2015-01-17,Open Men's 56 kg,Mariano Hernandez,54.6,55,59,62,84,90,-94,62,90,152
+First Of the Year Open,2015-01-17,Women's Masters (40-44) 63 kg,Marisol Esquilin,60.3,60,64,-68,71,76,-80,64,76,140
+First Of the Year Open,2015-01-17,Open Women's 48 kg,Yecenia Feliz,10,36,39,43,62,65,-68,43,65,108
+First Of the Year Open,2015-01-17,Open Women's 53 kg,Kennedy Lachicotte,48.7,40,43,-46,54,57,-60,43,57,100
+First Of the Year Open,2015-01-17,Women's 14-15 Age Group 69 kg,Jazmin Peterman,65.8,32,34,36,39,42,-47,36,42,78
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Justin Benacquisto,80.7,-80,-80,-80,109,-112,-112,0,109,0
+First Of the Year Open,2015-01-17,Open Men's 85 kg,James Robertson,81.8,-90,90,94,-120,-120,-120,94,0,0
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Daniel Carvajal,77.4,-100,-100,101,-125,-127,-127,101,0,0
+First Of the Year Open,2015-01-17,Open Men's 85 kg,Matthew Benacquisto,84.8,-108,-109,-109,128,-132,132,0,132,0

--- a/event_data/US/1299.csv
+++ b/event_data/US/1299.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2nd to last Chance Qualifier,2014-05-17,Open Women's +75 Kg,Amy Ellis,108.1,25,28,30,36,39,42,30,42,72

--- a/event_data/US/168.csv
+++ b/event_data/US/168.csv
@@ -1,0 +1,107 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Darin Weeks,103.65,130,-140,-141,162,-168,-168,130,162,292
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Sheldon Stuckart,81.65,120,126,-131,151,156,160,126,160,286
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Jon Dawson,94,125,-127,-127,155,158,160,125,160,285
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Pedro Aneses,120.3,117,123,126,147,152,157,126,157,283
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Dominick Trozzi,81.07,116,121,125,146,151,156,125,156,281
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Douglas Piper,99.8,117,122,125,148,153,156,125,156,281
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Alexander Beddow,84,120,125,131,-145,148,-155,131,148,279
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Eric Schnatz,99.15,110,116,-120,142,146,-150,116,146,262
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Mark Swartz,88.2,111,-116,116,140,145,-150,116,145,261
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Marcus Mucheck,82.3,105,-115,115,130,-140,140,115,140,255
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Brett Talcott,93.3,107,111,115,135,140,-145,115,140,255
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Jake Hartsook,76.2,100,105,108,137,141,145,108,145,253
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Jordan Szymanowski,116.05,105,-110,112,130,136,140,112,140,252
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Bailey DiMenna,83.55,-110,110,115,130,135,-140,115,135,250
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Tyler Fountain,90.35,100,103,106,131,136,140,106,140,246
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Matt Hess,139.15,101,105,109,131,136,-140,109,136,245
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Terry Zeller,90,110,-113,-113,125,130,132,110,132,242
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Peter Nelson,93,97,100,-105,137,140,142,100,142,242
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Michael Lavoy,82.45,104,110,115,117,-124,125,115,125,240
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Adam Rogers,83.95,102,106,-110,125,130,133,106,133,239
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Benjamin Retherford,84.45,103,-108,110,129,-133,-133,110,129,239
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Zach Goldsmith,75.65,100,103,105,127,133,-140,105,133,238
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Chad Weldishofer,98.2,98,-102,102,125,132,-136,102,132,234
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,William Willard,83.45,102,-105,-107,122,127,131,102,131,233
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Andrew Gallagher,92.85,-102,-102,102,-130,-130,130,102,130,232
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Gregory Kerschbaum,103.8,100,-107,107,115,120,125,107,125,232
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,John Dill,84.35,95,98,100,125,-130,130,100,130,230
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Jay Malone,76.25,98,-101,-101,119,-123,125,98,125,223
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Sergiy Turchyn,76.95,93,97,-101,115,121,125,97,125,222
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Jordan Houghton,84.5,-102,102,-105,-120,-120,120,102,120,222
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Ben Moran,76,94,96,99,111,116,122,99,122,221
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 69 kg,Guillermo Fernandez,68.7,90,95,-100,120,125,-130,95,125,220
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Cory Moore,77.95,96,101,-106,116,119,-122,101,119,220
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Sean O'Day,113.75,85,90,92,120,126,128,92,128,220
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Willis Johnson,73.95,98,-103,-103,-114,114,118,98,118,216
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Alexander Rafeld,86.15,90,94,-100,118,122,-126,94,122,216
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Scott Bowman,99.8,85,90,95,110,115,120,95,120,215
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Wesley Freeman,76.2,86,-91,94,110,115,118,94,118,212
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Todd Sexton,84.1,86,91,-95,112,119,-123,91,119,210
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Lucas Hurst,82.65,88,-91,-92,113,118,-127,88,118,206
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Matthew Boeding,76.3,82,86,90,106,110,114,90,114,204
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Jordan Cramer,137.2,87,-92,-92,102,107,-110,87,107,194
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Eric Hanna,80.4,-85,85,-90,107,-110,-110,85,107,192
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Joseph Naim,82.8,75,80,85,95,100,105,85,105,190
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Andrew Wyatt,101.55,85,-89,-91,105,-110,-110,85,105,190
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Sam Ashworth,74.95,80,-85,-85,100,105,-108,80,105,185
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Justin Schumacher,71.6,79,81,-84,98,104,-110,81,104,185
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 62 kg,Tyler Berryman,62,-78,-80,80,95,100,-105,80,100,180
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Vernon Duett,99.9,75,80,83,95,-100,-100,83,95,178
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Nalin Prabhu,90.65,70,-75,75,98,-102,102,75,102,177
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 56 kg,Keith Connolly,55.1,-78,-78,78,97,-104,-104,78,97,175
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 69 kg,Garlund Clay,63.55,70,73,76,90,95,98,76,98,174
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 63 kg,Katherine Lee,58.5,72,75,-80,-93,93,96,75,96,171
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Heath Wenzel,73.85,66,70,75,85,90,95,75,95,170
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Paul Theders,73.4,65,70,74,83,88,92,74,92,166
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Bryan Opaskar,74.5,65,68,71,85,90,95,71,95,166
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 69 kg,Parker Vaughan,68.05,68,72,-75,86,91,-100,72,91,163
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 62 kg,John Kresila,60.45,68,-71,73,85,89,-93,73,89,162
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 75 kg,Candace Gorby,74.35,-70,-70,71,-90,90,-92,71,90,161
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 63 kg,Joelle Emery,62.05,65,67,-71,88,-93,93,67,93,160
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 69 kg,Dylan Thitoff,67.65,62,66,71,78,82,86,71,86,157
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's +75 Kg,Jennifer Cusick,81.15,59,62,-66,82,85,89,62,89,151
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Michael George,124.6,55,60,-62,85,90,-95,60,90,150
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (40-44) +75 kg,Melanie Perry,107.25,60,-62,-63,81,84,88,60,88,148
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 69 kg,Siu Weldishofer,66.3,-65,65,-70,75,80,82,65,82,147
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 62 kg,Sung Kim,58.2,60,65,-72,65,70,80,65,80,145
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Stevan Vaughan,96,58,63,65,72,73,80,65,80,145
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Dalton Jalovec,74.2,58,63,65,-79,-79,79,65,79,144
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 75 kg,Courtney Chae,72.5,64,-69,-71,80,-85,-85,64,80,144
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 63 kg,Laura Prosser,62.5,63,-65,67,73,75,-79,67,75,142
+2015 Ohio State Weightlifting Championships,2015-09-13,Men's 14-15 Age Group 77 kg,Jared Jones,70.55,56,59,61,74,78,-80,61,78,139
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 58 kg,Abby Watson,56.45,51,-57,57,72,78,82,57,82,139
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 63 kg,Danielle Purtell,62.4,57,60,-63,75,78,-82,60,78,138
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (35-39) 69 kg,Racheal Gallant,67.45,58,-63,-63,75,78,-81,58,78,136
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (35-39) 63 kg,Stephanie Magee,58.95,57,-59,60,-73,73,-76,60,73,133
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Jameson Vaughan,85.15,45,50,53,66,71,77,53,77,130
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 75 kg,Claire Kopko,72.6,55,58,60,63,70,-73,60,70,130
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (50-54) 69 kg,Shellie Edington,64.2,53,56,-60,70,72,-74,56,72,128
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 77 kg,Michael Miller,75.2,45,50,55,62,66,70,55,70,125
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 69 kg,Melanie Conklin,66.8,53,-57,-57,68,71,-72,53,71,124
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (35-39) 69 kg,Katherine Farmer,68.7,48,52,55,58,63,67,55,67,122
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's 14-15 Age Group 58 kg,Samantha Watkins,57.8,47,-50,50,60,65,67,50,67,117
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 63 kg,Tiffany Beskid,58.2,43,46,49,-64,68,-70,49,68,117
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (35-39) 69 kg,Heidi White,68.3,39,43,47,58,63,66,47,66,113
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (50-54) +75 kg,Debbie Alexander,127,-46,48,53,52,57,60,53,60,113
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (35-39) 69 kg,Alejandra Florez,65.1,43,45,-51,61,64,-68,45,64,109
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 69 kg,Erin Hoehn,68.4,42,45,47,56,60,-64,47,60,107
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's +75 Kg,Lisa Canitia,80.65,-45,45,-48,57,-60,60,45,60,105
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (45-49) +75 kg,Emily Davis,106.5,40,-43,44,56,58,60,44,60,104
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 62 kg,Kyle Holman,57.05,45,-48,-48,50,55,-57,45,55,100
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's 16-17 Age Group 48 kg,Anya Penner,47.8,34,38,-42,50,54,-57,38,54,92
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's 14-15 Age Group 69 kg,Elizabeth Keefe,65.4,35,37,-39,45,50,-52,37,50,87
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 75 kg,Renae Martin,74.75,-36,36,39,39,43,46,39,46,85
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's Masters (55-59) +75 kg,Linda Glynias,75.4,27,30,-32,43,45,47,30,47,77
+2015 Ohio State Weightlifting Championships,2015-09-13,Men's 14-15 Age Group 44kg,Seth Best,41.2,-28,28,30,34,36,38,30,38,68
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Women's 48 kg,Krista Salmon,45.65,26,-30,-30,32,35,38,26,38,64
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's 13 Under Age Group 48kg,Mia Howard-Stevens,45.45,-22,22,24,28,30,32,24,32,56
+2015 Ohio State Weightlifting Championships,2015-09-13,Women's 13 Under Age Group +58 Kg,Renee Hutchins,69.85,22,24,-26,30,-32,32,24,32,56
+2015 Ohio State Weightlifting Championships,2015-09-13,{'type': 'unset'},Wyatt Abbott,35.1,20,22,-24,30,32,-34,22,32,54
+2015 Ohio State Weightlifting Championships,2015-09-13,Men's 13 Under Age Group 50 Kg,Cole Barnes,49.2,14,15,17,23,25,-28,17,25,42
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Nathan Napolitano,83.65,85,90,-94,-110,-110,-110,90,0,0
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Christopher Keyser,83.05,-95,-95,-100,115,116,-120,0,116,0
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 85 kg,Matt Guarnieri,83.15,-107,-107,-107,-128,-128,-128,0,0,0
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 94 kg,Greg Wise,93.4,-95,-95,-95,120,-125,-125,0,120,0
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's 105 kg,Glen Kalbaugh,100.8,118,-122,123,-145,-148,-148,123,0,0
+2015 Ohio State Weightlifting Championships,2015-09-13,Open Men's+105 kg,Michael Kreatsoulas,120.5,155,-161,-161,-190,-195,-195,155,0,0

--- a/event_data/US/1814.csv
+++ b/event_data/US/1814.csv
@@ -1,0 +1,41 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's+105 kg,Raymond Criado,127.1,122,125,128,165,-172,172,128,172,300
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 105 kg,carlos Ramos,105,-127,-127,127,160,-164,-166,127,160,287
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 85 kg,Merrek Peters,81.5,-115,-115,115,156,-160,0,115,156,271
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Nick Pann,91.2,110,115,120,140,147,-151,120,147,267
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Thomas Levy,93.1,92,97,100,127,131,135,100,135,235
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Scott Miller,91.4,-99,-100,100,123,128,-132,100,128,228
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Casey Metoyer,92,97,102,-108,120,121,-131,102,121,223
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 85 kg,Mark Schiavone,82.4,94,-98,100,-121,122,-125,100,122,222
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 77 kg,Jensen Talmo,74.5,88,93,-97,119,123,127,93,127,220
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Kurt Schiele,86.7,85,-90,-90,110,115,120,85,120,205
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 85 kg,Victor Rodriguez,79.4,86,-89,-89,112,117,-123,86,117,203
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 77 kg,Timothy Natividad,73.9,80,-85,87,-113,115,-120,87,115,202
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 85 kg,Pluton Gradeci,80.5,83,-87,-87,106,-111,111,83,111,194
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 69 kg,Dorothy Morenitn,67.4,76,79,83,93,97,-103,83,97,180
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Michael Keating,85.4,71,75,79,90,95,100,79,100,179
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 94 kg,Ryan Capriccio,91,72,76,79,-92,92,96,79,96,175
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 105 kg,Joel Perez Jr,103,-72,74,78,92,97,-101,78,97,175
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 69 kg,Lindsey Deitsch,67.5,-69,69,73,80,84,88,73,88,161
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 63 kg,Christine Wiley,60.95,-69,70,73,79,83,87,73,87,160
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Women's Masters (35-39) 69 kg,Rachel Gamallo,66.2,-71,-71,71,89,-95,-95,71,89,160
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 75 kg,Heather Sanders,72.1,66,70,74,79,84,-89,74,84,158
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 58 kg,Kristan Clever,56.95,-65,66,70,79,82,84,70,84,154
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's +75 Kg,Urbana Sepulveda,82.4,62,65,-67,-83,83,87,65,87,152
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 58 kg,Danielle Marino,55.55,60,63,-66,82,86,-91,63,86,149
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 63 kg,Deanna Douglas,62.6,59,62,65,75,77,-81,65,77,142
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 69 kg,Mercedes Munoz,65.05,55,-58,-58,75,79,82,55,82,137
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 53 kg,Cynthia Rodriguez,53,-60,60,-64,-75,75,-80,60,75,135
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 58 kg,CHRISTINE REES,56.9,-55,57,60,70,74,75,60,75,135
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 58 kg,Mallory Mazzuca,55,-55,57,61,-73,73,-76,61,73,134
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 63 kg,Rocio Ramirez,62.7,-57,57,-60,70,75,-77,57,75,132
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's +75 Kg,Mackenzie Levine,77.58,52,55,57,64,68,72,57,72,129
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's +75 Kg,Regina Pulido,101.2,45,-50,53,60,65,-71,53,65,118
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Women's Masters (35-39) 63 kg,Megan Mudge-Longfellow,62,-40,40,45,55,60,65,45,65,110
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Women's 14-15 Age Group 53 kg,Alijah Salas,52.95,42,-45,45,55,58,-60,45,58,103
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Women's 14-15 Age Group 53 kg,Lindsay Diller,49.15,42,44,46,-50,50,51,46,51,97
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 53 kg,Nancy Alvarado,52.15,-42,42,-45,50,-54,-56,42,50,92
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Women's Masters (55-59) 63 kg,Joanne Pope,62.5,25,28,-31,36,41,46,28,46,74
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's 53 kg,Jenyffer Ortega,50,-55,55,-60,-68,-70,-73,55,0,0
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Women's +75 Kg,Melissa Corsini,85.5,74,-77,-80,-95,-98,-98,74,0,0
+BARBARIAN BARBELL presents OctoBar Fest!,2016-10-15,Open Men's 77 kg,dominick peru,74.3,-96,-99,-99,-124,-124,-124,0,0,0

--- a/event_data/US/2146.csv
+++ b/event_data/US/2146.csv
@@ -1,0 +1,30 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Fall 2016 IronCat Open,2016-10-15,Open Men's 77 kg,Joshua Robinett,75.4,108,114,-118,134,137,-141,114,137,251
+Fall 2016 IronCat Open,2016-10-15,Open Men's+105 kg,Micajah Driver,112.7,103,107,111,128,-132,136,111,136,247
+Fall 2016 IronCat Open,2016-10-15,Open Men's 94 kg,John Hill,86.8,-102,-102,102,136,142,-146,102,142,244
+Fall 2016 IronCat Open,2016-10-15,Open Men's 77 kg,Nick Piacente,76.8,106,111,-115,131,-137,-138,111,131,242
+Fall 2016 IronCat Open,2016-10-15,Open Men's 85 kg,Josue Flores,81.3,93,-97,98,122,128,-130,98,128,226
+Fall 2016 IronCat Open,2016-10-15,Open Men's 105 kg,Cesar Jr. Gutierrez,100.6,91,95,-103,120,125,127,95,127,222
+Fall 2016 IronCat Open,2016-10-15,Open Men's 105 kg,Kristopher Greenhill,100.8,-82,82,87,103,-108,110,87,110,197
+Fall 2016 IronCat Open,2016-10-15,Open Men's 85 kg,Joshua Snipp,79.9,-83,83,-87,103,-106,-106,83,103,186
+Fall 2016 IronCat Open,2016-10-15,Open Men's 77 kg,Aaron Horning,75,-78,78,-82,98,104,-108,78,104,182
+Fall 2016 IronCat Open,2016-10-15,Open Men's 77 kg,Christopher Perez,72.7,77,80,-84,97,-100,100,80,100,180
+Fall 2016 IronCat Open,2016-10-15,Open Men's 85 kg,Oscar Fumero Gonzalez,78.3,72,74,-77,89,95,100,74,100,174
+Fall 2016 IronCat Open,2016-10-15,Open Men's 77 kg,David Griffin,76.2,72,75,-77,95,-100,-100,75,95,170
+Fall 2016 IronCat Open,2016-10-15,Open Men's 62 kg,Matthew Cecilio,61.3,65,68,-72,90,95,100,68,100,168
+Fall 2016 IronCat Open,2016-10-15,Open Men's 94 kg,Christopher Perez Sr.,92.7,62,66,-70,95,98,100,66,100,166
+Fall 2016 IronCat Open,2016-10-15,Open Men's 69 kg,Clayton Stamper,67.1,60,70,-85,70,-85,85,70,85,155
+Fall 2016 IronCat Open,2016-10-15,Open Women's 63 kg,Gladybel Mercado,59.5,-60,-60,62,75,82,-87,62,82,144
+Fall 2016 IronCat Open,2016-10-15,Open Women's 63 kg,Devin Costa,61.7,55,59,61,65,69,71,61,71,132
+Fall 2016 IronCat Open,2016-10-15,Open Women's +75 Kg,Veronica Partridge,84.5,50,54,57,60,65,-68,57,65,122
+Fall 2016 IronCat Open,2016-10-15,Women's 16-17 Age Group 69 kg,Shelby Rodriguez,68.4,55,-58,-60,65,-69,-71,55,65,120
+Fall 2016 IronCat Open,2016-10-15,Open Women's 69 kg,Sarah Dacy,68.7,44,47,50,-65,65,68,50,68,118
+Fall 2016 IronCat Open,2016-10-15,Women's Masters (35-39) 75 kg,Leah Alter,71,45,-47,48,65,-68,-68,48,65,113
+Fall 2016 IronCat Open,2016-10-15,Open Women's 53 kg,Jennifer Polzin,52.5,45,-48,49,56,58,-61,49,58,107
+Fall 2016 IronCat Open,2016-10-15,Women's 14-15 Age Group 69 kg,Kara Posey,66.7,-38,-39,39,50,54,-58,39,54,93
+Fall 2016 IronCat Open,2016-10-15,Women's 14-15 Age Group 53 kg,Mariah Perez,50.1,27,30,34,40,45,-50,34,45,79
+Fall 2016 IronCat Open,2016-10-15,Women's 13 Under Age Group 35kg,Natalyzbel Rodriguez Cabrera,33.3,15,17,18,22,24,26,18,26,44
+Fall 2016 IronCat Open,2016-10-15,Open Men's 69 kg,Ryan Ramos,68.8,95,-98,-98,-130,-135,-135,95,0,0
+Fall 2016 IronCat Open,2016-10-15,Open Men's 85 kg,Austin Newman,85,-120,-120,-120,-140,-145,-145,0,0,0
+Fall 2016 IronCat Open,2016-10-15,Open Men's 85 kg,Benjamin Ingell,85,-115,-115,-115,140,145,-150,0,145,0
+Fall 2016 IronCat Open,2016-10-15,Open Men's 85 kg,David Bray,84.3,-120,-120,-121,-145,145,-151,0,145,0

--- a/event_data/US/2157.csv
+++ b/event_data/US/2157.csv
@@ -1,0 +1,86 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 94 kg,Frankie Murray,88.15,125,130,135,150,160,174,135,174,309
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,John Aguinaldo,76.9,112,117,120,148,153,156,120,156,276
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 105 kg,David Urovish,99.5,-115,117,-125,-146,156,-165,117,156,273
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 105 kg,Marcin Burdzy,95.25,121,-126,-127,141,146,151,121,151,272
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Christopher Szymanski,82,112,117,-120,145,154,-157,117,154,271
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 69 kg,James Corsitto,68.9,115,-120,-120,143,148,153,115,153,268
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Roger Gesswein,76.6,-118,-118,118,140,-147,-147,118,140,258
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,George Sidiroglou,83.7,-107,107,111,142,147,-150,111,147,258
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Kleon Hayles,115.45,102,106,-108,-127,130,-135,106,130,236
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 62 kg,Dean Otsuka,61.85,-102,-102,104,120,126,-131,104,126,230
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 69 kg,John Shishido,68.6,90,97,-105,120,127,132,97,132,229
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 94 kg,Jason Eng,89.15,95,99,-102,125,-130,130,99,130,229
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 94 kg,Adam Bakatsias,88.6,102,-106,-106,125,-130,-130,102,125,227
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,George Bakatsias,82.45,-100,100,-105,125,-130,-130,100,125,225
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Kevin Galligan,84.15,95,100,105,120,-125,-125,105,120,225
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Vince Tonolete,71.15,92,95,98,-122,122,-127,98,122,220
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 62 kg,Khalil Harrison,61.9,95,-99,-99,114,-117,117,95,117,212
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Vitaly Zvonchuk,110.45,80,85,-90,110,115,121,85,121,206
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Hardeep Singh,117.95,83,-88,88,111,116,-121,88,116,204
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 105 kg,Willie Xu,97.3,89,-92,92,105,108,111,92,111,203
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Nicholas Werker,82.05,82,-86,86,106,111,-115,86,111,197
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 94 kg,Mohamed Lemfadli,90.95,-81,81,85,103,108,112,85,112,197
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Nicholas Novak,76,85,-88,-88,105,110,-115,85,110,195
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Bryan Butterfass,82.3,-80,80,84,100,105,109,84,109,193
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 69 kg,Heather Farmer,65.4,-83,83,-86,-106,106,-111,83,106,189
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Jacob Fields,80.6,-87,87,-90,100,-104,-104,87,100,187
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Joel Chicantek,83.35,75,-78,-80,112,-115,-115,75,112,187
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Alex Ortiz,84.65,79,-85,-85,104,-108,-112,79,104,183
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 62 kg,Jonathan Santos,61.15,80,-85,-85,100,-105,-105,80,100,180
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 94 kg,John Hubble,87.8,75,-78,-78,100,-105,105,75,105,180
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Danny Wong,75.35,75,80,-85,90,97,-108,80,97,177
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 69 kg,Max Baron,68.45,73,76,-80,95,-98,100,76,100,176
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Salvatore Rotondo,111.4,-75,75,-83,94,-100,101,75,101,176
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 58 kg,Rhiannon Reynolds,57.85,-75,75,-78,94,98,-102,75,98,173
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Christopher Smith,132.4,71,76,-80,92,97,-102,76,97,173
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Daniel Boland,111.1,72,77,-80,90,95,-98,77,95,172
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 62 kg,domenick caracappa,60.95,70,-74,-75,88,-92,95,70,95,165
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 62 kg,Mark Ongeyberg,61.2,65,70,73,82,88,91,73,91,164
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Dean Warner,107.95,69,-72,72,88,90,92,72,92,164
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Abrar Ahmed,70.3,57,-65,71,75,84,-91,71,84,155
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 105 kg,Thomas Hughes,94.1,-70,70,-73,85,-90,-91,70,85,155
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's+105 kg,Gordon Coor,114.5,57,65,70,72,78,85,70,85,155
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 69 kg,Kasey Heil,68.4,-70,70,-72,84,-89,-89,70,84,154
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Krishna teja Velagapudi,79.1,60,65,-70,80,86,-91,65,86,151
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's +75 Kg,Toni Fiani,87.55,60,64,-68,75,-83,83,64,83,147
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 58 kg,Ines Spenjian,54.6,58,62,65,80,-84,-85,65,80,145
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's +75 Kg,Lauren Salz,82.85,60,-63,66,72,76,-80,66,76,142
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 69 kg,Ian Matlak,67.35,62,-66,-66,75,80,-85,62,80,142
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 58 kg,Brittany Rottkamp,54.4,57,61,64,75,-79,-82,64,75,139
+2016 Metropolitan Weightlifting Championships,2016-10-16,Women's Masters (40-44) 63 kg,Amy Fliss,60.35,55,58,-61,74,77,-79,58,77,135
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Sosara Ma,62.4,58,-61,-63,67,72,-76,58,72,130
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's +75 Kg,Lillian Luu,82.65,53,-56,57,64,67,69,57,69,126
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 62 kg,Thomas Pomfret,60,45,50,-53,65,70,73,50,73,123
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Bill Dunks,78.5,45,48,50,68,70,73,50,73,123
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Amanda Lopez,62.5,50,-53,53,65,68,-74,53,68,121
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 69 kg,Laura Kovach,67,50,53,-56,-60,64,68,53,68,121
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 53 kg,Sara Hana,52.55,50,52,-54,65,67,-69,52,67,119
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 58 kg,Stephanie Tuazon,54,49,52,-55,66,-70,-70,52,66,118
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 58 kg,Marissa Troiano,57.75,-48,48,-51,-68,-69,69,48,69,117
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Gerard Dunne,75.2,48,51,0,62,66,-68,51,66,117
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 69 kg,Ashley Jurkiewicz,68.9,-53,53,-59,-62,63,-66,53,63,116
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 53 kg,Katherine McDevitt,52.55,51,-54,-55,62,64,-66,51,64,115
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Amanda Palmeri,59.25,50,52,-54,60,-63,63,52,63,115
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Dawn Lo,63,48,51,52,55,59,63,52,63,115
+2016 Metropolitan Weightlifting Championships,2016-10-16,Women's Masters (45-49) 75 kg,Elke Lohan,69.6,45,-50,50,60,65,-70,50,65,115
+2016 Metropolitan Weightlifting Championships,2016-10-16,Women's Masters (35-39) +75 kg,Sara Soto,75.7,46,50,-52,60,65,-67,50,65,115
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 48 kg,Carla Miranda,48,-48,48,-50,-65,65,-67,48,65,113
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 75 kg,Brittany Baudanza,74.1,-46,46,47,63,66,-69,47,66,113
+2016 Metropolitan Weightlifting Championships,2016-10-16,Women's Masters (45-49) 58 kg,Jennifer Alvarez,56.5,44,46,48,56,59,-61,48,59,107
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Stephanie Lew Lew,61.05,42,45,48,51,54,58,48,58,106
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 75 kg,Mary Baccellieri,74.2,35,46,-50,50,56,60,46,60,106
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Kristina Naplatarski,60.3,-45,45,47,55,58,-60,47,58,105
+2016 Metropolitan Weightlifting Championships,2016-10-16,Men's 13 Under Age Group 56 Kg,LAWRENCE MINTZ,51.3,32,37,-41,54,58,60,37,60,97
+2016 Metropolitan Weightlifting Championships,2016-10-16,Men's 14-15 Age Group 69 kg,Andrew Smith,65.6,-36,36,37,56,-60,-63,37,56,93
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 63 kg,Judy Zhou,58.4,40,43,-45,45,49,-52,43,49,92
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Women's 53 kg,Elizabeth Piazza,51.9,30,-35,-35,40,43,48,30,48,78
+2016 Metropolitan Weightlifting Championships,2016-10-16,Women's Masters (40-44) 58 kg,Maja Leibovitz,54.25,25,27,29,25,28,31,29,31,60
+2016 Metropolitan Weightlifting Championships,2016-10-16,Men's 13 Under Age Group 31 Kg,Benjamin Drescher,30.95,12,-16,-16,16,-20,-20,12,16,28
+2016 Metropolitan Weightlifting Championships,2016-10-16,Women's Masters (45-49) 63 kg,Ramona Cadogan,62.55,-54,54,-57,-67,-67,-67,54,0,0
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 69 kg,aaron dickel,66.55,81,84,-88,-100,-103,-107,84,0,0
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 69 kg,Kenneth Bretania,68.6,-95,-95,-95,0,0,0,0,0,0
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Daniel Pino,74.4,-70,70,-73,-88,-88,-88,70,0,0
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 77 kg,Ivan Duncan,75.5,-115,-115,-115,0,0,0,0,0,0
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Daniel Billian,84.05,-115,121,-126,-150,-150,-150,121,0,0
+2016 Metropolitan Weightlifting Championships,2016-10-16,Open Men's 85 kg,Mihalis Alisandratos,84.35,-104,-104,-104,-126,-126,0,0,0,0

--- a/event_data/US/2179.csv
+++ b/event_data/US/2179.csv
@@ -1,0 +1,54 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Lord of the Lifts Super Competition,2016-10-16,Open Men's 105 kg,Nathanael Bacott,96.5,118,121,125,156,161,163,125,163,288
+Lord of the Lifts Super Competition,2016-10-16,Open Men's 94 kg,Brandon Deines,91.5,116,121,127,150,155,160,127,160,287
+Lord of the Lifts Super Competition,2016-10-16,Open Men's 105 kg,Tommy Damian,97.9,115,120,125,145,150,155,125,155,280
+Lord of the Lifts Super Competition,2016-10-16,Open Men's 85 kg,Matthew Fuller,81.6,115,118,122,140,145,145,122,145,267
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 81kg,Jason Morgan,79.4,110,115,-118,140,148,-152,115,148,263
+Lord of the Lifts Super Competition,2020-02-15,Men's Masters (35-39) +109kg,Thomas Murphy,112.45,96,99,-105,131,137,143,99,143,242
+Lord of the Lifts Super Competition,2020-02-15,Open Men's +109kg,Paul Ivarie,120.65,105,-109,-109,130,-135,-135,105,130,235
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 73kg,Steven Rodriguez,71.55,93,97,-104,-137,137,-144,97,137,234
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 89kg,Nathan Morris,88.45,102,-107,-107,126,-131,132,102,132,234
+Lord of the Lifts Super Competition,2016-10-16,Open Men's 85 kg,Stephen Parmentier,81.3,85,95,101,110,125,125,101,125,226
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 81kg,Myron Kirchner,78.4,95,-100,-100,-127,127,131,95,131,226
+Lord of the Lifts Super Competition,2020-02-15,Open Men's +109kg,Austin Spires,112.45,85,92,99,120,126,-131,99,126,225
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 73kg,Mitchell Dreska,71.05,95,100,-105,120,-125,-127,100,120,220
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 81kg,erik miranda,74.85,100,-105,-105,120,-125,-130,100,120,220
+Lord of the Lifts Super Competition,2020-02-15,Open Men's +109kg,Grant Pestka,124.4,86,-89,90,-128,129,-133,90,129,219
+Lord of the Lifts Super Competition,2020-02-15,Men's Masters (40-44) 96kg,Kenneth Zetye,95.85,92,-98,102,115,-120,-123,102,115,217
+Lord of the Lifts Super Competition,2020-02-15,Men's Masters (50-54) 96kg,Charles Janicki,92.15,87,92,96,111,115,118,96,118,214
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 81kg,Keenen Peck-Valdivia,80.3,95,-100,101,110,-114,-116,101,110,211
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 89kg,Jeffrey Sontag,88.55,95,98,-101,-113,113,-117,98,113,211
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 89kg,Nicholas Mclean,87.55,-90,90,-95,114,120,-130,90,120,210
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 102kg,Spencer Bernard,100.8,-82,85,90,97,-103,109,90,109,199
+Lord of the Lifts Super Competition,2020-02-15,Men's Masters (50-54) 96kg,Paul LaDuke,95.45,80,85,-88,100,105,107,85,107,192
+Lord of the Lifts Super Competition,2016-10-16,Open Women's +75 Kg,Elisa Rhynedance,81.7,80,83,85,98,101,103,85,103,188
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 71kg,Erin Nelson,70.85,68,74,77,85,89,95,77,95,172
+Lord of the Lifts Super Competition,2020-02-15,Men's Masters (40-44) 73kg,Christopher Carter,72.6,70,75,77,91,-99,-99,77,91,168
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 71kg,Adrienne Vogelsang,69.75,-69,72,-76,84,-88,88,72,88,160
+Lord of the Lifts Super Competition,2016-10-16,Open Men's+105 kg,Robert Dias,114.4,56,60,64,83,87,92,64,92,156
+Lord of the Lifts Super Competition,2020-02-15,Men's 16-17 Age Group 67kg,Nicholas Conlin,65.1,65,70,-76,-83,-84,84,70,84,154
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 64kg,Sarah Smiley,61.95,62,-64,64,83,-86,-86,64,83,147
+Lord of the Lifts Super Competition,2016-10-16,Open Women's 63 kg,Tamara Gray,58.9,62,63,64,77,78,80,64,80,144
+Lord of the Lifts Super Competition,2016-10-16,Open Women's +75 Kg,Misty Leflar,78.4,61,61,63,72,74,77,63,77,140
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 59kg,Kaitlyn Fiore,56.55,60,63,-66,73,-76,77,63,77,140
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 64kg,Emma WEI,61.1,55,-60,60,75,-80,80,60,80,140
+Lord of the Lifts Super Competition,2020-02-15,Women's Masters (35-39) 81kg,Chresa Anderson,79.3,-52,52,55,73,-76,79,55,79,134
+Lord of the Lifts Super Competition,2020-02-15,Women's Masters (35-39) 64kg,Millie Suk,60.8,56,-59,-60,73,-77,77,56,77,133
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 59kg,Ashley Cronin,58.55,47,50,-55,65,70,75,50,75,125
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 59kg,Marguerite Beckingham,55,47,50,53,60,66,70,53,70,123
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 49kg,Theresa Tran,48.95,48,-51,51,66,69,-72,51,69,120
+Lord of the Lifts Super Competition,2016-10-16,Women's Masters (35-39) 75 kg,Lena Pace,70.9,40,44,48,60,64,68,48,68,116
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 81kg,Katie Donohue,80.7,48,-51,-51,57,-62,62,48,62,110
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 71kg,Meagan Montoya,69.25,40,43,44,57,-65,-65,44,57,101
+Lord of the Lifts Super Competition,2020-02-15,Men's 14-15 Age Group 89kg,Benjamin Spangler,83.25,40,44,48,45,51,-57,48,51,99
+Lord of the Lifts Super Competition,2020-02-15,Women's Masters (40-44) 64kg,Inoira Maduro,59.25,-36,36,38,52,-55,55,38,55,93
+Lord of the Lifts Super Competition,2020-02-15,Men's 13 Under Age Group 67kg,Isaiah Parsons,63.7,34,37,40,40,43,46,40,46,86
+Lord of the Lifts Super Competition,2020-02-15,Men's 13 Under Age Group 61kg,Grant Spangler,58.1,27,30,34,31,34,36,34,36,70
+Lord of the Lifts Super Competition,2020-02-15,Women's 14-15 Age Group 45kg,HarleyJane Carter,42.65,20,24,27,27,31,-34,27,31,58
+Lord of the Lifts Super Competition,2016-10-16,Men's 13 Under Age Group 44kg,Ashley Gray,39.5,17,18,19,25,26,26,19,26,45
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 71kg,Chelsie Frisby,70.55,45,-48,49,-66,-67,-68,49,0,0
+Lord of the Lifts Super Competition,2020-02-15,Open Women's 71kg,Shala Giardini,70.35,-80,-83,-85,82,-95,-97,0,82,0
+Lord of the Lifts Super Competition,2020-02-15,Men's Masters (35-39) 81kg,juan leo baltierra,79.95,95,100,103,-123,-125,-125,103,0,0
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 81kg,Devin Perreault,80.05,-97,-98,-99,123,-127,-127,0,123,0
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 96kg,Jonathan Denning,93.5,106,110,-114,-140,-141,-141,110,0,0
+Lord of the Lifts Super Competition,2020-02-15,Open Men's 102kg,John San Filippo,100.9,106,113,120,-134,-140,-140,120,0,0

--- a/event_data/US/2180.csv
+++ b/event_data/US/2180.csv
@@ -1,0 +1,14 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Red River Classic,2016-10-15,Open Men's 105 kg,Jordan Berroteran,99.4,123,130,134,163,167,170,134,170,304
+Red River Classic,2016-10-15,Open Men's 85 kg,Beaux Blackwood,83.4,0,125,127,153,0,157,127,157,284
+Red River Classic,2016-10-15,Open Men's+105 kg,Chad Troquille,161.6,91,96,102,135,140,145,102,145,247
+Red River Classic,2016-10-15,Open Men's 105 kg,Fred Passin,101.7,103,0,108,120,125,130,108,130,238
+Red River Classic,2016-10-15,Open Men's 85 kg,Brandon Wheeler,79.6,68,81,0,102,0,107,81,107,188
+Red River Classic,2016-10-15,Open Men's 77 kg,Noah Crofton,72.27,70,75,80,90,95,100,80,100,180
+Red River Classic,2016-10-15,Open Women's 63 kg,Rachel Knight,62.1,62,0,65,78,80,0,65,80,145
+Red River Classic,2016-10-15,Open Women's +75 Kg,Napatong Anderson,81.2,52,54,0,0,64,66,54,66,120
+Red River Classic,2016-10-15,Men's 14-15 Age Group 77 kg,Joshua Peterman,71,43,0,45,60,64,0,45,64,109
+Red River Classic,2016-10-15,Women's 13 Under Age Group +58 Kg,Savannah Brister,61.4,28,35,38,40,42,45,38,45,83
+Red River Classic,2016-10-15,Women's 14-15 Age Group +69 kg,Kaci Kennedy,86.7,33,36,0,40,43,45,36,45,81
+Red River Classic,2016-10-15,Women's 16-17 Age Group 44 kg,Alexandra Lazarus,40.9,0,25,26,35,37,40,26,40,66
+Red River Classic,2016-10-15,Women's 13 Under Age Group 31kg,Emma Lazarus,29.9,10,12,15,12,15,17,15,17,32

--- a/event_data/US/2187.csv
+++ b/event_data/US/2187.csv
@@ -1,0 +1,97 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 105 kg,Isaac Villagrana,101.85,115,123,-130,140,148,-160,123,148,271
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Andrew King,93.95,115,120,-124,145,150,-154,120,150,270
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's+105 kg,Nick DeShane,122.75,118,122,-130,145,-150,-153,122,145,267
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 105 kg,Vernon Barber,99.25,-120,-122,122,138,143,-147,122,143,265
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's+105 kg,Thomas Gossweiler,110.4,105,-110,110,-150,150,-155,110,150,260
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Andrew Swasey,93.55,110,115,-120,135,141,-145,115,141,256
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Isaac Espriu,84.75,105,108,112,142,-145,-145,112,142,254
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Devon Hood,91.2,-105,109,113,-140,140,-147,113,140,253
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Nicholas Cousino,76.3,102,107,111,127,134,-137,111,134,245
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Jake Slaton,72.55,-110,110,-114,132,-138,-138,110,132,242
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Jonah Logan,93.65,105,110,-115,125,-130,130,110,130,240
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Alan Genter,89.45,95,98,103,125,132,137,103,137,240
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Victor Rodriguez,83.6,100,-103,103,125,-131,131,103,131,234
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Glenn Saenz,84.2,97,-100,101,126,-130,130,101,130,231
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Mitchel Galusha,76.75,90,95,100,117,122,127,100,127,227
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Alec Adkins,76.95,89,-96,96,116,126,131,96,131,227
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Diego Ambrosi,76.85,-95,95,100,125,-132,-132,100,125,225
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 69 kg,Dejay Paquillo,67.85,88,-93,95,120,125,-128,95,125,220
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Albert Argueta,83.25,88,94,98,115,122,-125,98,122,220
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Victor Le,85.5,-93,93,-98,120,-125,125,93,125,218
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,David Bennett,79.5,94,-98,-98,119,-122,122,94,122,216
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 105 kg,Jared Hartman,103.7,90,-95,-100,126,-130,-132,90,126,216
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 105 kg,Travis Pinto,94,82,93,-98,100,115,121,93,121,214
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Daniel Crescitelli,83.1,84,90,-96,112,118,122,90,122,212
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 105 kg,Christopher Valdovinos,102.9,-90,91,94,110,114,118,94,118,212
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Jaden Sanchez,72.75,86,88,92,114,117,-120,92,117,209
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Frutoso Gonzalez,91.45,90,-94,94,110,115,-121,94,115,209
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Bryce Iturzaeta,76.75,-87,87,92,113,-117,-117,92,113,205
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Juan Quintanilla,82.5,-93,93,94,-111,111,-113,94,111,205
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 105 kg,Gabriel-Alberto Arce,94,80,88,-92,111,117,-121,88,117,205
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Blake Antzoulatos,89.65,78,84,-92,117,120,-125,84,120,204
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Jose Ramirez,83.05,78,85,-91,111,115,118,85,118,203
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Scott Kellner,91.25,80,85,-91,110,116,-121,85,116,201
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Andrew Bird`,76.45,85,90,-97,-110,110,-113,90,110,200
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Marco Perez,76.45,77,82,86,95,102,110,86,110,196
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 69 kg,Christopher Erdos,68.85,80,84,89,100,104,106,89,106,195
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Anthony Sosa,92.45,80,84,-87,108,111,-113,84,111,195
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Nestor Damasco,72.9,76,82,-87,100,107,-109,82,107,189
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Christian Figueroa,76.8,76,82,-90,100,106,-113,82,106,188
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Ryan Espiritu,74.3,-77,77,82,95,100,105,82,105,187
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 69 kg,Renaldo Hill,68.9,70,75,80,100,106,-112,80,106,186
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Joshua Wilson,82.9,79,-82,83,98,102,-106,83,102,185
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Sean Simon,84.55,80,86,-91,95,99,-102,86,99,185
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Kayli Bains,66,-76,-79,79,97,101,105,79,105,184
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's+105 kg,Vidans Castro,116.9,-74,77,81,100,-110,-110,81,100,181
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 90 kg,Megan Bradley,89.1,-64,64,69,95,-100,102,69,102,171
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Christopher Shipman,93.6,65,68,71,88,91,-94,71,91,162
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Kaitlin Mohr,65.2,64,68,71,87,90,-92,71,90,161
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 90 kg,Angela Mascioli,88.45,68,-73,-73,88,93,-95,68,93,161
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Natasha Shamloufard,66.45,61,65,68,84,87,91,68,91,159
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's+105 kg,Cedar Coleman,141.45,65,69,-74,-90,-90,90,69,90,159
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Josiah Timothy Molina,79.25,60,63,66,80,85,90,66,90,156
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 90 kg,Jaime Stolis,79.35,60,68,-76,72,80,86,68,86,154
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 77 kg,Renato Nerida,75.6,65,67,-69,-80,80,84,67,84,151
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 69 kg,Patrick de la Garza,67.85,61,-63,63,-85,85,87,63,87,150
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 85 kg,Brian Briggs,84.1,58,62,65,77,82,-87,65,82,147
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 58 kg,Monica Oddo,57.6,65,68,70,75,77,-79,70,77,147
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 63 kg,Tracy Temmel,62.65,65,69,-70,70,75,-81,69,75,144
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (35-39) 75 kg,Brooke Beronda,74.6,-60,60,63,75,78,80,63,80,143
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 75 kg,Amber Prado,74.95,54,57,61,70,75,80,61,80,141
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Men's 94 kg,Christopher Marshall,90.85,50,-60,60,68,74,80,60,80,140
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 58 kg,Carly Podesto,57.95,53,-56,59,74,-77,77,59,77,136
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 75 kg,Ashley Stark,74.8,58,-61,-62,71,74,77,58,77,135
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Megan Grubbs,67.85,51,54,57,66,71,76,57,76,133
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Sara Jester,68.85,50,53,-56,72,76,80,53,80,133
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Yesenia Vallejo,64.8,53,-58,58,75,-80,-82,58,75,133
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (35-39) 90 kg,Jamie Swartz,77,54,-58,-58,74,-77,77,54,77,131
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 58 kg,Dana Faldmo,56.55,56,59,62,65,69,-72,62,69,131
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 53 kg,Allison Handel,52.8,-60,60,-63,65,68,-72,60,68,128
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (35-39) 53 kg,Jacqueline Vekich,51.55,-54,57,-62,64,-68,71,57,71,128
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 75 kg,Lindsay Leahy,74.05,-53,53,-56,67,70,73,53,73,126
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 75 kg,Shannon Blyth,73.65,56,-57,-61,65,68,-71,56,68,124
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 63 kg,Jacqueline Fuller,60.2,50,53,56,60,64,68,56,68,124
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (35-39) 58 kg,Kenda Wallace,56.1,51,53,-56,66,69,-72,53,69,122
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (35-39) 58 kg,Wendy Anderson,57.55,50,52,-54,65,69,-73,52,69,121
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (40-44) 58 kg,Cheree Lovell,57.05,50,52,-55,62,66,68,52,68,120
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (40-44) 63 kg,Robyn Bennett,62.95,48,50,52,65,68,-71,52,68,120
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 63 kg,Minna Ranjeva,62.4,50,-53,-53,64,68,70,50,70,120
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 53 kg,Lauren Allen,52.95,52,54,-57,62,-65,66,54,66,120
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 75 kg,Nikoll Burko,73.25,47,50,53,65,-69,-69,53,65,118
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 75 kg,Sarah Dirro,74.6,49,52,-55,66,-70,-73,52,66,118
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 63 kg,Laura Popwell,62.95,-45,45,49,65,69,-73,49,69,118
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 63 kg,Christin Voros,60.4,45,47,51,60,64,-70,51,64,115
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 58 kg,Patricia Victoria Mata,58,50,-54,-60,60,63,-67,50,63,113
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 63 kg,Corina Guzman,62.55,48,50,-52,58,60,62,50,62,112
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's 16-17 Age Group 53 kg,Alijah Salas,52.6,-42,43,45,58,-61,63,45,63,108
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (35-39) 90 kg,Andrea Evans,77.2,45,-47,-49,57,59,62,45,62,107
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 48 kg,Elizabeth Duran,47.9,40,42,45,60,62,-65,45,62,107
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 48 kg,Thuy Nguyen,47.65,45,-48,-48,55,58,-60,45,58,103
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's 16-17 Age Group 48 kg,Lindsay Diller,47.5,42,45,48,-50,-50,50,48,50,98
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (50-54) 90 kg,Maria BARNABE,88.6,35,38,-40,58,-60,-60,38,58,96
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's +90 kg,Andressa Giacomini,99.55,32,36,42,43,48,-55,42,48,90
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (55-59) 48 kg,Terri Kinjo,47.9,32,-35,-35,41,-44,-45,32,41,73
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's Masters (40-44) 63 kg,theresa brinsa,60.2,26,28,-31,33,36,40,28,40,68
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Women's 13 Under Age Group 53kg,Mia Barcelo,51.8,23,25,28,30,34,37,28,37,65
+Double Barrel Classic Presented by Rogue Fitness,2017-02-12,Open Women's 69 kg,Desiree Rogers,68.5,82,-84,-85,-92,-92,-92,82,0,0

--- a/event_data/US/2460.csv
+++ b/event_data/US/2460.csv
@@ -1,0 +1,10 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Open Men's 94 kg,Darrin Clement,85.9,73,77,-84,88,95,102,77,102,179
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Open Men's+105 kg,Luben Ikonomov,136.8,66,70,75,84,88,95,75,95,170
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Open Men's+105 kg,caleb Davidson,119.8,59,64,68,-84,84,93,68,93,161
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Open Men's 94 kg,Zane Rodriguez,91.8,55,59,-61,75,-82,-82,59,75,134
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Open Men's 77 kg,Leon Pelletier,74.8,-48,48,52,-54,-54,59,52,59,111
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Women's Masters (60-64) 75 kg,Valerie Thompson,69.5,32,34,37,41,43,45,37,45,82
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Women's Masters (50-54) 48 kg,Denise Bloom,43.6,32,-34,34,41,43,0,34,43,77
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Open Women's 63 kg,Nicole Cameron,62.8,32,-34,-34,-41,-41,41,32,41,73
+Thor's Stone Winter Weightlifting Meet,2017-02-11,Women's Masters (65-69) 53 kg,Jane Higgins,52,26,29,0,34,36,39,29,39,68

--- a/event_data/US/2808.csv
+++ b/event_data/US/2808.csv
@@ -1,0 +1,35 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+End of Summer Meet,2017-09-16,Open Men's 85 kg,Tylor Sanchez,83.1,114,-119,119,145,151,156,119,156,275
+End of Summer Meet,2017-09-16,Open Men's 105 kg,Dominick Farris,103.3,98,103,-108,130,135,142,103,142,245
+End of Summer Meet,2017-09-16,Open Men's 94 kg,Alan-Nghia Duong,92.4,102,106,109,130,135,-140,109,135,244
+End of Summer Meet,2017-09-16,Open Men's 105 kg,Christopher O'Daniel,97.5,98,104,-110,130,-136,136,104,136,240
+End of Summer Meet,2017-09-16,Open Men's 105 kg,Carlos Wendler,104.4,-100,100,105,120,127,-132,105,127,232
+End of Summer Meet,2017-09-16,Open Men's 77 kg,Sergio Celis,69.5,97,-100,-101,113,-115,-115,97,113,210
+End of Summer Meet,2017-09-16,Open Men's 85 kg,Andrew Stuart,84.2,89,-93,93,110,115,-119,93,115,208
+End of Summer Meet,2017-09-16,Open Men's 94 kg,Mark Nelson,93.2,75,80,85,100,105,110,85,110,195
+End of Summer Meet,2017-09-16,Open Men's 94 kg,Ching Lu,93.7,81,-85,-85,-110,110,111,81,111,192
+End of Summer Meet,2017-09-16,Open Men's 77 kg,Marc Charest,76.2,-85,85,-90,102,106,-110,85,106,191
+End of Summer Meet,2017-09-16,Open Men's 77 kg,Raymundo Gardea,69.2,-80,80,85,103,106,-109,85,106,191
+End of Summer Meet,2017-09-16,Open Men's 62 kg,Erik Nunez,61.49,72,76,-80,98,103,106,76,106,182
+End of Summer Meet,2017-09-16,Open Women's +90 kg,Consuelo Rios,116.74,75,78,-81,97,-102,102,78,102,180
+End of Summer Meet,2017-09-16,Open Men's 85 kg,Adam El Hamlaoui,83.9,-72,72,77,98,-102,-102,77,98,175
+End of Summer Meet,2017-09-16,Open Women's 53 kg,Jessica Gianardi,53,-60,60,64,90,-93,95,64,95,159
+End of Summer Meet,2017-09-16,Open Women's 63 kg,Pilar Bennett,62.61,-61,-66,66,80,86,-90,66,86,152
+End of Summer Meet,2017-09-16,Open Women's 53 kg,Robyn Feder,52.94,59,61,63,82,-85,-86,63,82,145
+End of Summer Meet,2017-09-16,Open Women's 69 kg,Katherine (Katie) Plante,67.4,60,63,-65,71,75,78,63,78,141
+End of Summer Meet,2017-09-16,Open Men's 94 kg,Joseph Parmoon,88.47,65,-67,-67,65,66,67,65,67,132
+End of Summer Meet,2017-09-16,Open Women's 53 kg,Iriana Grajeda,52.98,51,53,56,71,73,76,56,76,132
+End of Summer Meet,2017-09-16,Open Women's +90 kg,Alexis MacLennan Kenney,93.01,51,54,-57,65,69,72,54,72,126
+End of Summer Meet,2017-09-16,Women's Masters (35-39) 90 kg,Alisa Damholt,80.19,48,-51,51,62,65,68,51,68,119
+End of Summer Meet,2017-09-16,Open Women's 58 kg,Emily Maxon,55.66,46,-48,48,65,68,-71,48,68,116
+End of Summer Meet,2017-09-16,Women's Masters (35-39) 58 kg,Lisa Hood,57.9,47,49,52,60,63,-66,52,63,115
+End of Summer Meet,2017-09-16,Open Women's +90 kg,Desa Daniel,104.3,40,44,48,62,65,-67,48,65,113
+End of Summer Meet,2017-09-16,Open Men's 56 kg,Jacob Rutgers,56,-41,-41,41,56,60,-65,41,60,101
+End of Summer Meet,2017-09-16,Men's 13 Under Age Group 56 Kg,Mazen Salzman,54,40,42,44,45,48,52,44,52,96
+End of Summer Meet,2017-09-16,Women's Masters (45-49) 58 kg,Dina Jansen,57.6,35,38,-41,45,48,-51,38,48,86
+End of Summer Meet,2017-09-16,Women's 16-17 Age Group +75 kg,Sadie Steadman,82.95,30,34,38,36,41,-45,38,41,79
+End of Summer Meet,2017-09-16,Open Women's 58 kg,Melissa Barbara,56.49,28,-30,31,-40,42,45,31,45,76
+End of Summer Meet,2017-09-16,Women's Masters (60-64) 53 kg,Carolyn Sajdecki,48.44,23,26,-29,33,36,-39,26,36,62
+End of Summer Meet,2017-09-16,Men's 14-15 Age Group 56 Kg,Paolo Vela,55.4,25,27,-29,30,34,-38,27,34,61
+End of Summer Meet,2017-09-16,Women's Masters (60-64) 58 kg,Linda Rouse,53.53,20,-23,-23,-25,25,28,20,28,48
+End of Summer Meet,2017-09-16,Open Men's 69 kg,Riley Banez,68.4,-95,-95,-100,121,-126,-127,0,121,0

--- a/event_data/US/2820.csv
+++ b/event_data/US/2820.csv
@@ -1,0 +1,17 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Athletic Lab Fall Classic,2017-09-17,Open Men's+105 kg,Steven Gaudet,120.7,120,-125,130,163,175,-186,130,175,305
+Athletic Lab Fall Classic,2017-09-17,Open Men's 85 kg,Anthony Kerr,84.1,120,125,130,-150,152,-157,130,152,282
+Athletic Lab Fall Classic,2017-09-17,Open Men's 94 kg,Joshua Wells,92.8,110,-120,-120,150,160,-176,110,160,270
+Athletic Lab Fall Classic,2017-09-17,Open Men's 77 kg,Cole Fandale,76.6,-118,120,-122,143,148,-154,120,148,268
+Athletic Lab Fall Classic,2017-09-17,Open Men's+105 kg,Franklin Muntis,121.4,92,97,102,112,-117,121,102,121,223
+Athletic Lab Fall Classic,2017-09-17,Open Men's 77 kg,Michael Young,77,96,-101,102,-115,-117,118,102,118,220
+Athletic Lab Fall Classic,2017-09-17,Open Men's 85 kg,Timothy Nguyen,80.9,-85,-85,85,105,110,113,85,113,198
+Athletic Lab Fall Classic,2017-09-17,Open Men's 94 kg,Michael Joyce,93.5,85,-90,-92,110,-120,-121,85,110,195
+Athletic Lab Fall Classic,2017-09-17,Open Men's 94 kg,Charles Davis,90.1,72,73,-77,85,90,-95,73,90,163
+Athletic Lab Fall Classic,2017-09-17,Women's 14-15 Age Group 58 kg,Hannah Dunn,58,58,60,62,68,70,73,62,73,135
+Athletic Lab Fall Classic,2017-09-17,Open Women's 63 kg,Courtney Brock,61.9,50,-56,-56,69,-74,-76,50,69,119
+Athletic Lab Fall Classic,2017-09-17,Women's 16-17 Age Group +75 kg,Victoria Saunders,152.6,43,47,50,56,60,63,50,63,113
+Athletic Lab Fall Classic,2017-09-17,Women's Masters (45-49) 63 kg,Margaret Litton,60.3,43,45,-47,53,56,58,45,58,103
+Athletic Lab Fall Classic,2017-09-17,Men's 13 Under Age Group 62 Kg,Austin Roberts,58.8,25,30,35,39,48,-57,35,48,83
+Athletic Lab Fall Classic,2017-09-17,Women's 14-15 Age Group 69 kg,Anna Shiffler,64.5,25,27,30,38,43,46,30,46,76
+Athletic Lab Fall Classic,2017-09-17,Open Men's 105 kg,James Gold,101,100,-105,-108,-128,-133,-135,100,0,0

--- a/event_data/US/2834.csv
+++ b/event_data/US/2834.csv
@@ -1,0 +1,11 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's+105 kg,Tyler Sears,116,110,117,121,130,140,144,121,144,265
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's 85 kg,Sam Lucas,84.4,-110,-110,110,125,130,-136,110,130,240
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's 105 kg,Cody Watkins,103,-110,110,-115,130,-140,-140,110,130,240
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's 105 kg,Christian John,105,95,100,-106,130,135,-140,100,135,235
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's 77 kg,Dominic Cairns-Shaw,76.7,97,100,-105,115,120,-125,100,120,220
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's 105 kg,Jerrel Fairweather,105,-90,-90,90,-125,-125,125,90,125,215
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Women's 53 kg,Becky Reaver,52.7,52,-56,57,71,-72,-72,57,71,128
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Women's 53 kg,Valentina Amaya,52.2,38,41,47,-53,53,-59,47,53,100
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Women's 63 kg,Tierra Carter,63,-57,-57,-57,68,-70,-70,0,68,0
+Port Saint Lucie Weightlifting Qualifier,2017-09-16,Open Men's 85 kg,Lee Codner,84.9,95,100,-105,-120,-120,-125,100,0,0

--- a/event_data/US/2846.csv
+++ b/event_data/US/2846.csv
@@ -1,0 +1,18 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Orlando Open,2017-09-16,Open Men's 77 kg,Nahum Guerrero,74.8,100,104,-108,128,134,140,104,140,244
+Orlando Open,2017-09-16,Open Men's 77 kg,Dade Stanley,72.5,100,103,105,125,131,137,105,137,242
+Orlando Open,2017-09-16,Open Men's 85 kg,Braylin Young,83,100,103,-105,125,131,137,103,137,240
+Orlando Open,2017-09-16,Open Men's 77 kg,Jonathan Gilley,74.4,90,100,-110,120,128,-130,100,128,228
+Orlando Open,2017-09-16,Open Men's 94 kg,Glenn Taylor,91.7,88,-92,-93,115,-120,-120,88,115,203
+Orlando Open,2017-09-16,Open Men's 85 kg,Garrett Krichbaum,83.9,80,84,88,108,112,-116,88,112,200
+Orlando Open,2017-09-16,Open Men's 85 kg,Teddy Binette,83.3,63,67,71,88,91,94,71,94,165
+Orlando Open,2017-09-16,Open Women's 75 kg,Skylar Matelau,75,59,-62,-62,78,-81,-82,59,78,137
+Orlando Open,2017-09-16,Women's 16-17 Age Group 53 kg,Maryah Collins,52.6,58,61,-63,71,75,-78,61,75,136
+Orlando Open,2017-09-16,Women's 16-17 Age Group 69 kg,Kyleigh Beecham,67.5,50,52,-54,65,70,74,52,74,126
+Orlando Open,2017-09-16,Men's 14-15 Age Group 77 kg,James padgett,76.6,45,48,52,57,61,70,52,70,122
+Orlando Open,2017-09-16,Women's 14-15 Age Group 63 kg,Rebekah taylor,60.9,43,46,49,58,62,65,49,65,114
+Orlando Open,2017-09-16,Open Women's 58 kg,Lydia Piedra,56.4,-42,42,44,57,-60,60,44,60,104
+Orlando Open,2017-09-16,Women's 16-17 Age Group 75 kg,Allyanna Dunbar,70.8,38,41,43,52,56,-60,43,56,99
+Orlando Open,2017-09-16,Open Women's 58 kg,Valerie Thomas,56.8,-42,42,-45,49,51,54,42,54,96
+Orlando Open,2017-09-16,Women's Masters (50-54) 90 kg,Mary  (Betsy) Binette,85.5,32,35,-38,48,51,54,35,54,89
+Orlando Open,2017-09-16,Open Women's +90 kg,Eliana Gonzalez,96.2,36,38,40,45,-48,48,40,48,88

--- a/event_data/US/2871.csv
+++ b/event_data/US/2871.csv
@@ -1,0 +1,32 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2017 Marin Open,2017-09-16,Open Men's+105 kg,Shane Sevcik,124,135,-141,145,165,-175,-176,145,165,310
+2017 Marin Open,2017-09-16,Open Men's 94 kg,Yang Su,93.6,112,116,120,140,145,-150,120,145,265
+2017 Marin Open,2017-09-16,Open Men's+105 kg,Raphael Dozzi,111,105,-110,110,140,145,-151,110,145,255
+2017 Marin Open,2017-09-16,Open Men's 85 kg,Nathan Prokop,83.6,97,102,-107,132,140,147,102,147,249
+2017 Marin Open,2017-09-16,Open Men's 85 kg,Daniel David,84.7,97,101,-103,132,-135,-136,101,132,233
+2017 Marin Open,2017-09-16,Open Men's 94 kg,Minh Triet Pham,93.3,100,103,106,127,-136,-136,106,127,233
+2017 Marin Open,2017-09-16,Open Men's 85 kg,Colin Swann,82.1,95,100,-105,120,125,-130,100,125,225
+2017 Marin Open,2017-09-16,Open Women's 90 kg,Phoebe Ng,81.7,84,-87,88,107,111,114,88,114,202
+2017 Marin Open,2017-09-16,Women's 16-17 Age Group 75 kg,Athena Schrijver,73.1,83,-87,87,105,109,113,87,113,200
+2017 Marin Open,2017-09-16,Open Men's 85 kg,Julian Pantano,82.7,76,81,86,101,106,-111,86,106,192
+2017 Marin Open,2017-09-16,Men's 14-15 Age Group 77 kg,William Prokop,69.5,74,78,82,90,95,-100,82,95,177
+2017 Marin Open,2017-09-16,Open Men's 85 kg,Manuel Reyes,83.1,70,-74,76,95,101,-106,76,101,177
+2017 Marin Open,2017-09-16,Open Women's 63 kg,Alexandra Lorenzen,62.5,73,-75,75,95,98,100,75,100,175
+2017 Marin Open,2017-09-16,Open Men's 62 kg,Abel Mendoza,62,69,73,77,88,93,97,77,97,174
+2017 Marin Open,2017-09-16,Open Women's 90 kg,Brianna Lamb,77.3,70,-75,75,90,95,-100,75,95,170
+2017 Marin Open,2017-09-16,Open Women's 69 kg,Emily Atkinson,69,66,70,72,86,90,93,72,93,165
+2017 Marin Open,2017-09-16,Open Men's 94 kg,Terry Dickman,93.6,65,69,72,85,89,92,72,92,164
+2017 Marin Open,2017-09-16,Open Women's 58 kg,seraphina schinner,57.4,70,72,74,84,87,-90,74,87,161
+2017 Marin Open,2017-09-16,Open Women's 69 kg,Debra Austin,67,62,-66,66,80,84,-87,66,84,150
+2017 Marin Open,2017-09-16,Open Women's 48 kg,Chloe Tacata,48,59,-62,62,79,-83,-83,62,79,141
+2017 Marin Open,2017-09-16,Open Men's 85 kg,Ivan Castro,84.6,60,64,-67,72,74,76,64,76,140
+2017 Marin Open,2017-09-16,Open Men's 94 kg,Russell Stolp,89,53,57,60,73,78,-81,60,78,138
+2017 Marin Open,2017-09-16,Women's 16-17 Age Group 63 kg,Katherine Hull,60.6,-51,52,55,68,71,-75,55,71,126
+2017 Marin Open,2017-09-16,Women's Masters (35-39) 63 kg,Hollee Curl,62.7,-50,52,-55,68,72,-75,52,72,124
+2017 Marin Open,2017-09-16,Open Women's 63 kg,Charlotte Pay,61,54,-57,-60,68,-72,-72,54,68,122
+2017 Marin Open,2017-09-16,Women's 16-17 Age Group 53 kg,Mckenzie Barnes,52.3,50,53,-56,62,65,68,53,68,121
+2017 Marin Open,2017-09-16,Men's 13 Under Age Group 50 Kg,Bodhi Aldridge,47.6,-29,29,31,37,40,-43,31,40,71
+2017 Marin Open,2017-09-16,Women's 13 Under Age Group 58kg,Isabella Faye,57.9,-26,27,30,36,-39,-39,30,36,66
+2017 Marin Open,2017-09-16,Open Men's 105 kg,Michael Ramage,101,120,-123,123,-150,-150,-150,123,0,0
+2017 Marin Open,2017-09-16,Open Women's 63 kg,Brittany DiMarco,61.9,-75,75,-76,-95,-95,-95,75,0,0
+2017 Marin Open,2017-09-16,Open Women's 69 kg,Challen Pressley Schleh,69,-80,-83,-84,100,105,-107,0,105,0

--- a/event_data/US/294.csv
+++ b/event_data/US/294.csv
@@ -1,0 +1,16 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Western States Fall Open,2015-09-13,Open Men's 85 kg,Tommy Flanagan,83.99,107,-111,-113,132,140,0,107,140,247
+Western States Fall Open,2015-09-13,Open Men's 85 kg,Karl Johnson,84.03,107,-111,113,134,-140,-146,113,134,247
+Western States Fall Open,2015-09-13,Open Men's 85 kg,Nathaniel Goertz,84.95,105,110,-115,-129,131,-137,110,131,241
+Western States Fall Open,2015-09-13,Open Men's 85 kg,Brian Bender,84.01,103,-107,-107,125,-130,130,103,130,233
+Western States Fall Open,2015-09-13,Open Men's 94 kg,Corey King,90.57,75,-78,80,93,97,102,80,102,182
+Western States Fall Open,2015-09-13,Open Men's 85 kg,Nicholas Anderson,84.68,70,75,80,90,95,100,80,100,180
+Western States Fall Open,2015-09-13,Open Men's 85 kg,Alex Paine,78.45,78,-82,-84,94,-98,98,78,98,176
+Western States Fall Open,2015-09-13,Open Men's 77 kg,Devin Pace,72.04,74,77,80,85,92,-98,80,92,172
+Western States Fall Open,2015-09-13,Open Women's 58 kg,Devoney Cooke,57.36,64,67,70,80,85,-91,70,85,155
+Western States Fall Open,2015-09-13,Women's 16-17 Age Group 63 kg,Sheridan Lintz,61.96,-52,52,-54,70,-74,-75,52,70,122
+Western States Fall Open,2015-09-13,Open Women's 58 kg,Maria Snyder,53.47,50,52,-55,61,65,-69,52,65,117
+Western States Fall Open,2015-09-13,Women's 13 Under Age Group 48kg,Isabelle Hageman,47.36,30,32,34,47,50,53,34,53,87
+Western States Fall Open,2015-09-13,Open Men's 85 kg,James Cushing-murray,84.32,37,40,-43,44,-48,-52,40,44,84
+Western States Fall Open,2015-09-13,Open Men's 62 kg,mychael swenning,61.84,-88,-88,-91,-108,-108,-108,0,0,0
+Western States Fall Open,2015-09-13,Open Women's 75 kg,Shayla Shell,73.35,-63,-63,-63,82,86,-89,0,86,0

--- a/event_data/US/310.csv
+++ b/event_data/US/310.csv
@@ -1,0 +1,70 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+TCA Fall Lift-off,2015-09-12,Open Men's 105 kg,carlos Ramos,103.04,112,122,-126,150,-160,-160,122,150,272
+TCA Fall Lift-off,2015-09-12,Open Men's 105 kg,Paul Bezilla,102.36,111,115,120,137,-140,0,120,137,257
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Kerris Seward,75.32,110,-115,-118,125,132,140,110,140,250
+TCA Fall Lift-off,2015-09-12,Open Men's 94 kg,Aaron Martinez,89.54,102,106,110,136,-143,-143,110,136,246
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Connor Malone,81.45,105,110,-116,-130,133,-137,110,133,243
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Nabil Suleiman,74.92,105,107,110,122,127,-133,110,127,237
+TCA Fall Lift-off,2015-09-12,Open Men's 105 kg,Eric Carlos,102.48,-95,-96,96,-135,138,-143,96,138,234
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,David Manatan,83.62,105,108,-110,120,125,-130,108,125,233
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Erik Raposa,75.62,-105,105,107,125,-130,-130,107,125,232
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Aaron Glean-Sealey,75.78,100,104,-106,128,-130,-130,104,128,232
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Carlos Quiros,82.36,92,97,102,115,-125,128,102,128,230
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Michael Willoughby,75.04,99,-102,-102,124,128,-133,99,128,227
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Kristian Guerra,84.68,-100,100,104,118,122,-127,104,122,226
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Jensen Talmo,73.22,87,91,95,119,123,-127,95,123,218
+TCA Fall Lift-off,2015-09-12,Open Men's+105 kg,Michael Soto,110.55,92,97,-103,115,120,-123,97,120,217
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Danny Ear,75.54,-90,90,-95,121,-125,-127,90,121,211
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Jeffrey Morgan,76.78,90,94,-97,110,115,-120,94,115,209
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Dane Tiongson,84.62,-95,-95,95,110,-115,-116,95,110,205
+TCA Fall Lift-off,2015-09-12,Open Men's 105 kg,Jason Luo,100.74,85,90,95,105,110,-116,95,110,205
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Pluton Gradeci,82.74,85,88,-93,105,-110,110,88,110,198
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Paolo Sison,83.2,-85,85,-90,105,110,-115,85,110,195
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,James Corsini,80.3,73,77,81,-102,102,106,81,106,187
+TCA Fall Lift-off,2015-09-12,Open Women's 69 kg,Allison Truscheit,67.04,83,-87,-89,95,98,101,83,101,184
+TCA Fall Lift-off,2015-09-12,Open Women's +75 Kg,Crystal Plouffe,75,77,81,-84,102,-104,-104,81,102,183
+TCA Fall Lift-off,2015-09-12,Open Men's 105 kg,James Barry,99.58,75,78,-80,95,-100,100,78,100,178
+TCA Fall Lift-off,2015-09-12,Open Men's 94 kg,Ben David,89.32,70,75,80,90,96,-100,80,96,176
+TCA Fall Lift-off,2015-09-12,Open Men's 69 kg,Eric Trinh,69,68,-72,72,86,92,95,72,95,167
+TCA Fall Lift-off,2015-09-12,Open Women's +75 Kg,Heather Duarte,114.42,64,68,70,89,94,-100,70,94,164
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Graham Nesas,84.5,65,70,74,85,-90,90,74,90,164
+TCA Fall Lift-off,2015-09-12,Open Men's 94 kg,Angel Duarte,92.18,64,-68,68,90,-102,-102,68,90,158
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Kevin Peng,74.4,-66,68,-75,81,87,-92,68,87,155
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Aaron Cruz,85,60,62,65,70,74,78,65,78,143
+TCA Fall Lift-off,2015-09-12,Open Men's+105 kg,Forrest Campbell,122.44,60,65,-71,70,-75,78,65,78,143
+TCA Fall Lift-off,2015-09-12,Open Women's 63 kg,Deanna Douglas,62.5,56,62,66,71,-75,76,66,76,142
+TCA Fall Lift-off,2015-09-12,Open Women's 53 kg,Wendy Huang,51.92,57,59,62,75,79,-82,62,79,141
+TCA Fall Lift-off,2015-09-12,Open Women's 58 kg,Ashley Dvorin,55.64,58,61,63,-68,69,71,63,71,134
+TCA Fall Lift-off,2015-09-12,Open Women's 63 kg,Kathleen Nogoy,62.56,55,-57,-57,70,75,77,55,77,132
+TCA Fall Lift-off,2015-09-12,Open Women's 69 kg,Rocio Ramirez,67.68,-55,57,-63,68,73,-80,57,73,130
+TCA Fall Lift-off,2015-09-12,Open Women's 75 kg,Megan Schrader,72.3,52,56,-59,65,70,73,56,73,129
+TCA Fall Lift-off,2015-09-12,Open Women's 58 kg,Cynthia Rodriguez,54.76,54,-57,-58,69,73,-76,54,73,127
+TCA Fall Lift-off,2015-09-12,Open Women's +75 Kg,Mackenzie Levine,78.56,55,-59,-59,66,70,-74,55,70,125
+TCA Fall Lift-off,2015-09-12,Open Men's 69 kg,Willis Wong,67.52,-52,52,-55,-70,-70,70,52,70,122
+TCA Fall Lift-off,2015-09-12,Women's Masters (40-44) 75 kg,Rachel Mickelson,70.56,51,55,-58,60,65,-68,55,65,120
+TCA Fall Lift-off,2015-09-12,Open Men's 56 kg,Miguel Sanchez,52.8,48,-50,51,66,68,-71,51,68,119
+TCA Fall Lift-off,2015-09-12,Open Women's 69 kg,Alix Furgang,67.52,43,46,50,68,-73,-74,50,68,118
+TCA Fall Lift-off,2015-09-12,Open Women's 58 kg,CHRISTINE REES,56.92,43,47,-52,57,62,64,47,64,111
+TCA Fall Lift-off,2015-09-12,Women's Masters (35-39) 58 kg,Kimberly Carrasco,57.2,46,48,51,54,57,59,51,59,110
+TCA Fall Lift-off,2015-09-12,Open Men's+105 kg,Jeff Francis,111.98,40,45,-50,61,65,-70,45,65,110
+TCA Fall Lift-off,2015-09-12,Women's Masters (50-54) 58 kg,Julie Foley,57.26,45,-48,49,56,60,-62,49,60,109
+TCA Fall Lift-off,2015-09-12,Women's Masters (35-39) 75 kg,Micel Reynoso,69.12,35,40,45,50,55,61,45,61,106
+TCA Fall Lift-off,2015-09-12,Open Men's 62 kg,Griffin Smith,60.4,43,-47,-47,-57,57,62,43,62,105
+TCA Fall Lift-off,2015-09-12,Women's Masters (45-49) 63 kg,Laurie Espinosa,61.96,43,-45,-46,57,60,-63,43,60,103
+TCA Fall Lift-off,2015-09-12,Open Women's 53 kg,Sarah Thornhill,50.12,35,40,-46,50,-55,55,40,55,95
+TCA Fall Lift-off,2015-09-12,Open Men's 62 kg,Art Tarwater,59,41,-43,43,51,-55,-56,43,51,94
+TCA Fall Lift-off,2015-09-12,Open Women's +75 Kg,Elizabeth Rawson,85.96,-37,37,40,47,50,53,40,53,93
+TCA Fall Lift-off,2015-09-12,Women's Masters (45-49) 53 kg,Jami Chung,49.36,38,41,-44,49,-52,52,41,52,93
+TCA Fall Lift-off,2015-09-12,Open Women's 53 kg,Christine Banares,50.82,25,30,-36,40,45,-51,30,45,75
+TCA Fall Lift-off,2015-09-12,Women's Masters (50-54) 58 kg,Deanna Johnson,57.52,28,30,-32,40,-42,-45,30,40,70
+TCA Fall Lift-off,2015-09-12,Open Women's 75 kg,Elisa Rhynedance,74.44,75,77,-79,-94,-95,-95,77,0,0
+TCA Fall Lift-off,2015-09-12,Open Men's 69 kg,David Mak,68.56,-90,-90,-90,105,-110,110,0,110,0
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Geoffrey Yazzetta,74.42,-92,-94,-94,111,113,-116,0,113,0
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,David Sellin,75.3,-97,-98,-98,-120,120,-130,0,120,0
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Ador Lopez,84.12,102,107,-110,-130,-130,-132,107,0,0
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Erik Fay,84.28,103,-108,-108,-139,-139,-144,103,0,0
+TCA Fall Lift-off,2015-09-12,Open Men's 105 kg,Will Burns,101.6,-106,-106,107,-135,-136,-136,107,0,0
+TCA Fall Lift-off,2015-09-12,Open Men's 77 kg,Blair Lowe,77,-85,-86,-87,100,-105,-107,0,100,0
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Brach Poston,84.48,115,-121,-121,-132,-132,-132,115,0,0
+TCA Fall Lift-off,2015-09-12,Open Men's 85 kg,Scott Miller,84.57,-90,90,94,-114,-114,-114,94,0,0
+TCA Fall Lift-off,2015-09-12,Open Men's 94 kg,Robert Bozick,88.69,-85,-88,-88,-105,-110,-110,0,0,0

--- a/event_data/US/3115.csv
+++ b/event_data/US/3115.csv
@@ -1,0 +1,14 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+ABC Invitational,2018-01-27,Open Men's 105 kg,Trey Lovell,98.7,118,121,-125,145,151,157,121,157,278
+ABC Invitational,2018-01-27,Open Men's 85 kg,Kyle Peterson,84.1,110,-115,118,134,140,143,118,143,261
+ABC Invitational,2018-01-27,Open Men's+105 kg,Silas Hoeppner,120,96,102,109,120,127,136,109,136,245
+ABC Invitational,2018-01-27,Women's Masters (35-39) 69 kg,Lacey Sotelo,68.1,63,66,-68,86,87,91,66,91,157
+ABC Invitational,2018-01-27,Open Women's 63 kg,Alyssa Wilhelm,61.1,67,-71,71,-80,81,-88,71,81,152
+ABC Invitational,2018-01-27,Open Women's 63 kg,Elva Griffin,62.4,-58,-58,59,74,77,80,59,80,139
+ABC Invitational,2018-01-27,Women's Masters (35-39) 58 kg,Sonya Miller,55.1,59,-62,-62,73,76,-79,59,76,135
+ABC Invitational,2018-01-27,Women's Masters (35-39) 58 kg,Rebecca DeWild,57,48,50,53,67,70,72,53,72,125
+ABC Invitational,2018-01-27,Open Men's 56 kg,Shea Parkis,56,43,46,48,63,66,70,48,70,118
+ABC Invitational,2018-01-27,Open Women's 53 kg,Paige Citurs,52.8,49,-51,-51,62,65,-67,49,65,114
+ABC Invitational,2018-01-27,Men's 13 Under Age Group 39kg,Riley Parkis,37.3,-28,30,-34,43,46,-50,30,46,76
+ABC Invitational,2018-01-27,Men's 13 Under Age Group 56 Kg,John Teggatz,51.7,25,28,30,31,35,38,30,38,68
+ABC Invitational,2018-01-27,Women's 13 Under Age Group 53kg,Gracy Johnson,49,23,25,28,28,30,32,28,32,60

--- a/event_data/US/3120.csv
+++ b/event_data/US/3120.csv
@@ -1,0 +1,52 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Packer Weightlifting Meet,2018-01-27,Open Men's 77 kg,Dylan Brandt,74.7,85,90,-95,113,-120,-120,90,113,203
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,Nicholas Mathias,90.2,82,87,92,105,111,-117,92,111,203
+Packer Weightlifting Meet,2018-01-27,Open Men's 105 kg,Ali Younis,97.5,82,87,-95,115,-124,-124,87,115,202
+Packer Weightlifting Meet,2018-01-27,Open Men's+105 kg,Tristan Duerr,120.7,-86,-86,86,110,-115,-115,86,110,196
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,Kirkland Zitzow,78.7,63,68,-72,95,100,105,68,105,173
+Packer Weightlifting Meet,2018-01-27,Open Men's 77 kg,Troy Knutson,75.6,64,-68,68,92,-95,100,68,100,168
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,Jacob Wesley,87.9,72,-76,-76,-93,93,-97,72,93,165
+Packer Weightlifting Meet,2018-01-27,Open Men's+105 kg,NOLAN MAIER,109,-70,70,72,90,92,-100,72,92,164
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,Justin Rudnick,79.6,66,-70,-70,86,89,97,66,97,163
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,jada kuchlong,79.2,69,-73,73,83,-88,89,73,89,162
+Packer Weightlifting Meet,2018-01-27,Open Men's 77 kg,Leseberg Gabriel,76.1,65,67,-70,79,89,0,67,89,156
+Packer Weightlifting Meet,2018-01-27,Open Men's 69 kg,Logan Kainz,68.5,61,65,-69,83,-87,89,65,89,154
+Packer Weightlifting Meet,2018-01-27,Open Men's 69 kg,Caleb Jamieson,66.9,58,64,-70,79,83,88,64,88,152
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,Cristian Vega,90.7,-59,60,63,80,84,87,63,87,150
+Packer Weightlifting Meet,2018-01-27,Open Men's 77 kg,Jacob Palluck,75.2,55,61,66,74,79,82,66,82,148
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,Alexander Pahl,91.2,53,57,63,80,-83,-83,63,80,143
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,Mahmoud Younis,82,52,57,59,70,74,82,59,82,141
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,Robert Chalifoux,86.9,52,56,60,75,78,81,60,81,141
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,Justin Burnside,82,52,57,60,70,74,80,60,80,140
+Packer Weightlifting Meet,2018-01-27,Open Men's 69 kg,Tyminderious Hayes,63.4,56,59,-61,74,78,-83,59,78,137
+Packer Weightlifting Meet,2018-01-27,Open Men's 77 kg,Jack Schaub,71.3,54,58,-62,74,-78,78,58,78,136
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,Elliot Mathias,84.1,53,59,-64,74,-79,-79,59,74,133
+Packer Weightlifting Meet,2018-01-27,Open Men's 85 kg,Isaac Benedict,82.9,52,56,62,68,71,-76,62,71,133
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,Javier Quiroz,87.9,53,-57,-59,73,77,80,53,80,133
+Packer Weightlifting Meet,2018-01-27,Open Men's 62 kg,Kaden Tranby,60.8,51,-55,-55,71,76,-80,51,76,127
+Packer Weightlifting Meet,2018-01-27,Open Men's 56 kg,Logan Shaw,54.3,48,-52,-52,67,73,78,48,78,126
+Packer Weightlifting Meet,2018-01-27,Open Women's +90 kg,Denise Charley,115.6,52,-56,-56,-65,65,70,52,70,122
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group +75 kg,Dominique Charley,109.8,47,-52,-54,61,65,70,47,70,117
+Packer Weightlifting Meet,2018-01-27,Open Men's 69 kg,Jose Franssen,65,45,-50,51,50,55,60,51,60,111
+Packer Weightlifting Meet,2018-01-27,Open Men's 69 kg,Desmond Hester,68.2,45,48,51,-57,59,-62,51,59,110
+Packer Weightlifting Meet,2018-01-27,Open Women's 90 kg,Shane Spencer,88.8,47,-51,-52,61,-66,-66,47,61,108
+Packer Weightlifting Meet,2018-01-27,Open Women's 58 kg,Alexis Thomas,57.6,-49,49,-51,-58,58,-60,49,58,107
+Packer Weightlifting Meet,2018-01-27,Open Women's +90 kg,Kallie Zander,90.5,36,40,44,54,59,-62,44,59,103
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group +75 kg,Gabrielle Feil,80.8,41,45,-47,-53,-57,57,45,57,102
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group 58 kg,Kiarra Summers,56.8,-40,40,-42,51,-55,55,40,55,95
+Packer Weightlifting Meet,2018-01-27,Open Women's 90 kg,Melaine Koffi,81.5,34,38,-46,43,47,54,38,54,92
+Packer Weightlifting Meet,2018-01-27,Women's 14-15 Age Group +69 kg,Claire Atchison,72,34,-38,-38,-48,-51,51,34,51,85
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group 58 kg,Sophie Schaumann,58,38,-42,-42,41,45,-52,38,45,83
+Packer Weightlifting Meet,2018-01-27,Open Women's 63 kg,Terruth Massy,61.4,33,-38,-38,44,49,-53,33,49,82
+Packer Weightlifting Meet,2018-01-27,Men's 13 Under Age Group 69 Kg,Micah Cozad,66.7,28,33,-36,43,-46,46,33,46,79
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group +75 kg,Olivia Arth,78,30,-34,34,39,-43,43,34,43,77
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group +75 kg,Yitzel Delgado,89.1,-33,-34,34,43,-48,-51,34,43,77
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group 58 kg,Gabriella Hernandez,55.1,31,-33,34,40,42,-47,34,42,76
+Packer Weightlifting Meet,2018-01-27,Men's 13 Under Age Group 50 Kg,Xavier Thomas,44.6,22,-25,-26,34,-36,36,22,36,58
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group +75 kg,Althea Bradsteen,85.7,-43,-43,-43,56,-59,-59,0,56,0
+Packer Weightlifting Meet,2018-01-27,Open Men's+105 kg,Sergio Gomzalez,127.8,53,-56,-56,-76,-76,-76,53,0,0
+Packer Weightlifting Meet,2018-01-27,Open Men's+105 kg,Tyler Martin,133.3,-55,-55,-55,65,69,73,0,73,0
+Packer Weightlifting Meet,2018-01-27,Open Men's 94 kg,JACOB LILJA,93.1,54,-57,59,-87,-87,-87,59,0,0
+Packer Weightlifting Meet,2018-01-27,Open Men's+105 kg,Jameson Cozad,123.1,-90,-93,-93,0,0,0,0,0,0
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group 75 kg,Ellie Rehder,70.3,30,-34,-34,-43,-43,-52,30,0,0
+Packer Weightlifting Meet,2018-01-27,Women's 16-17 Age Group 58 kg,Olivia Carlson,57.6,-44,-44,-44,-56,56,58,0,58,0

--- a/event_data/US/3275.csv
+++ b/event_data/US/3275.csv
@@ -1,0 +1,58 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2018 Armor Open,2018-10-27,Open Men's 89kg,Christopher Douglas,82,123,127,-132,157,-165,165,127,165,292
+2018 Armor Open,2018-10-27,Open Men's 81kg,David Adeyemo,75.3,112,-116,117,150,155,159,117,159,276
+2018 Armor Open,2018-10-27,Open Men's 96kg,Jeremy Garcia,95.15,-120,120,-125,155,-165,-165,120,155,275
+2018 Armor Open,2018-10-27,Open Men's 96kg,Jake Cirincione,92.55,115,-122,-122,145,-150,-153,115,145,260
+2018 Armor Open,2018-10-27,Open Men's 89kg,Daniel Gally,85.65,102,-106,108,128,133,-139,108,133,241
+2018 Armor Open,2018-10-27,Open Men's 81kg,Michael Westbrooks,80.7,100,-105,-105,-130,130,-137,100,130,230
+2018 Armor Open,2018-10-27,Open Men's 89kg,Jonathan Acevedo,88,100,-105,-106,130,-133,0,100,130,230
+2018 Armor Open,2018-10-27,Open Men's 89kg,Colin Schembri,87.05,95,100,-105,112,117,125,100,125,225
+2018 Armor Open,2018-10-27,Open Men's +109kg,Nicholas Dewing,121.9,87,92,96,119,125,-127,96,125,221
+2018 Armor Open,2018-10-27,Open Men's 73kg,Mason Ostrom,72.35,-100,-100,100,120,-125,-125,100,120,220
+2018 Armor Open,2018-10-27,Open Men's 96kg,Craig Cadonau,94.65,-96,-97,97,118,120,-122,97,120,217
+2018 Armor Open,2018-10-27,Open Women's +87kg,McKenzie Warren,129.5,85,-90,90,105,110,-115,90,110,200
+2018 Armor Open,2018-10-27,Open Men's 102kg,Joseph Menz,100.7,-87,87,-92,108,112,-116,87,112,199
+2018 Armor Open,2018-10-27,Open Men's 81kg,Joshua Folen,80.3,81,-86,90,101,106,-110,90,106,196
+2018 Armor Open,2018-10-27,Open Men's 89kg,Tom Yabe,86.15,-84,84,-89,102,107,111,84,111,195
+2018 Armor Open,2018-10-27,Open Men's 73kg,Maxwell Lessman,71.55,-75,76,79,100,106,110,79,110,189
+2018 Armor Open,2018-10-27,Open Women's 81kg,Samantha Dowgin,80.85,80,-84,-85,100,-104,104,80,104,184
+2018 Armor Open,2018-10-27,Open Men's 89kg,Andrew Rutherford,87.15,-80,81,82,94,97,100,82,100,182
+2018 Armor Open,2018-10-27,Open Women's 71kg,Brittany Brooks,70.75,73,76,80,94,97,-100,80,97,177
+2018 Armor Open,2018-10-27,Open Men's +109kg,Zachary Wright,120,70,74,-77,98,-103,-107,74,98,172
+2018 Armor Open,2018-10-27,Women's Masters (35-39) 59kg,Ashleigh Moe,58.1,70,73,75,91,94,-98,75,94,169
+2018 Armor Open,2018-10-27,Open Men's 73kg,Andrew Sheng,72.65,65,69,72,92,96,-101,72,96,168
+2018 Armor Open,2018-10-27,Open Men's 89kg,Geoffrey Kubitz,86,63,66,70,85,90,94,70,94,164
+2018 Armor Open,2018-10-27,Women's Masters (35-39) 71kg,Christy Campbell,70.7,71,-74,-75,89,92,-94,71,92,163
+2018 Armor Open,2018-10-27,Open Women's 71kg,Samantha Matte,65.15,64,67,70,84,87,90,70,90,160
+2018 Armor Open,2018-10-27,Open Women's +87kg,Samantha Noe,88.15,62,66,69,76,81,86,69,86,155
+2018 Armor Open,2018-10-27,Open Women's 64kg,Laramie Eckerdt,63.64,68,-71,71,80,83,-86,71,83,154
+2018 Armor Open,2018-10-27,Open Women's 55kg,Ann-Marie Doble,54.65,64,67,-69,82,86,-89,67,86,153
+2018 Armor Open,2018-10-27,Women's Masters (40-44) 71kg,Kimberly Renken,68.6,68,-71,-72,83,-87,-88,68,83,151
+2018 Armor Open,2018-10-27,Open Women's 76kg,Erica Honkonen,72,65,-68,68,83,-86,-86,68,83,151
+2018 Armor Open,2018-10-27,Open Women's 71kg,Kailee Simons,65.7,-68,68,-71,79,82,-84,68,82,150
+2018 Armor Open,2018-10-27,Open Women's 71kg,Stefanie Hatlin,68.1,64,67,-70,80,-83,83,67,83,150
+2018 Armor Open,2018-10-27,Women's 14-15 Age Group 55kg,Katharine Estep,54.3,59,62,65,74,78,80,65,80,145
+2018 Armor Open,2018-10-27,Open Women's 59kg,Emily Baskin,57.9,58,61,64,73,77,81,64,81,145
+2018 Armor Open,2018-10-27,Open Women's 71kg,helena hudak,64.75,57,-62,-62,80,82,85,57,85,142
+2018 Armor Open,2018-10-27,Women's 14-15 Age Group 55kg,Noelle Toro,54.3,59,61,63,72,76,78,63,78,141
+2018 Armor Open,2018-10-27,Open Women's 55kg,Heather Oltmann,54.4,63,-66,-66,78,-81,-81,63,78,141
+2018 Armor Open,2018-10-27,Open Women's 76kg,Ashley Righetti,74.55,55,58,60,75,79,-81,60,79,139
+2018 Armor Open,2018-10-27,Women's Masters (35-39) 71kg,Lauren Plooster,69.45,50,54,-56,68,71,73,54,73,127
+2018 Armor Open,2018-10-27,Women's Masters (35-39) +87kg,Jennifer Burruel,129.65,50,-54,54,66,72,-80,54,72,126
+2018 Armor Open,2018-10-27,Open Men's 89kg,Christopher Mullins,82.8,40,45,-49,70,75,80,45,80,125
+2018 Armor Open,2018-10-27,Open Women's 59kg,Kaitlyn Henry,57.5,49,52,54,60,63,-66,54,63,117
+2018 Armor Open,2018-10-27,Open Women's 71kg,Stephanie Mills,70.05,47,50,-53,64,67,-70,50,67,117
+2018 Armor Open,2018-10-27,Women's Masters (35-39) 76kg,Shannyn Fuerst,75.5,45,47,-51,59,62,65,47,65,112
+2018 Armor Open,2018-10-27,Open Women's 71kg,Allison Pastewka,70.75,45,48,-50,56,59,62,48,62,110
+2018 Armor Open,2018-10-27,Open Women's 64kg,Laura Price,63.3,43,46,47,-57,57,59,47,59,106
+2018 Armor Open,2018-10-27,Open Women's 71kg,Elsa Moluf,66.25,42,45,-49,53,57,-61,45,57,102
+2018 Armor Open,2018-10-27,Women's 13 Under Age Group 55kg,Natalie Hatch,53.1,40,43,45,48,52,55,45,55,100
+2018 Armor Open,2018-10-27,Women's Masters (45-49) 59kg,April Freeland,59,39,41,-44,52,54,-56,41,54,95
+2018 Armor Open,2018-10-27,Women's Masters (40-44) 59kg,Kim Saito,55.25,36,-38,-38,50,52,55,36,55,91
+2018 Armor Open,2018-10-27,Women's 13 Under Age Group 55kg,Alina Dziembowski,51.8,36,38,-40,46,49,-50,38,49,87
+2018 Armor Open,2018-10-27,Women's 13 Under Age Group 36kg,Kendra Hoover,34.15,34,36,37,45,48,50,37,50,87
+2018 Armor Open,2018-10-27,Women's 14-15 Age Group 55kg,Lauren Mau,51.8,34,-36,36,43,46,49,36,49,85
+2018 Armor Open,2018-10-27,Women's Masters (35-39) 71kg,Sarah Goff,70.5,38,40,42,40,43,-44,42,43,85
+2018 Armor Open,2018-10-27,Women's 13 Under Age Group 36kg,Cuchara Baron,33.65,9,10,11,11,13,15,11,15,26
+2018 Armor Open,2018-10-27,Open Men's 96kg,Jonathan Douglas,94.65,118,122,-128,-145,-146,-146,122,0,0
+2018 Armor Open,2018-10-27,Open Men's 96kg,Dylan Bergschneider,94.15,117,121,-125,0,0,0,121,0,0

--- a/event_data/US/3373.csv
+++ b/event_data/US/3373.csv
@@ -1,0 +1,45 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Relentless Open,2018-10-27,Open Men's 102kg,Kyle Barber,98.12,120,125,-130,150,-155,-155,125,150,275
+Relentless Open,2018-10-27,Open Men's 81kg,Vinnie Hoffman,80.75,103,106,109,136,141,146,109,146,255
+Relentless Open,2018-10-27,Open Men's +109kg,Matt Hess,133.09,100,105,-108,130,135,-136,105,135,240
+Relentless Open,2018-10-27,Open Men's 96kg,Alex Masl,91.35,91,-96,101,120,126,131,101,131,232
+Relentless Open,2018-10-27,Open Men's 102kg,John Demko,98.22,90,-95,95,123,128,133,95,133,228
+Relentless Open,2018-10-27,Open Men's 102kg,Dom Gomez,97,93,98,-103,120,125,130,98,130,228
+Relentless Open,2018-10-27,Open Men's 81kg,Derek Palmerton,79.4,-93,-93,93,110,114,-120,93,114,207
+Relentless Open,2018-10-27,Open Men's 89kg,Christopher Arroyo,86.34,-91,-91,91,110,-120,-120,91,110,201
+Relentless Open,2018-10-27,Open Men's 96kg,Logan McMahon,90.92,82,-94,-94,95,100,107,82,107,189
+Relentless Open,2018-10-27,Open Men's 81kg,"Richard Pearsall, II",80.92,-74,75,78,-101,101,105,78,105,183
+Relentless Open,2018-10-27,Open Women's 64kg,Sabrina Jennings,63.34,78,-81,82,88,-91,-91,82,88,170
+Relentless Open,2018-10-27,Open Men's 81kg,Tyler Shoulders,77.38,70,75,-80,90,95,-100,75,95,170
+Relentless Open,2018-10-27,Open Women's 71kg,Breanne Prinkey,70.22,-71,-73,73,-94,95,-97,73,95,168
+Relentless Open,2018-10-27,Open Men's 96kg,Michael Phillips,92.23,60,66,74,85,90,-100,74,90,164
+Relentless Open,2018-10-27,Open Men's 61kg,alec coulter,60.92,63,67,71,82,87,92,71,92,163
+Relentless Open,2018-10-27,Open Men's 73kg,John Crawford,70.86,60,65,-68,80,85,92,65,92,157
+Relentless Open,2018-10-27,Open Women's 81kg,Emily Kessler-Lewis,80.96,65,-69,-72,-83,-84,84,65,84,149
+Relentless Open,2018-10-27,Women's Masters (35-39) +87kg,Brandi Darby,93.71,65,-70,-71,72,-77,78,65,78,143
+Relentless Open,2018-10-27,Open Men's 67kg,Xiao Chuan Ong,65.98,-60,60,65,75,-80,-80,65,75,140
+Relentless Open,2018-10-27,Open Men's 67kg,Andre Ainsworth,66.84,-61,61,64,71,75,-80,64,75,139
+Relentless Open,2018-10-27,Open Women's 76kg,Jaime Achille,73.57,-58,-58,58,75,80,-87,58,80,138
+Relentless Open,2018-10-27,Open Men's 61kg,Trey Kratz,55.88,55,58,60,67,72,75,60,75,135
+Relentless Open,2018-10-27,Women's Masters (40-44) 71kg,Denise Dunbar,70.14,57,-60,-62,72,75,-78,57,75,132
+Relentless Open,2018-10-27,Open Women's 59kg,Marisa Galli,58.94,-51,51,-55,-75,75,-78,51,75,126
+Relentless Open,2018-10-27,Women's Masters (35-39) 55kg,Nichole Summers,53.76,53,55,-57,66,69,71,55,71,126
+Relentless Open,2018-10-27,Women's 16-17 Age Group 76kg,Alexis Talluto,73.09,44,48,52,60,65,71,52,71,123
+Relentless Open,2018-10-27,Women's Masters (35-39) 64kg,Mary Haines,61.62,46,48,51,61,64,-68,51,64,115
+Relentless Open,2018-10-27,Open Women's 76kg,Priscilla Araujo,73.02,-50,50,-54,65,-70,-70,50,65,115
+Relentless Open,2018-10-27,Open Women's +87kg,Jena Dahl,125.93,46,-49,49,59,62,65,49,65,114
+Relentless Open,2018-10-27,Women's Masters (35-39) 71kg,Maghan Lunsford,70.98,49,-52,-52,62,-65,65,49,65,114
+Relentless Open,2018-10-27,Open Women's 76kg,Megan Shaner,73.14,43,-46,48,56,59,64,48,64,112
+Relentless Open,2018-10-27,Women's Masters (45-49) 55kg,Aimee Rice,52.06,47,50,-52,55,60,-65,50,60,110
+Relentless Open,2018-10-27,Open Women's 59kg,Erin Herhold,59,-47,47,48,58,61,-63,48,61,109
+Relentless Open,2018-10-27,Open Men's 89kg,Luke Darby,81.32,40,45,-53,-56,56,-60,45,56,101
+Relentless Open,2018-10-27,Men's 14-15 Age Group 67kg,Dylan Young,67,34,-37,37,50,55,-58,37,55,92
+Relentless Open,2018-10-27,Women's 16-17 Age Group 64kg,Shelby Harris,60.76,-35,-35,35,50,55,-60,35,55,90
+Relentless Open,2018-10-27,Women's Masters (45-49) 55kg,Tracey Weaver,52.23,36,39,42,43,45,48,42,48,90
+Relentless Open,2018-10-27,Women's 13 Under Age Group 40kg,Isabella Rice,39.16,25,27,29,-31,33,-37,29,33,62
+Relentless Open,2018-10-27,Men's 13 Under Age Group 44kg,Jack Weaver,40.57,18,20,22,26,29,31,22,31,53
+Relentless Open,2018-10-27,Open Men's 73kg,Gregory McElravy,69.02,-103,-103,-103,0,0,0,0,0,0
+Relentless Open,2018-10-27,Open Women's 71kg,Madison Mitchell,70.55,-56,-56,-57,-72,75,-80,0,75,0
+Relentless Open,2018-10-27,Open Women's +87kg,Sarah Crow,111.36,-42,-42,-42,50,53,56,0,56,0
+Relentless Open,2018-10-27,Open Men's 81kg,adam hess,80.14,-104,-106,-106,125,132,-138,0,132,0
+Relentless Open,2018-10-27,Women's 16-17 Age Group 55kg,Carleen Shasko,55,57,-60,-62,-76,-76,-76,57,0,0

--- a/event_data/US/3414.csv
+++ b/event_data/US/3414.csv
@@ -1,0 +1,47 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Sooner State Open,2018-10-27,Open Men's 102kg,Austin Atkins,101.8,135,140,143,165,171,-176,143,171,314
+Sooner State Open,2018-10-27,Open Men's 96kg,Makoa Tyndall,94,125,128,131,155,159,162,131,162,293
+Sooner State Open,2018-10-27,Open Men's +109kg,Nickolas Shironaka,134,125,-130,135,145,152,-156,135,152,287
+Sooner State Open,2018-10-27,Open Men's 102kg,Jason Frimpong,101,106,112,-120,156,164,-170,112,164,276
+Sooner State Open,2018-10-27,Open Men's 102kg,Aaron Price,100,125,-127,127,144,146,148,127,148,275
+Sooner State Open,2018-10-27,Open Men's 102kg,Stephen Trevino,96,114,-116,-117,142,144,148,114,148,262
+Sooner State Open,2018-10-27,Open Men's 96kg,joseph Moos,93.7,-95,95,102,125,132,140,102,140,242
+Sooner State Open,2018-10-27,Open Men's 89kg,Samuel Suflita,89,105,111,-115,128,-134,-135,111,128,239
+Sooner State Open,2018-10-27,Open Men's 102kg,Matt Laird,101.6,105,-108,-109,125,-132,132,105,132,237
+Sooner State Open,2018-10-27,Open Men's +109kg,Xander Parsons,117,95,99,103,120,125,-129,103,125,228
+Sooner State Open,2018-10-27,Open Men's 73kg,Toshiro Toyama,72.9,101,105,-108,120,-126,-130,105,120,225
+Sooner State Open,2018-10-27,Open Men's 81kg,Lino Gomez,79.6,92,-96,98,114,-126,-126,98,114,212
+Sooner State Open,2018-10-27,Open Men's 96kg,JJ Prachyl,95,88,-91,-91,109,112,114,88,114,202
+Sooner State Open,2018-10-27,Open Men's 61kg,Victor Vargas,61,77,81,86,104,108,112,86,112,198
+Sooner State Open,2018-10-27,Open Men's 67kg,Willis Huynh,65.6,75,78,82,100,105,110,82,110,192
+Sooner State Open,2018-10-27,Open Men's 81kg,Reed Blackard,80.8,73,76,80,100,-105,106,80,106,186
+Sooner State Open,2018-10-27,Open Men's 81kg,Michael Jackson,78.7,-70,75,-90,90,98,106,75,106,181
+Sooner State Open,2018-10-27,Open Men's 67kg,Shamar Boone,67,71,73,-76,98,103,105,73,105,178
+Sooner State Open,2018-10-27,Open Men's 96kg,Tyler Scott,92.6,65,72,-77,90,95,101,72,101,173
+Sooner State Open,2018-10-27,Open Men's 96kg,Zachary Catella,94.9,-76,76,-81,-91,93,-96,76,93,169
+Sooner State Open,2018-10-27,Open Men's 109kg,Matthew Davidson,107.9,70,-75,-77,80,85,90,70,90,160
+Sooner State Open,2018-10-27,Open Women's +87kg,Ashley Pierson,89.5,67,71,74,75,-78,80,74,80,154
+Sooner State Open,2018-10-27,Open Women's 59kg,Elizabeth Le,56,-65,-65,65,-85,-87,87,65,87,152
+Sooner State Open,2018-10-27,Women's 14-15 Age Group +76kg,lauren williams,76,62,-65,65,75,-78,-78,65,75,140
+Sooner State Open,2018-10-27,Open Women's +87kg,Lacie Hickey,88.1,53,56,59,75,78,81,59,81,140
+Sooner State Open,2018-10-27,Open Women's 76kg,Alexis Long,71.6,55,-59,60,71,75,80,60,80,140
+Sooner State Open,2018-10-27,Women's 16-17 Age Group 76kg,Skylar Gavin,76,57,60,-63,-66,69,73,60,73,133
+Sooner State Open,2018-10-27,Open Men's 81kg,David Moore,80.3,58,-62,-62,71,74,-80,58,74,132
+Sooner State Open,2018-10-27,Open Men's 67kg,Kellen Bullock,66.1,52,-54,54,70,75,-80,54,75,129
+Sooner State Open,2018-10-27,Women's 14-15 Age Group 59kg,Karlee Carrouth,58.6,52,54,58,65,68,-72,58,68,126
+Sooner State Open,2018-10-27,Open Men's +109kg,James Knapp,117.9,50,54,57,60,64,67,57,67,124
+Sooner State Open,2018-10-27,Women's 16-17 Age Group 71kg,Piper Siler,64.8,53,-56,-59,55,58,-62,53,58,111
+Sooner State Open,2018-10-27,Men's 14-15 Age Group +89kg,Wesley Hartquist,106.1,45,48,50,55,-58,60,50,60,110
+Sooner State Open,2018-10-27,Open Women's 59kg,Heather Walton,56.9,40,43,47,55,59,-63,47,59,106
+Sooner State Open,2018-10-27,Open Women's 81kg,McKenzie Sipes,79.1,38,42,45,46,50,56,45,56,101
+Sooner State Open,2018-10-27,Open Women's 59kg,Kristen Rhoads,58.4,42,-44,-44,50,52,55,42,55,97
+Sooner State Open,2018-10-27,Open Men's 61kg,John Blasco,57.6,-41,41,44,46,51,-56,44,51,95
+Sooner State Open,2018-10-27,Open Women's 71kg,Jackeline Escobedo,66.2,33,37,-42,40,45,50,37,50,87
+Sooner State Open,2018-10-27,Men's 13 Under Age Group +73kg,Brody Richter,117,30,35,40,30,37,43,40,43,83
+Sooner State Open,2018-10-27,Open Men's 67kg,Austin Smith,65.4,36,-38,38,40,42,45,38,45,83
+Sooner State Open,2018-10-27,Men's 13 Under Age Group 73kg,Damian Stewart,71.8,25,30,33,25,30,35,33,35,68
+Sooner State Open,2018-10-27,Men's 13 Under Age Group 73kg,Cheii Larney,72,22,-24,25,30,32,34,25,34,59
+Sooner State Open,2018-10-27,Women's Masters (55-59) 59kg,Jocelyn Ludlow,59,16,17,-18,20,22,23,17,23,40
+Sooner State Open,2018-10-27,Women's 13 Under Age Group 40kg,Yocelin Soto,37.9,7,10,12,12,14,-17,12,14,26
+Sooner State Open,2018-10-27,Open Women's 81kg,Marissa Roberson,79.4,-75,-75,-75,90,-94,0,0,90,0
+Sooner State Open,2018-10-27,Open Men's 81kg,Timothy Christopher,74.1,0,0,0,0,0,0,0,0,0

--- a/event_data/US/3529.csv
+++ b/event_data/US/3529.csv
@@ -1,0 +1,63 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 109kg,Matthew Coffelt,107.52,135,141,148,165,170,175,148,175,323
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 102kg,Kevin Wexler,96.9,120,124,128,-150,157,160,128,160,288
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 96kg,Joey Brinton,92.08,-115,118,-122,-147,147,-152,118,147,265
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Tyson Hymas,86.58,108,-113,115,133,138,144,115,144,259
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 73kg,Sun Chang,71.94,102,106,110,132,136,140,110,140,250
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Dylan Clagg,87.74,105,108,-114,133,-138,140,108,140,248
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 109kg,Kelly Johnson,107.62,94,99,105,-133,-133,133,105,133,238
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 96kg,Kris Foster,94.8,100,104,108,116,-125,125,108,125,233
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Kallton Josephson,88.42,98,-112,-112,114,125,-132,98,125,223
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's +109kg,Kyle Alexander,120.52,92,97,-102,125,-129,-130,97,125,222
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 81kg,James Petzke,80.38,93,100,-106,120,-122,-122,100,120,220
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Brandon Ober,83.76,95,100,-106,115,120,-125,100,120,220
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Nathan Erickson,82.9,93,96,-100,120,-124,124,96,124,220
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's +109kg,Leon Samuels,133.96,90,95,100,110,115,120,100,120,220
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Vince D'Orazi,87.46,98,-104,-111,-118,120,-130,98,120,218
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Jeffrey Templeton,85.62,88,92,96,110,116,121,96,121,217
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 89kg,Carlos Pliego Gomez,87.16,-90,90,93,117,-120,120,93,120,213
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 73kg,Lucas Carlisle,71.86,87,90,95,107,111,117,95,117,212
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (35-39) 64kg,Kristi Brewer,63.34,80,84,88,106,109,112,88,112,200
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's +87kg,Shay Carlock,87,87,-90,90,108,-110,110,90,110,200
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 81kg,Tyson Berg,79.88,-84,86,96,-100,104,-112,96,104,200
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 109kg,Andres Bueno,102.1,75,-78,78,105,110,115,78,115,193
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 67kg,Connor Davis,66.76,66,76,82,90,100,110,82,110,192
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 73kg,Derek Andreason,71.94,73,76,-79,103,106,110,76,110,186
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 96kg,Neil Skorka,95.3,73,75,77,-103,103,107,77,107,184
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 81kg,Alec Hedlund,73.2,-78,78,-81,-95,96,100,78,100,178
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 71kg,Cassandra Smith,67.38,75,80,84,90,93,-97,84,93,177
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 76kg,Megan Wetzel,75.94,70,-73,74,-92,92,95,74,95,169
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 76kg,Crystal Brinton,74.68,72,-76,-78,91,95,-98,72,95,167
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 67kg,Edmund Ellis,65.94,70,-73,76,80,84,88,76,88,164
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 81kg,Alexis Onofre,75.88,60,65,71,83,90,-95,71,90,161
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 73kg,Kevin Burke,71.1,66,68,-71,88,-91,-91,68,88,156
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 64kg,Maren Conolly,62.1,66,68,-72,83,85,-89,68,85,153
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 71kg,addison coffelt,67.38,65,-68,68,79,84,-87,68,84,152
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (50-54) +87kg,Deborah Hanscom,101.52,55,58,62,80,84,88,62,88,150
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 64kg,Chelsy Okuma,63.6,67,-70,-72,81,-85,-87,67,81,148
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's 16-17 Age Group 59kg,Rylie Krahn,58.9,64,67,-71,-79,80,-82,67,80,147
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 76kg,Tara Boerman,73.8,60,61,-68,75,79,84,61,84,145
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 55kg,Arrow Anderson,54.36,55,-57,57,75,-77,78,57,78,135
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (35-39) 49kg,Courtney Yamada-Anderson,47.98,51,53,55,70,-73,75,55,75,130
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's +87kg,Shelly Lucas,90.8,54,-57,57,69,-72,72,57,72,129
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 55kg,Megan Chang,54.62,52,55,-57,68,71,73,55,73,128
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 59kg,Bailey Sharpe,57,56,58,-61,70,-75,-75,58,70,128
+2018 Idaho State Weightlifting Championships,2018-10-27,Men's 13 Under Age Group 67kg,Henry Chouinard,65.8,50,54,57,65,68,71,57,71,128
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's +87kg,Baillee Poage,95.4,47,-52,-52,75,77,80,47,80,127
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 87kg,Alexandra Behrend,82.5,47,50,-53,73,76,-80,50,76,126
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 61kg,Connor Burback,60.38,51,54,-56,65,68,71,54,71,125
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 55kg,Shea Moyer,54.9,47,-50,50,65,67,70,50,70,120
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (35-39) 59kg,Petra Jauregui,58.2,45,50,55,60,-65,65,55,65,120
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 55kg,Raela Mink,54,45,50,-55,60,63,66,50,66,116
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 55kg,Amber Jones,51.7,45,-48,50,60,64,-67,50,64,114
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 81kg,Dalia Mellish,79.5,45,-50,50,55,60,-65,50,60,110
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 71kg,Amber Nelson,65.4,45,48,-50,55,60,-65,48,60,108
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 71kg,Adriann Romero,69.8,41,44,-48,61,-64,64,44,64,108
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (35-39) 49kg,Caroline Merritt,48.8,43,-45,45,59,62,-65,45,62,107
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (50-54) 55kg,Brenda Walden,55,-35,35,-38,50,53,-56,35,53,88
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's Masters (40-44) 55kg,Kerry Davis,54.6,35,38,-39,45,-46,-46,38,45,83
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Women's 87kg,Araceli Corona,81.6,32,36,-40,42,46,-50,36,46,82
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's 16-17 Age Group 55kg,Isabel Ruiz,49.3,26,-30,-30,-38,-38,38,26,38,64
+2018 Idaho State Weightlifting Championships,2018-10-27,Open Men's 55kg,Frank Beauvais,54.5,22,25,29,27,28,31,29,31,60
+2018 Idaho State Weightlifting Championships,2018-10-27,Women's 13 Under Age Group 30kg,SkotLynd Cagle,26.9,21,-23,-23,-31,31,-32,21,31,52
+2018 Idaho State Weightlifting Championships,2018-10-27,Men's 13 Under Age Group 36kg,Trey Peterson,32.3,13,15,17,18,21,24,17,24,41

--- a/event_data/US/3531.csv
+++ b/event_data/US/3531.csv
@@ -1,0 +1,23 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 109kg,David Hodgin,105.6,102,107,-112,132,137,142,107,142,249
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 73kg,Nathan Weamer,72,105,-108,0,130,0,0,105,130,235
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 81kg,Cristian Ballesteros,79.9,103,105,107,122,-126,-126,107,122,229
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 89kg,Trevor Smith,85.2,85,90,93,107,114,120,93,120,213
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 96kg,Marcus Morin,90.3,85,90,95,112,-117,-117,95,112,207
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 96kg,Dylan Curet,90.9,73,-77,-77,95,100,-105,73,100,173
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 71kg,Sidney Donzella,69.8,72,77,-82,89,95,-100,77,95,172
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 71kg,sandra suito,67.7,71,-74,74,93,96,-100,74,96,170
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 81kg,Jason Lee,76,74,76,-80,85,90,-95,76,90,166
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 71kg,Emily Rea,68,56,-56,56,74,77,-80,56,77,133
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 89kg,Benjamin Tallan,88.3,-55,55,58,72,-77,-77,58,72,130
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 64kg,Lyndsey Duncan,63.2,48,50,52,62,65,68,52,68,120
+Last Chance American Open Qualifier Tucson,2018-10-27,Women's 14-15 Age Group 64kg,Mattea Mattox,62.3,49,52,54,58,61,64,54,64,118
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's +87kg,Emily Thompson,118.8,49,-52,-52,64,66,-68,49,66,115
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 87kg,Shanice Vanzandt,84.2,48,49,51,-64,64,-66,51,64,115
+Last Chance American Open Qualifier Tucson,2018-10-27,Women's Masters (35-39) 55kg,Elizabeth Wielebinski,49.5,40,43,45,51,53,-55,45,53,98
+Last Chance American Open Qualifier Tucson,2018-10-27,Women's 16-17 Age Group 71kg,Cameron Rigel,65.5,32,34,-40,50,53,58,34,58,92
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 71kg,Regina Chavez,68.4,40,-43,-43,45,50,-65,40,50,90
+Last Chance American Open Qualifier Tucson,2018-10-27,Women's Masters (35-39) 81kg,Brandy Ohnheiser,78.6,36,37,-41,46,-49,-50,37,46,83
+Last Chance American Open Qualifier Tucson,2018-10-27,Women's 13 Under Age Group 49kg,Mackenzie Wielebinski,46.5,24,27,30,36,40,43,30,43,73
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Women's 59kg,Rachael Slosky,56.7,28,29,-32,38,41,-45,29,41,70
+Last Chance American Open Qualifier Tucson,2018-10-27,Open Men's 73kg,Albert Sy,72.6,95,103,-108,-126,-132,-132,103,0,0

--- a/event_data/US/3614.csv
+++ b/event_data/US/3614.csv
@@ -1,0 +1,10 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+The Great Pumpkin Qualifier,2018-10-27,Open Men's 67kg,Carlos Millen,61.4,98,102,105,128,132,137,105,137,242
+The Great Pumpkin Qualifier,2018-10-27,Open Men's 96kg,Yane Gonzalez,91.6,85,90,-95,105,110,115,90,115,205
+The Great Pumpkin Qualifier,2018-10-27,Men's 14-15 Age Group 67kg,Keontay Price,66.7,80,-84,84,100,105,108,84,108,192
+The Great Pumpkin Qualifier,2018-10-27,Open Men's 55kg,Kye Bryant,52,80,83,87,98,102,-105,87,102,189
+The Great Pumpkin Qualifier,2018-10-27,Open Men's 67kg,Randy Lewis,63.7,77,-82,82,90,95,-100,82,95,177
+The Great Pumpkin Qualifier,2018-10-27,Women's 16-17 Age Group +81kg,Na'Erykah Goodwin,87.4,70,-74,74,92,96,-100,74,96,170
+The Great Pumpkin Qualifier,2018-10-27,Women's 13 Under Age Group 49kg,Kaiya Bryant,47,63,66,-68,78,81,83,66,83,149
+The Great Pumpkin Qualifier,2018-10-27,Women's 16-17 Age Group 76kg,Janiah Jones,76,64,-66,66,-80,-80,81,66,81,147
+The Great Pumpkin Qualifier,2018-10-27,Men's 13 Under Age Group 55kg,Ahmad Minor,53,28,30,32,37,42,-45,32,42,74

--- a/event_data/US/3631.csv
+++ b/event_data/US/3631.csv
@@ -1,0 +1,21 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Performance One Fall Open,2018-10-27,Open Men's 102kg,Heaverth Tan,101.2,115,120,125,165,170,175,125,175,300
+Performance One Fall Open,2018-10-27,Open Men's 73kg,Nathan Cerwinske,71.6,114,-117,-120,140,-145,145,114,145,259
+Performance One Fall Open,2018-10-27,Open Men's 102kg,Doug Clouse,101,100,105,-110,125,130,135,105,135,240
+Performance One Fall Open,2018-10-27,Open Men's 73kg,Braden Younglove,71.7,85,88,93,115,120,-125,93,120,213
+Performance One Fall Open,2018-10-27,Open Women's +87kg,Lauren Bennett,88.7,85,88,91,100,105,110,91,110,201
+Performance One Fall Open,2018-10-27,Open Men's 55kg,John Chubbuck,54.2,80,-83,83,105,110,-115,83,110,193
+Performance One Fall Open,2018-10-27,Women's 16-17 Age Group 64kg,Louissa Arneson,62.7,70,73,75,88,-91,91,75,91,166
+Performance One Fall Open,2018-10-27,Women's Masters (40-44) 59kg,Jenny Clouse,58.7,65,68,70,75,79,83,70,83,153
+Performance One Fall Open,2018-10-27,Open Men's 81kg,Drew Scheffer,73.8,-57,61,-65,-85,85,90,61,90,151
+Performance One Fall Open,2018-10-27,Open Women's 59kg,Tram Tran,55.3,65,68,71,75,79,-82,71,79,150
+Performance One Fall Open,2018-10-27,Open Men's 109kg,David Meltzer,102.6,50,53,56,65,70,73,56,73,129
+Performance One Fall Open,2018-10-27,Open Women's 55kg,Cayla Amatulli,53.2,50,54,58,65,68,70,58,70,128
+Performance One Fall Open,2018-10-27,Open Men's 55kg,Luke Clouse,49.3,50,53,56,64,68,72,56,72,128
+Performance One Fall Open,2018-10-27,Women's Masters (35-39) 64kg,Alanna Anthony,63.5,45,47,49,63,-68,68,49,68,117
+Performance One Fall Open,2018-10-27,Open Women's 59kg,Daisy Moreno,57.1,38,41,44,54,57,60,44,60,104
+Performance One Fall Open,2018-10-27,Open Women's 59kg,Ashley Cranford,56.8,-40,40,43,54,57,60,43,60,103
+Performance One Fall Open,2018-10-27,Women's Masters (45-49) 64kg,Nicole Slaugh,59.1,41,43,-46,54,57,59,43,59,102
+Performance One Fall Open,2018-10-27,Open Men's 55kg,Magnus Gustafson,53.2,38,41,45,54,57,-60,45,57,102
+Performance One Fall Open,2018-10-27,Men's 13 Under Age Group 44kg,Weston Clouse,43,37,-40,-40,44,47,51,37,51,88
+Performance One Fall Open,2018-10-27,Men's 13 Under Age Group 32kg,Antonino Micela,30.5,14,16,18,23,26,30,18,30,48

--- a/event_data/US/3637.csv
+++ b/event_data/US/3637.csv
@@ -1,0 +1,10 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Women's 71kg,Heather Farmer,67.5,75,85,91,107,115,-120,91,115,206
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Men's 89kg,Christopher Roan,84.8,85,90,-95,100,-105,-105,90,100,190
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Women's 55kg,Katherine Lee,54.8,70,73,75,88,-91,93,75,93,168
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Women's 71kg,Harper Spell,70.9,75,-78,-78,85,-90,-90,75,85,160
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Women's Masters (35-39) 64kg,Jessica Lake,61.5,47,-51,51,58,61,64,51,64,115
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Men's 67kg,Bryan Castillo,64.2,45,-50,-52,58,64,70,45,70,115
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Women's +87kg,Lauren Devine,123.7,41,45,48,57,60,-63,48,60,108
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Women's Masters (40-44) 64kg,Jennifer Kroll,63.4,40,43,-46,55,59,-62,43,59,102
+Out of Step Barbell Open #19 - Last Chance Qualifier!,2018-10-27,Open Men's 89kg,Justin Bradfield,88.8,-125,-125,-125,140,-145,-145,0,140,0

--- a/event_data/US/3700.csv
+++ b/event_data/US/3700.csv
@@ -1,0 +1,56 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Matthew King,95.3,110,115,120,150,155,160,120,160,280
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's +109kg,Drew Coffey,120.3,110,115,118,138,142,147,118,147,265
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Elias Talcott,80.7,100,104,109,130,137,145,109,145,254
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Lucas Cullison,79.2,100,107,-111,-140,140,145,107,145,252
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,David Graham,84.5,108,112,-116,130,137,-143,112,137,249
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Seth Hernly,90.2,102,106,-110,132,137,-140,106,137,243
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Mohammad Hakim,93.9,95,100,103,122,130,134,103,134,237
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Joshua Roberts,79.7,90,95,100,130,-135,135,100,135,235
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,Allan Moorhead,85.8,95,100,105,120,125,-135,105,125,230
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,Dane Van Paris,87.6,95,-98,-101,125,-128,131,95,131,226
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Brandon Lovett,80.8,98,102,-107,115,120,-125,102,120,222
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Drew Barnard,93.3,90,95,100,-117,117,-120,100,117,217
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Nicholas Gaines,94.4,90,94,97,110,115,120,97,120,217
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Christopher Quetant,93,75,80,85,125,132,-140,85,132,217
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 73kg,Zachary Dillow,72.7,90,93,96,120,-125,-125,96,120,216
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's +109kg,Seth Nichols,113.8,80,85,90,110,115,120,90,120,210
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,Grant Lenahan,83.3,85,90,-95,113,-117,-117,90,113,203
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Jacob Jewell,80.5,90,95,-100,105,-110,0,95,105,200
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Harold Brown lll,74.3,83,-86,86,-110,113,-118,86,113,199
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,William Fairfield,80.8,85,89,93,-106,106,-110,93,106,199
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Aaron Elledge,80.5,75,80,-87,98,-105,107,80,107,187
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,Quinton Sparrow,85,79,82,-85,100,-103,105,82,105,187
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,Nathan Quinn,86.6,65,73,83,85,95,100,83,100,183
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Carlos Garcia,80.1,70,-75,75,100,-105,107,75,107,182
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's +87kg,Hali Shaffer,93.4,74,-77,80,90,96,-100,80,96,176
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 67kg,Nikhil Shah,65.7,70,-73,73,95,-97,98,73,98,171
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 67kg,nick patterson,67,70,75,-80,95,-100,-100,75,95,170
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 89kg,Michael Warner,87.5,66,70,72,-93,93,97,72,97,169
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 55kg,Cristofer Park,51.6,65,71,75,79,84,89,75,89,164
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 71kg,Madeline Shine,67.2,-67,67,70,-87,-87,87,70,87,157
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 73kg,Harlan Siegel,70.4,58,62,66,83,-87,90,66,90,156
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 76kg,Siera Updike,72.5,55,62,68,75,82,-90,68,82,150
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 71kg,Jaclyn Fisher,67.1,65,67,-71,78,83,-85,67,83,150
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 59kg,Claire Vahary,57.6,62,65,-68,81,84,-87,65,84,149
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's Masters (40-44) 71kg,Glenna Asmus,70.4,64,-67,-67,-82,82,-86,64,82,146
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 76kg,Jaime Chase,72.1,60,63,66,72,76,80,66,80,146
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 76kg,Lexington Ziegler,75.8,60,-64,65,73,78,-82,65,78,143
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's Masters (40-44) 76kg,Cara Phillips,74,55,59,-61,70,75,-79,59,75,134
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's Masters (40-44) 87kg,Amy Brungard,86.9,50,53,56,68,72,75,56,75,131
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 81kg,Emma Wilhite,76.3,55,-58,-58,68,-72,-75,55,68,123
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 73kg,Vernon Tichenor,71.9,-45,45,50,60,66,70,50,70,120
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 64kg,Taylor Graham,61.6,45,-48,48,62,-68,70,48,70,118
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 96kg,Loren Bertocci,93.2,46,49,52,60,64,-66,52,64,116
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 71kg,Bridget Hannon,68,43,45,48,57,59,62,48,62,110
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's 14-15 Age Group 71kg,Andie Zelaya,69.5,39,43,45,55,60,65,45,65,110
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 59kg,Erika Fox,58.1,45,48,50,53,-56,56,50,56,106
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 64kg,Holly Laker,63.8,43,46,-50,54,-59,59,46,59,105
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's Masters (45-49) 64kg,Lisa Talcott,63.6,-43,43,45,45,50,53,45,53,98
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's Masters (55-59) 71kg,Frances Ledbetter,68.9,-35,35,37,45,50,53,37,53,90
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's 16-17 Age Group 71kg,Faith Holmes,68.8,38,45,-48,45,-51,-54,45,45,90
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 55kg,Lindsey Burnam,51.9,30,-35,-36,39,41,43,30,43,73
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Women's 13 Under Age Group 40kg,Grace Dietel,40,15,17,-20,20,23,-25,17,23,40
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Men's 81kg,Samuel Lee,77.6,-85,-85,-85,98,101,-105,0,101,0
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's 59kg,Morgan Wiebers,57.8,-50,-50,-50,67,-69,69,0,69,0
+Lift Lab AO Series 1 Last Chance Qualifier,2019-01-26,Open Women's +87kg,Kaitlyn Jarrett,91.5,85,-90,90,-111,-115,-115,90,0,0

--- a/event_data/US/3723.csv
+++ b/event_data/US/3723.csv
@@ -1,0 +1,30 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Feeling Frosty,2019-01-26,Open Men's 96kg,Adam Oare,92.6,97,101,-103,128,132,-135,101,132,233
+Feeling Frosty,2019-01-26,Open Men's 89kg,Calvin Pollard,88.9,-101,-101,101,125,130,-132,101,130,231
+Feeling Frosty,2019-01-26,Open Men's 102kg,Jake Brigham,98.35,83,87,90,127,132,-135,90,132,222
+Feeling Frosty,2019-01-26,Open Men's 109kg,Ruben Martinez,105.8,83,86,-89,-109,112,115,86,115,201
+Feeling Frosty,2019-01-26,Open Men's 67kg,Austin Manera,66.2,75,-80,80,104,110,115,80,115,195
+Feeling Frosty,2019-01-26,Open Men's 81kg,James Collins,80,-88,-88,90,104,-108,-112,90,104,194
+Feeling Frosty,2019-01-26,Open Men's 89kg,Enrique Torres,86.6,74,-77,-81,108,-111,-111,74,108,182
+Feeling Frosty,2019-01-26,Open Men's 89kg,ARTHUR CHU,87.55,-75,77,-81,91,97,102,77,102,179
+Feeling Frosty,2019-01-26,Open Men's 96kg,Rafael Fernandez,94.7,70,73,76,95,99,102,76,102,178
+Feeling Frosty,2019-01-26,Open Men's 81kg,Michael Sunderland,80.9,67,70,73,90,95,98,73,98,171
+Feeling Frosty,2019-01-26,Women's Masters (35-39) 71kg,Robin Brougher,69.3,65,68,71,85,89,92,71,92,163
+Feeling Frosty,2019-01-26,Open Men's 73kg,Jacob Janowiak,72.05,-66,-66,66,93,-96,-99,66,93,159
+Feeling Frosty,2019-01-26,Open Men's 81kg,Colby Yeh-Tinetti,74.8,65,68,71,-80,80,83,71,83,154
+Feeling Frosty,2019-01-26,Open Women's 49kg,Chloe Tacata,48.6,64,67,-70,79,82,85,67,85,152
+Feeling Frosty,2019-01-26,Open Women's 64kg,Chelsea Wilkes,63,-63,63,65,72,-75,77,65,77,142
+Feeling Frosty,2019-01-26,Open Women's 71kg,Jenevieve Jones,69,61,63,65,71,74,77,65,77,142
+Feeling Frosty,2019-01-26,Open Women's 59kg,Alexi Fair,56.5,56,59,61,71,74,77,61,77,138
+Feeling Frosty,2019-01-26,Women's Masters (35-39) 64kg,Stephanie Anson,59.4,61,63,-65,71,73,75,63,75,138
+Feeling Frosty,2019-01-26,Open Men's 96kg,Brian Wright,95,52,55,60,-74,-78,78,60,78,138
+Feeling Frosty,2019-01-26,Open Women's 76kg,NormaJean Hatten,76,59,63,-66,74,-77,-79,63,74,137
+Feeling Frosty,2019-01-26,Women's 16-17 Age Group 64kg,madison hamp,59.2,-54,57,59,65,69,72,59,72,131
+Feeling Frosty,2019-01-26,Open Women's 71kg,Kara Krnacik,68.1,53,56,58,70,-73,73,58,73,131
+Feeling Frosty,2019-01-26,Open Women's 64kg,Baley Houldson,62.2,50,53,-56,-70,72,-74,53,72,125
+Feeling Frosty,2019-01-26,Women's Masters (35-39) 76kg,Nyssa Hicks,72.6,49,51,53,61,64,-67,53,64,117
+Feeling Frosty,2019-01-26,Open Women's 55kg,Alexandra Lieberman,53.6,43,46,48,62,65,67,48,67,115
+Feeling Frosty,2019-01-26,Open Men's 61kg,Oliver Marche,59.55,43,-46,46,57,60,62,46,62,108
+Feeling Frosty,2019-01-26,Open Women's 76kg,Nicole Marsaglia,72.2,37,40,42,56,59,62,42,62,104
+Feeling Frosty,2019-01-26,Open Women's 76kg,Kendra Rettig,75,35,38,41,52,54,56,41,56,97
+Feeling Frosty,2019-01-26,Open Men's 55kg,Marcus Galyen,47.35,29,31,33,40,42,44,33,44,77

--- a/event_data/US/3890.csv
+++ b/event_data/US/3890.csv
@@ -1,0 +1,7 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Dayton Barbell Invitational,2019-01-26,Open Men's 102kg,Andrew Olson,101.8,100,105,-111,115,120,125,105,125,230
+Dayton Barbell Invitational,2019-01-26,Open Men's 81kg,Mark Mercier,77.4,75,80,-85,95,100,0,80,100,180
+Dayton Barbell Invitational,2019-01-26,Open Women's 76kg,Rachel Brindley,74.16,75,-78,-78,89,-94,-94,75,89,164
+Dayton Barbell Invitational,2019-01-26,Open Men's 96kg,Dakota Gereg,90.8,60,65,-70,80,85,-95,65,85,150
+Dayton Barbell Invitational,2019-01-26,Open Women's 64kg,Ani Manukian,60.3,55,58,-65,72,-75,-75,58,72,130
+Dayton Barbell Invitational,2019-01-26,Open Women's 59kg,Kiarra Matos,59,-48,48,-53,68,-72,-72,48,68,116

--- a/event_data/US/3940.csv
+++ b/event_data/US/3940.csv
@@ -1,0 +1,31 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 109kg,Samuel Christofferson,107.41,120,124,127,161,-166,-166,127,161,288
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 109kg,Tucker Benjamin,107.6,110,115,-120,145,-150,-150,115,145,260
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 89kg,Joseph Hoeve,87.37,93,97,100,137,142,146,100,146,246
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's +109kg,Jacob Conn,121.45,95,-100,-100,140,-145,-145,95,140,235
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's +109kg,Gabriel Erpelding,122.64,95,100,105,-120,120,125,105,125,230
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 81kg,Jacob Cooper,78.63,90,95,-100,-120,125,130,95,130,225
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 109kg,Matthew Mientkiewicz,105,90,93,95,120,123,-126,95,123,218
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's +109kg,David Motoyoshi,113,80,83,88,102,107,114,88,114,202
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 81kg,Aaron Larkin,77.9,86,-90,90,-107,110,112,90,112,202
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 73kg,Joseph Amundson,71.75,71,-75,75,102,107,115,75,115,190
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 76kg,Amber Klaphake,74.44,64,67,-70,-86,87,96,67,96,163
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's +87kg,Sheena Reed,133.55,70,-75,75,75,80,85,75,85,160
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 81kg,Daniel Nelson,77.47,-66,66,70,82,87,-91,70,87,157
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 73kg,William Cooke,68.16,58,62,-65,80,85,90,62,90,152
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 71kg,victoria tupy,68.01,-60,60,-64,80,84,90,60,90,150
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 81kg,Patricia Geisen,80.08,53,57,60,70,75,81,60,81,141
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 59kg,Samantha Ondrey,58.13,53,56,59,78,-82,-85,59,78,137
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 81kg,Keri Lindquist,78.48,52,55,-59,70,74,-78,55,74,129
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 76kg,Corina Loya,71.48,-52,52,55,68,72,-76,55,72,127
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's +87kg,Shelby Schroepfer,113.55,-50,50,52,71,73,-75,52,73,125
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 64kg,Lucy Berman,64,52,54,-56,-68,-68,69,54,69,123
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 81kg,Jennifer Lein,79.2,-43,-43,43,56,60,64,43,64,107
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's +87kg,Laura Lusson,104.62,40,43,-46,55,58,-61,43,58,101
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 81kg,Anneliese Wagner,78.42,-40,-40,40,55,58,61,40,61,101
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 55kg,Midori Krieger,53.2,37,40,43,52,55,-58,43,55,98
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 64kg,Angela Josephs,60.61,38,-41,41,-48,52,53,41,53,94
+Team Spartacus Spring Open 2019,2019-05-04,Women's Masters (40-44) 45kg,test aigroup,44,10,13,30,40,50,60,30,60,90
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 55kg,Alyssa Minser,52.52,-35,35,38,50,-53,-53,38,50,88
+Team Spartacus Spring Open 2019,2019-05-04,Open Women's 59kg,Ashley Greenfield,55.26,35,-37,-38,-40,40,44,35,44,79
+Team Spartacus Spring Open 2019,2019-05-04,Open Men's 73kg,Darin Vossen,70.98,95,97,-100,-126,-128,-128,97,0,0

--- a/event_data/US/3941.csv
+++ b/event_data/US/3941.csv
@@ -1,0 +1,30 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2019 Wyoming State Championships,2019-05-04,Open Men's 81kg,Shane Welter,80,98,-104,106,115,121,-128,106,121,227
+2019 Wyoming State Championships,2019-05-04,Open Men's 96kg,ALEXANDER YATES,94.8,70,73,75,95,100,-105,75,100,175
+2019 Wyoming State Championships,2019-05-04,Open Men's 73kg,Joseph Kravetsky,69.8,70,76,-85,87,92,-100,76,92,168
+2019 Wyoming State Championships,2019-05-04,Open Men's 89kg,David Currie,82.5,65,68,-72,75,79,82,68,82,150
+2019 Wyoming State Championships,2019-05-04,Open Women's 71kg,Gabrielle Perea,67.4,-59,59,-61,77,80,-82,59,80,139
+2019 Wyoming State Championships,2019-05-04,Women's Masters (45-49) 76kg,Anjanette Beard,72.7,56,58,60,74,-76,77,60,77,137
+2019 Wyoming State Championships,2019-05-04,Open Men's 89kg,William Hastings,86.5,60,-64,-64,69,72,-76,60,72,132
+2019 Wyoming State Championships,2019-05-04,Open Women's 81kg,Mikayla White,80.6,52,-54,-54,77,-80,-80,52,77,129
+2019 Wyoming State Championships,2019-05-04,Open Women's 71kg,Morgan Doporto,69.4,50,-54,54,66,70,73,54,73,127
+2019 Wyoming State Championships,2019-05-04,Open Men's 61kg,Winston Green,56.3,50,55,-60,70,-76,-76,55,70,125
+2019 Wyoming State Championships,2019-05-04,Open Women's 49kg,Samantha Lower,48.1,50,53,56,60,65,69,56,69,125
+2019 Wyoming State Championships,2019-05-04,Women's Masters (40-44) 71kg,Kellianne Kilpatrick,69,47,49,52,60,64,68,52,68,120
+2019 Wyoming State Championships,2019-05-04,Open Men's 89kg,Jedediah Bennett,87.3,42,45,0,63,68,-72,45,68,113
+2019 Wyoming State Championships,2019-05-04,Open Women's 71kg,Chloe Joesten,69.4,42,47,-51,59,64,-69,47,64,111
+2019 Wyoming State Championships,2019-05-04,Open Men's 55kg,Augustus Moeller,53.2,43,45,-46,52,56,59,45,59,104
+2019 Wyoming State Championships,2019-05-04,Open Women's 71kg,Lela C’‚‚‚‚‚Hair,65,40,43,-47,56,60,-64,43,60,103
+2019 Wyoming State Championships,2019-05-04,Open Men's 55kg,Jaxon Moe,45.1,36,-37,37,56,57,-59,37,57,94
+2019 Wyoming State Championships,2019-05-04,Women's Masters (45-49) 71kg,Christine Donovan,69.9,38,-42,-43,53,56,-60,38,56,94
+2019 Wyoming State Championships,2019-05-04,Women's Masters (35-39) 64kg,Cassandra Bennett,63.8,28,30,32,40,43,-45,32,43,75
+2019 Wyoming State Championships,2019-05-04,Women's Masters (55-59) 59kg,Corina Lymburner,57.7,30,33,35,35,38,-40,35,38,73
+2019 Wyoming State Championships,2019-05-04,Women's Masters (60-64) 76kg,Victoria Liptak,72,29,34,-39,38,-43,-43,34,38,72
+2019 Wyoming State Championships,2019-05-04,Men's 14-15 Age Group 61kg,Austin Green,61,25,27,29,35,38,41,29,41,70
+2019 Wyoming State Championships,2019-05-04,Women's 13 Under Age Group 64kg,Inger Peterson,61.2,28,30,-32,30,35,38,30,38,68
+2019 Wyoming State Championships,2019-05-04,Men's 13 Under Age Group 36kg,Tristan Moeller,34.7,23,25,26,33,35,38,26,38,64
+2019 Wyoming State Championships,2019-05-04,Men's 13 Under Age Group 36kg,Bridger Bennett,33.2,13,15,17,17,19,22,17,22,39
+2019 Wyoming State Championships,2019-05-04,Men's 13 Under Age Group 32kg,DILLON BAZZLE,32,12,14,16,15,17,20,16,20,36
+2019 Wyoming State Championships,2019-05-04,Men's 13 Under Age Group 32kg,Levi Kilpatrick,27.2,11,13,15,14,16,18,15,18,33
+2019 Wyoming State Championships,2019-05-04,Women's 13 Under Age Group 49kg,Shealyn Bennett,46.3,11,13,15,14,14,18,15,18,33
+2019 Wyoming State Championships,2019-05-04,Women's 13 Under Age Group 30kg,Gabriella Green,22,7,8,-9,7,8,9,8,9,17

--- a/event_data/US/4135.csv
+++ b/event_data/US/4135.csv
@@ -1,0 +1,6 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Double Barrel Classic,2020-06-25,Women's Masters (35-39) 71kg,Jennifer White,69.8,75,78,-81,95,98,102,78,102,180
+Double Barrel Classic,2020-02-15,Open Women's 55kg,Janessa Somera,54,54,-57,57,68,72,-78,57,72,129
+Double Barrel Classic,2020-02-15,Open Women's 64kg,Sommer Reed,63.9,50,53,56,67,70,73,56,73,129
+Double Barrel Classic,2020-07-01,Open Women's 55kg,Lauren Moreland,54,47,50,52,57,-61,64,52,64,116
+Double Barrel Classic,2020-02-16,Women's Masters (55-59) 64kg,Debra Seabern,63.9,43,45,-48,50,53,55,45,55,100

--- a/event_data/US/4307.csv
+++ b/event_data/US/4307.csv
@@ -1,0 +1,24 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Die Hard A Christmas Meet,2019-12-14,Open Men's 96kg,Harley Burke,90.8,120,125,-130,145,150,-155,125,150,275
+Die Hard A Christmas Meet,2019-12-14,Open Men's 102kg,Mack Graham,101.3,113,116,-120,-138,139,-143,116,139,255
+Die Hard A Christmas Meet,2019-12-14,Open Men's 89kg,Andre Gomez-Demine,85.7,105,110,-114,130,135,140,110,140,250
+Die Hard A Christmas Meet,2019-12-14,Open Men's +109kg,Ronald Goodwin,111.4,102,-107,-107,130,137,-141,102,137,239
+Die Hard A Christmas Meet,2019-12-14,Open Men's 81kg,Alexander Penner,79.5,105,109,-113,123,-127,-128,109,123,232
+Die Hard A Christmas Meet,2019-12-14,Open Men's 102kg,Tracy Helton,101.8,95,98,103,120,124,-127,103,124,227
+Die Hard A Christmas Meet,2019-12-14,Open Men's 89kg,Parker Ballner,87.1,96,99,-102,121,125,-129,99,125,224
+Die Hard A Christmas Meet,2019-12-14,Open Men's 102kg,Anthony Klaas V,100.8,85,90,95,103,107,112,95,112,207
+Die Hard A Christmas Meet,2019-12-14,Open Men's 81kg,Midtah Phenephom,79.5,78,82,-86,-114,114,118,82,118,200
+Die Hard A Christmas Meet,2019-12-14,Open Men's 89kg,Dilan Chudasma,81.8,-85,-85,86,-108,108,-115,86,108,194
+Die Hard A Christmas Meet,2019-12-14,Open Women's 81kg,Chelsea Hadsel,77.4,58,-61,63,77,80,84,63,84,147
+Die Hard A Christmas Meet,2019-12-14,Women's Masters (35-39) 64kg,Kathryn Meier,61.5,59,-63,-63,80,83,86,59,86,145
+Die Hard A Christmas Meet,2019-12-14,Open Women's 71kg,Marida Eriksen,67.1,-63,63,-65,70,74,78,63,78,141
+Die Hard A Christmas Meet,2019-12-14,Open Women's 59kg,Anna Suggs,58.2,55,60,-64,70,74,78,60,78,138
+Die Hard A Christmas Meet,2019-12-14,Open Women's 59kg,Alana Gamundoy,58.9,57,-59,-60,70,74,78,57,78,135
+Die Hard A Christmas Meet,2019-12-14,Open Women's 87kg,Natisha Webb,86.8,55,53,60,68,71,75,60,75,135
+Die Hard A Christmas Meet,2019-12-14,Women's Masters (40-44) 87kg,Tamara Reynolds,84.5,57,60,62,65,68,70,62,70,132
+Die Hard A Christmas Meet,2019-12-14,Open Women's 87kg,Rachel Oakley,85.1,43,46,50,55,58,65,50,65,115
+Die Hard A Christmas Meet,2019-12-14,Open Women's 64kg,NAOMI MATLEY,63.6,38,40,44,-60,61,64,44,64,108
+Die Hard A Christmas Meet,2019-12-14,Open Women's 81kg,Jazmin Booker,80.2,41,43,46,-56,58,62,46,62,108
+Die Hard A Christmas Meet,2019-12-14,Women's Masters (40-44) +87kg,Diana Fridell,91.7,41,43,45,56,59,63,45,63,108
+Die Hard A Christmas Meet,2019-12-14,Women's 16-17 Age Group 71kg,Kylie Timmons,68.4,38,40,-44,52,54,-56,40,54,94
+Die Hard A Christmas Meet,2019-12-14,Men's 13 Under Age Group 49kg,Brayden Hampton,46.8,-28,28,31,38,41,-45,31,41,72

--- a/event_data/US/4345.csv
+++ b/event_data/US/4345.csv
@@ -1,0 +1,16 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2019 Winter Classic,2019-12-14,Open Men's 109kg,Evan Hampton,106.9,100,105,110,140,145,-150,110,145,255
+2019 Winter Classic,2019-12-14,Open Men's 96kg,Nathaniel Martin,94.1,104,108,112,135,140,-145,112,140,252
+2019 Winter Classic,2019-12-14,Open Men's 102kg,Jeremy Carlson,101.1,80,87,93,110,120,128,93,128,221
+2019 Winter Classic,2019-12-14,Men's 16-17 Age Group 89kg,Collin Taylor,83.5,73,76,80,98,102,109,80,109,189
+2019 Winter Classic,2019-12-14,Open Men's 89kg,Nicholas Tan,83.5,73,76,80,98,102,109,80,109,189
+2019 Winter Classic,2019-12-14,Open Men's 67kg,Adam Carney,66.8,72,-75,-75,100,106,-110,72,106,178
+2019 Winter Classic,2019-12-14,Open Women's 71kg,Erica Bexell,69.5,60,62,-64,75,78,-82,62,78,140
+2019 Winter Classic,2019-12-14,Open Men's 81kg,Robert Howe,75.7,45,50,55,70,75,-80,55,75,130
+2019 Winter Classic,2019-12-14,Women's Masters (35-39) 59kg,Melanie Grover,57,43,49,54,55,60,65,54,65,119
+2019 Winter Classic,2019-12-14,Women's Masters (40-44) 59kg,Moira Fauth,58.2,46,48,-50,65,67,-70,48,67,115
+2019 Winter Classic,2019-12-14,Open Men's 73kg,Noah Lukinovich,71.5,40,45,50,55,60,65,50,65,115
+2019 Winter Classic,2019-12-14,Open Men's 55kg,Nicholas Tan,53.5,45,-50,-50,64,-68,68,45,68,113
+2019 Winter Classic,2019-12-14,Women's 14-15 Age Group +76kg,grace lyles,87.6,36,39,42,47,50,53,42,53,95
+2019 Winter Classic,2019-12-14,Open Women's 59kg,Audrey Brumfield,56.5,38,41,-44,50,53,-57,41,53,94
+2019 Winter Classic,2019-12-14,Open Women's 64kg,Kiersten Kolstad,60.3,-45,-47,47,0,0,0,47,0,0

--- a/event_data/US/4346.csv
+++ b/event_data/US/4346.csv
@@ -1,0 +1,36 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Thirty Flirty and Thriving,2019-12-14,Open Men's 102kg,Andrew Olson,101.1,115,-120,125,134,-140,142,125,142,267
+Thirty Flirty and Thriving,2019-12-14,Open Men's +109kg,Parker Subia,126.6,101,106,110,145,150,-160,110,150,260
+Thirty Flirty and Thriving,2019-12-14,Men's Masters (45-49) +109kg,Kevin Holly,130.4,104,108,113,141,-146,-148,113,141,254
+Thirty Flirty and Thriving,2019-12-14,Open Men's 89kg,Michael Custer,85.6,-105,105,-108,130,135,140,105,140,245
+Thirty Flirty and Thriving,2019-12-14,Open Men's 96kg,Mace Reno,90.1,102,107,-111,129,-134,-135,107,129,236
+Thirty Flirty and Thriving,2019-12-14,Open Men's 81kg,Aaron Denney,79.3,98,-103,103,127,131,-134,103,131,234
+Thirty Flirty and Thriving,2019-12-14,Open Men's 89kg,Dylan Penny,83.2,87,92,-97,112,117,122,92,122,214
+Thirty Flirty and Thriving,2019-12-14,Open Men's 73kg,Linden Riley,72.5,85,88,90,116,119,-122,90,119,209
+Thirty Flirty and Thriving,2019-12-14,Open Men's 96kg,Jesse Hong,94.6,-95,95,100,103,106,108,100,108,208
+Thirty Flirty and Thriving,2019-12-14,Open Men's 73kg,Nicholas Fayette,71.2,90,-94,-95,112,116,-121,90,116,206
+Thirty Flirty and Thriving,2019-12-14,Open Men's 81kg,Jason Keister,79,-90,90,-100,-112,112,-120,90,112,202
+Thirty Flirty and Thriving,2019-12-14,Open Men's 89kg,Jacob Saul,87.7,83,-86,-87,-110,-113,113,83,113,196
+Thirty Flirty and Thriving,2019-12-14,Open Women's 76kg,Bethany Lassen,74.4,75,80,-84,101,107,110,80,110,190
+Thirty Flirty and Thriving,2019-12-14,Open Women's 87kg,Rachel Brindley,85.5,83,86,-88,98,101,-106,86,101,187
+Thirty Flirty and Thriving,2019-12-14,Open Women's 76kg,Morgan Johnson,73,75,77,-80,84,-87,-87,77,84,161
+Thirty Flirty and Thriving,2019-12-14,Open Women's +87kg,Caitlyn Rose,94.7,60,-63,63,-81,84,-87,63,84,147
+Thirty Flirty and Thriving,2019-12-14,Open Women's 87kg,Frances Houck,85.1,57,60,64,76,80,-84,64,80,144
+Thirty Flirty and Thriving,2019-12-14,Open Women's 76kg,Megan Hicks,71,53,58,60,73,78,82,60,82,142
+Thirty Flirty and Thriving,2019-12-14,Junior Women's 71kg,Lauren Fisher,68.2,60,62,65,71,73,76,65,76,141
+Thirty Flirty and Thriving,2019-12-14,Open Women's +87kg,Stephanie Hanson,98.3,-58,58,61,78,-80,-80,61,78,139
+Thirty Flirty and Thriving,2019-12-14,Women's Masters (50-54) +87kg,Tamara Burnett Penny,105.9,53,-56,56,70,73,78,56,78,134
+Thirty Flirty and Thriving,2019-12-14,Open Women's 81kg,Faith Holmes,76,48,53,-58,58,62,-65,53,62,115
+Thirty Flirty and Thriving,2019-12-14,Junior Women's 71kg,Zoe Janczyk,68.8,45,50,-55,50,55,60,50,60,110
+Thirty Flirty and Thriving,2019-12-14,Open Women's 81kg,Amy Haberstich,77.4,37,42,-46,52,57,63,42,63,105
+Thirty Flirty and Thriving,2019-12-14,Open Women's 64kg,Emily Schoenle,63.5,37,41,46,50,55,58,46,58,104
+Thirty Flirty and Thriving,2019-12-14,Open Women's +87kg,Peyton Thomas,95.7,42,45,47,47,51,55,47,55,102
+Thirty Flirty and Thriving,2019-12-14,Open Women's +87kg,Bethany Ireland,97,40,-44,-44,52,-57,57,40,57,97
+Thirty Flirty and Thriving,2019-12-14,Open Women's +87kg,Samantha Alvarado,95.6,30,35,40,40,48,49,40,49,89
+Thirty Flirty and Thriving,2019-12-14,Open Women's 55kg,Shelbi Bauer,52,33,36,-38,44,-48,-48,36,44,80
+Thirty Flirty and Thriving,2019-12-14,Open Women's +87kg,Janet Bales,120,28,30,35,38,42,45,35,45,80
+Thirty Flirty and Thriving,2019-12-14,Women's Masters (55-59) 71kg,MaryAnn Martinez,68.5,27,29,31,38,43,-47,31,43,74
+Thirty Flirty and Thriving,2019-12-14,Junior Women's 55kg,Carson Hidy,52,24,27,-29,33,35,38,27,38,65
+Thirty Flirty and Thriving,2019-12-14,Women's 13 Under Age Group 49kg,Jennica Holly,45,21,23,-27,25,28,32,23,32,55
+Thirty Flirty and Thriving,2019-12-14,Men's 13 Under Age Group 32kg,Jayden Matos,30.9,5,7,10,10,12,14,10,14,24
+Thirty Flirty and Thriving,2019-12-14,Open Men's 73kg,Zachary Edelstein,72,-92,-94,-94,116,119,-121,0,119,0

--- a/event_data/US/4391.csv
+++ b/event_data/US/4391.csv
@@ -1,0 +1,27 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Iron Athlete Winter Open,2019-12-14,Open Men's 96kg,Diego Contreras,94.5,110,111,-114,-130,132,135,111,135,246
+Iron Athlete Winter Open,2019-12-14,Open Men's 89kg,Timothy Moore,82.35,90,95,-98,115,120,-125,95,120,215
+Iron Athlete Winter Open,2019-12-14,Open Men's 96kg,Erick Gonzalez,90.8,-90,95,-100,-120,120,-130,95,120,215
+Iron Athlete Winter Open,2019-12-14,Open Men's 81kg,Victor Nguyen,80.4,73,78,83,100,108,116,83,116,199
+Iron Athlete Winter Open,2019-12-14,Open Men's 89kg,Billy Tallas,84.4,-70,70,74,110,-116,118,74,118,192
+Iron Athlete Winter Open,2019-12-14,Open Men's 73kg,JEAN-JACQUES CABOU,72.2,81,84,87,-97,101,-103,87,101,188
+Iron Athlete Winter Open,2019-12-14,Open Men's 81kg,Patrick Gallagher,79,72,75,80,106,108,-112,80,108,188
+Iron Athlete Winter Open,2019-12-14,Open Men's 102kg,Cameron Call,101.05,60,63,67,92,96,100,67,100,167
+Iron Athlete Winter Open,2019-12-14,Open Men's 61kg,Szabolcs Denes,61,65,70,75,83,90,-96,75,90,165
+Iron Athlete Winter Open,2019-12-14,Open Women's 64kg,Courtney Dyer,63.25,60,64,67,74,78,82,67,82,149
+Iron Athlete Winter Open,2019-12-14,Open Women's 76kg,Rachel Benkowski,75,64,65,67,76,78,-80,67,78,145
+Iron Athlete Winter Open,2019-12-14,Women's 16-17 Age Group 64kg,Mattea Mattox,62.15,60,63,66,-72,72,-74,66,72,138
+Iron Athlete Winter Open,2019-12-14,Open Women's 64kg,Lydia Pineault,59.15,55,58,-61,65,70,-72,58,70,128
+Iron Athlete Winter Open,2019-12-14,Women's Masters (40-44) 59kg,Jennifer Zazueta,55.15,50,53,56,63,66,69,56,69,125
+Iron Athlete Winter Open,2019-12-14,Open Women's 64kg,LaFonda Radcliffe,63.15,46,49,53,60,65,68,53,68,121
+Iron Athlete Winter Open,2019-12-14,Women's Masters (35-39) 87kg,Alanna Caracciolo,86.3,50,-54,-54,70,-73,-73,50,70,120
+Iron Athlete Winter Open,2019-12-14,Women's Masters (40-44) 71kg,Adrienne Scabby,71,50,53,-55,60,62,-64,53,62,115
+Iron Athlete Winter Open,2019-12-14,Open Women's +87kg,Victoria Padilla,107.85,48,50,52,59,63,-65,52,63,115
+Iron Athlete Winter Open,2019-12-14,Women's Masters (45-49) 64kg,Deanna Montalbano,63.75,43,45,47,62,64,-67,47,64,111
+Iron Athlete Winter Open,2019-12-14,Open Women's +87kg,Kara Wagner,88.75,44,-48,48,60,63,-66,48,63,111
+Iron Athlete Winter Open,2019-12-14,Women's Masters (35-39) +87kg,Claudia White,95.15,40,43,-45,63,66,-70,43,66,109
+Iron Athlete Winter Open,2019-12-14,Women's Masters (55-59) 64kg,Carol Hilko,63.55,37,39,41,53,55,57,41,57,98
+Iron Athlete Winter Open,2019-12-14,Women's 16-17 Age Group 55kg,Jala Gross,54.7,32,34,36,43,46,50,36,50,86
+Iron Athlete Winter Open,2019-12-14,Open Women's 55kg,Alize Ramirez,54.95,34,36,39,42,45,-48,39,45,84
+Iron Athlete Winter Open,2019-12-14,Women's Masters (45-49) 64kg,Andrea Cordero,60.15,28,30,32,44,46,-49,32,46,78
+Iron Athlete Winter Open,2019-12-14,Women's Masters (55-59) 71kg,Bridget Bellavigna,69.75,20,23,25,30,32,-35,25,32,57

--- a/event_data/US/4406.csv
+++ b/event_data/US/4406.csv
@@ -1,0 +1,9 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+PFP Barbell : Liftmas In house Meet,2019-12-14,Open Men's 89kg,Leo Radziwon,88.1,100,100,110,125,130,130,110,130,240
+PFP Barbell : Liftmas In house Meet,2019-12-14,Open Men's 67kg,Shenghai Jiang,66.7,84,84,88,108,112,112,88,112,200
+PFP Barbell : Liftmas In house Meet,2019-12-14,Open Men's 81kg,Gerald Haynes,80.7,75,80,88,95,100,108,88,108,196
+PFP Barbell : Liftmas In house Meet,2019-12-14,Open Women's 71kg,Georgina Moss,65.9,50,52,55,61,64,66,55,66,121
+PFP Barbell : Liftmas In house Meet,2019-12-14,Open Women's 55kg,Emma Thomas,50.3,44,47,47,60,63,66,47,66,113
+PFP Barbell : Liftmas In house Meet,2019-12-14,Women's Masters (35-39) 64kg,Elizabeth Skwarecki,63.8,38,41,41,46,49,53,41,53,94
+PFP Barbell : Liftmas In house Meet,2019-12-14,Women's 13 Under Age Group 40kg,MORGAN BROWN,39,12,14,16,16,18,20,16,20,36
+PFP Barbell : Liftmas In house Meet,2019-12-14,Women's 13 Under Age Group 36kg,Taylor Cervantes,34.4,12,14,15,16,18,18,15,18,33

--- a/event_data/US/4410.csv
+++ b/event_data/US/4410.csv
@@ -1,0 +1,12 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+HBC Closed Meet,2019-12-14,Open Men's 81kg,Jax Chancellor,78.11,85,90,93,108,112,114,93,114,207
+HBC Closed Meet,2019-12-14,Open Men's 81kg,George Trajanoski,76.55,75,-80,-80,92,97,-101,75,97,172
+HBC Closed Meet,2019-12-14,Open Men's 61kg,Joseph Feliciano,60.98,65,69,73,92,97,-100,73,97,170
+HBC Closed Meet,2019-12-14,Open Men's 67kg,Nkosi Bradford,66.32,65,70,73,85,92,97,73,97,170
+HBC Closed Meet,2020-03-14,Junior Women's 55kg,Evelyn Colvin,54.99,67,70,73,87,90,93,73,93,166
+HBC Closed Meet,2019-12-14,Women's 16-17 Age Group 55kg,Evelyn Colvin,54.74,-67,67,-71,85,90,92,67,92,159
+HBC Closed Meet,2019-12-14,Open Women's 59kg,Katelynn Neal,58.35,64,-67,-67,77,80,-82,64,80,144
+HBC Closed Meet,2019-12-14,Open Men's 61kg,Drayke Hermanson,60.99,57,60,63,70,75,80,63,80,143
+HBC Closed Meet,2019-12-14,Women's 14-15 Age Group 64kg,Alejandra Rosas,60.64,55,-60,60,70,75,78,60,78,138
+HBC Closed Meet,2019-12-14,Open Women's 59kg,Faith Bergner,58.87,50,53,55,65,68,72,55,72,127
+HBC Closed Meet,2019-12-14,Women's 16-17 Age Group 71kg,Gabrielle Camarillo,69.22,-45,-45,45,60,65,70,45,70,115

--- a/event_data/US/4451.csv
+++ b/event_data/US/4451.csv
@@ -1,0 +1,43 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+UnCharted Barbell's Spring Open,2021-04-17,Open Men's 81kg,Nolan Hauck,77,100,-103,104,120,126,132,104,132,236
+UnCharted Barbell's Spring Open,2021-04-17,Open Men's 89kg,David Schuknecht,81.1,86,90,95,108,113,116,95,116,211
+UnCharted Barbell's Spring Open,2021-04-17,Open Men's 61kg,Ian Moore,59.8,84,-88,-90,110,115,-126,84,115,199
+UnCharted Barbell's Spring Open,2021-04-17,Men's 14-15 Age Group 67kg,Taveon Sanders,65.3,76,80,-83,95,100,-103,80,100,180
+UnCharted Barbell's Spring Open,2021-04-17,Open Men's 89kg,Aaron Schwerdt,88.1,68,72,75,89,94,100,75,100,175
+UnCharted Barbell's Spring Open,2021-04-17,Men's 14-15 Age Group 67kg,Mekhi Lawson,66.3,76,80,-83,93,-97,-100,80,93,173
+UnCharted Barbell's Spring Open,2021-04-17,Women's Masters (35-39) 76kg,Erica Folk,74.7,55,59,63,76,83,87,63,87,150
+UnCharted Barbell's Spring Open,2021-04-17,Women's Masters (35-39) 76kg,Erica Folk,74.7,55,59,63,76,83,87,63,87,150
+UnCharted Barbell's Spring Open,2021-04-16,Women's Masters (35-39) 76kg,Erica Folk,74.7,55,59,63,76,83,87,63,87,150
+UnCharted Barbell's Spring Open,2021-04-16,Women's Masters (35-39) 76kg,Erica Folk,74.7,55,59,63,76,83,87,63,87,150
+UnCharted Barbell's Spring Open,2021-04-17,Open Men's 73kg,Matt Kole,71,60,64,-69,75,-82,82,64,82,146
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 71kg,Claudia Campbell,69.2,58,-62,62,70,75,78,62,78,140
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 71kg,Claudia Campbell,69.2,58,-62,62,70,75,78,62,78,140
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 71kg,Claudia Campbell,69.2,58,-62,62,70,75,78,62,78,140
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 71kg,Claudia Campbell,69.2,58,-62,62,70,75,78,62,78,140
+UnCharted Barbell's Spring Open,2021-04-17,Men's 13 Under Age Group 73kg,Tevin Austell,69.8,58,-62,62,68,72,75,62,75,137
+UnCharted Barbell's Spring Open,2021-04-17,Open Men's 67kg,Logan Pettit,66.1,53,-57,61,63,66,69,61,69,130
+UnCharted Barbell's Spring Open,2021-04-17,Women's 13 Under Age Group 64kg,Isabella Martin,59.8,46,50,53,58,62,65,53,65,118
+UnCharted Barbell's Spring Open,2021-04-16,Women's 13 Under Age Group 64kg,Isabella Martin,59.8,46,50,53,58,62,65,53,65,118
+UnCharted Barbell's Spring Open,2021-04-16,Women's 13 Under Age Group 64kg,Isabella Martin,59.8,46,50,53,58,62,65,53,65,118
+UnCharted Barbell's Spring Open,2021-04-17,Women's 13 Under Age Group 64kg,Isabella Martin,59.8,46,50,53,58,62,65,53,65,118
+UnCharted Barbell's Spring Open,2021-04-17,Men's 13 Under Age Group 55kg,Gabriel Couilloud,53.1,-46,46,49,54,57,60,49,60,109
+UnCharted Barbell's Spring Open,2021-04-16,Men's 13 Under Age Group 55kg,Gabriel Couilloud,53.1,-46,46,49,54,57,60,49,60,109
+UnCharted Barbell's Spring Open,2021-04-16,Men's 13 Under Age Group 55kg,Gabriel Couilloud,53.1,-46,46,49,54,57,60,49,60,109
+UnCharted Barbell's Spring Open,2021-04-17,Men's 13 Under Age Group 55kg,Gabriel Couilloud,53.1,-46,46,49,54,57,60,49,60,109
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 76kg,Katelyn Williams,75,41,43,46,53,57,62,46,62,108
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 76kg,Katelyn Williams,75,41,43,46,53,57,62,46,62,108
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 76kg,Katelyn Williams,75,41,43,46,53,57,62,46,62,108
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 76kg,Katelyn Williams,75,41,43,46,53,57,62,46,62,108
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 81kg,Rachel Kirk,79.3,41,43,46,53,-57,57,46,57,103
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 81kg,Rachel Kirk,79.3,41,43,46,53,-57,57,46,57,103
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 81kg,Rachel Kirk,79.3,41,43,46,53,-57,57,46,57,103
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 81kg,Rachel Kirk,79.3,41,43,46,53,-57,57,46,57,103
+UnCharted Barbell's Spring Open,2021-04-17,Women's Masters (60-64) 49kg,Nancy Taylor,49,35,36,38,44,47,48,38,48,86
+UnCharted Barbell's Spring Open,2021-04-17,Women's Masters (35-39) +87kg,Rachel Kirk,102.9,35,37,-39,45,-48,0,37,45,82
+UnCharted Barbell's Spring Open,2021-04-17,Men's 13 Under Age Group 49kg,Samson Porter,48.2,33,36,-39,38,42,45,36,45,81
+UnCharted Barbell's Spring Open,2021-04-17,Men's 13 Under Age Group 49kg,Samson Porter,48.2,33,36,-39,38,42,45,36,45,81
+UnCharted Barbell's Spring Open,2021-04-17,Men's 13 Under Age Group 67kg,Sidney Porter,63.7,22,25,28,33,36,-39,28,36,64
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 71kg,Rita Carrington,66.8,-46,46,-49,-68,-68,-68,46,0,0
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 71kg,Rita Carrington,66.8,-46,46,-49,-68,-68,-68,46,0,0
+UnCharted Barbell's Spring Open,2021-04-16,Open Women's 71kg,Rita Carrington,66.8,-46,46,-49,-68,-68,-68,46,0,0
+UnCharted Barbell's Spring Open,2021-04-17,Open Women's 71kg,Rita Carrington,66.8,-46,46,-49,-68,-68,-68,46,0,0

--- a/event_data/US/4622.csv
+++ b/event_data/US/4622.csv
@@ -1,0 +1,58 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 109kg,Richard Redus,103.3,125,130,135,160,170,-180,135,170,305
+Texas Barbell Fall Showdown,2020-10-31,Open Men's +109kg,Josiah Willis,145.3,125,130,135,150,155,160,135,160,295
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 109kg,Jacob Whitefield,108.4,110,120,130,140,150,-160,130,150,280
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 89kg,Charleston Bridges,88.7,112,-116,116,140,145,-150,116,145,261
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 109kg,Gabriel Sanchez,107,110,115,-121,-145,-145,145,115,145,260
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 73kg,Greg Cook,72.6,116,119,-121,135,141,-146,119,141,260
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 102kg,Abelardo Martinez-Lopez,100.8,108,114,118,127,135,139,118,139,257
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 102kg,Noel Miramontes,101.3,110,115,-118,135,139,-143,115,139,254
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 102kg,Kevin Kwon,96.8,104,110,-116,127,133,-136,110,133,243
+Texas Barbell Fall Showdown,2020-10-31,Men's 16-17 Age Group +102kg,Mason Sevigny,107.9,93,100,105,126,132,-135,105,132,237
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 73kg,Daniel Valdez,72.9,-99,100,-103,130,-135,-135,100,130,230
+Texas Barbell Fall Showdown,2020-10-31,Men's Masters (40-44) 73kg,Charles Tayona,72.1,95,100,103,116,-121,-121,103,116,219
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 67kg,Christian Moran,66.6,90,94,-97,118,122,-125,94,122,216
+Texas Barbell Fall Showdown,2020-10-31,Men's Masters (35-39) 89kg,Alex Rodriguez,86.9,90,95,-98,110,116,120,95,120,215
+Texas Barbell Fall Showdown,2020-10-31,Men's Masters (40-44) 81kg,John Bova,79.8,86,88,90,115,120,123,90,123,213
+Texas Barbell Fall Showdown,2020-10-31,Men's 16-17 Age Group 73kg,Zachary Gonzalez,72.3,99,-104,-106,110,-116,-117,99,110,209
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 89kg,Alex Garcia,85,76,81,90,101,110,116,90,116,206
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 89kg,Brandon Starcher,81.7,90,-95,-95,110,115,-119,90,115,205
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 102kg,Dakota Adamson,100,90,-95,95,105,110,-115,95,110,205
+Texas Barbell Fall Showdown,2020-10-31,Men's Masters (35-39) 89kg,Cristian Tobar,88,79,85,-91,105,110,115,85,115,200
+Texas Barbell Fall Showdown,2020-10-31,Junior Men's 81kg,Dillon James,78.7,-86,-86,86,106,111,-117,86,111,197
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 81kg,Jared Leake,73.5,78,81,86,100,105,110,86,110,196
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 81kg,Cullen Holderman,80.6,85,87,-89,105,106,-110,87,106,193
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 89kg,Christopher Hamlin,82.9,77,-80,80,-105,105,-110,80,105,185
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 76kg,Karly Jensen,75.8,80,82,-84,98,101,-103,82,101,183
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 71kg,Maddie Graham,65.1,-70,70,72,84,87,90,72,90,162
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 81kg,John Gieselmann,77.7,70,73,75,80,85,87,75,87,162
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 87kg,Gabriela Eufemia,86.5,69,72,74,80,83,86,74,86,160
+Texas Barbell Fall Showdown,2020-10-31,Junior Women's 64kg,Brie Gomez,61.2,-71,71,-73,84,87,-90,71,87,158
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 81kg,Adan Pruneda,78.4,60,64,67,80,86,90,67,90,157
+Texas Barbell Fall Showdown,2020-10-31,Junior Men's 89kg,Daniel Pina,87.9,55,58,62,80,86,90,62,90,152
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 59kg,christine Dang-Luu,58.6,62,-66,68,83,-88,-90,68,83,151
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 76kg,Robyn Henley,74.6,63,65,-68,80,85,-90,65,85,150
+Texas Barbell Fall Showdown,2020-10-31,Women's Masters (40-44) +87kg,Carolina Cortez,97.9,62,67,-70,83,-88,-88,67,83,150
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 55kg,Sarah Whatley,54.5,61,63,65,70,75,78,65,78,143
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 96kg,Jonathan Taborda,92.8,55,58,60,75,79,80,60,80,140
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 59kg,Stacey Lloyd,56.2,56,58,60,70,74,77,60,77,137
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 89kg,Christopher Fusselman,86.2,-50,50,53,75,79,84,53,84,137
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 55kg,Rayanne Garcia,54.6,54,56,57,72,75,-77,57,75,132
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 55kg,Cari Griffin,51.5,55,-58,58,-69,69,72,58,72,130
+Texas Barbell Fall Showdown,2020-10-31,Men's 13 Under Age Group 61kg,Mason Kuhl,58.9,53,57,-60,-70,70,73,57,73,130
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 71kg,Maegan Burke,67.4,-56,56,-59,62,65,-67,56,65,121
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 64kg,Jennifer Huynh,63.5,-48,-48,48,62,67,71,48,71,119
+Texas Barbell Fall Showdown,2020-10-31,Women's Masters (45-49) 64kg,Cyndi Wilson,62.1,46,48,50,58,60,62,50,62,112
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 64kg,Marissa Jennings,62.4,47,50,-53,57,-60,60,50,60,110
+Texas Barbell Fall Showdown,2020-10-31,Junior Women's 71kg,Juliet Aguilar,65.2,43,46,-48,54,58,61,46,61,107
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 89kg,Devon Sizemore,82.3,40,43,45,50,54,58,45,58,103
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 49kg,Gaelyn Byrne,48.9,33,36,-39,42,46,50,36,50,86
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 64kg,Samantha Steele,61.5,-34,-35,35,43,-48,48,35,48,83
+Texas Barbell Fall Showdown,2020-10-31,Open Women's +87kg,Gabriela Vidal,102.5,30,-35,-35,42,46,50,30,50,80
+Texas Barbell Fall Showdown,2020-10-31,Women's 14-15 Age Group 55kg,Hadassah Chapman,53.8,28,30,-32,-46,-46,46,30,46,76
+Texas Barbell Fall Showdown,2020-10-31,Junior Women's 55kg,Crystal Contreras,49.1,28,30,32,31,34,-37,32,34,66
+Texas Barbell Fall Showdown,2020-10-31,Junior Women's 71kg,Marisa Martinez,64.8,23,26,28,30,33,36,28,36,64
+Texas Barbell Fall Showdown,2020-10-31,Women's 13 Under Age Group 30kg,Norah Burke,25.5,15,16,17,18,20,21,17,21,38
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 76kg,Tina Martinez,75.5,70,-74,-77,-97,-101,-102,70,0,0
+Texas Barbell Fall Showdown,2020-10-31,Open Women's 71kg,Gabrielle Mathias,67.7,-48,-48,-48,-58,58,60,0,60,0
+Texas Barbell Fall Showdown,2020-10-31,Open Men's 96kg,Douglas Ligon,95.7,-133,-133,133,-160,-161,-161,133,0,0

--- a/event_data/US/4626.csv
+++ b/event_data/US/4626.csv
@@ -1,0 +1,9 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Halloween Kilo Smash,2020-10-31,Open Men's 89kg,Kyle Young,83.9,88,91,95,112,116,122,95,122,217
+Halloween Kilo Smash,2020-10-31,Open Men's 81kg,Alec Hedlund,77.2,83,86,-89,-106,106,110,86,110,196
+Halloween Kilo Smash,2020-10-31,Open Men's +109kg,David Church,118,65,68,70,83,87,91,70,91,161
+Halloween Kilo Smash,2020-10-31,Open Women's 81kg,Alexandra Behrend,79.8,60,-63,-65,80,83,86,60,86,146
+Halloween Kilo Smash,2020-10-31,Open Women's +87kg,Karena Hanscom,104.9,42,45,48,58,62,65,48,65,113
+Halloween Kilo Smash,2020-10-31,Open Women's 64kg,Jessica Comer,62.1,46,48,-50,60,-64,-64,48,60,108
+Halloween Kilo Smash,2020-10-31,Open Women's 55kg,Olivia Paulsen,54.4,34,37,39,-55,55,58,39,58,97
+Halloween Kilo Smash,2020-10-31,Women's 13 Under Age Group 49kg,Elyse Pippitt,48.3,17,-19,19,27,-30,-30,19,27,46

--- a/event_data/US/4636.csv
+++ b/event_data/US/4636.csv
@@ -1,0 +1,7 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+PXM Weightlifting Lift Off,2020-10-31,Open Men's 96kg,Senad Drpljanin,94.8,82,82,82,80,90,90,82,90,172
+PXM Weightlifting Lift Off,2020-10-31,Open Men's 73kg,John Buckley,67.4,58,61,64,62,66,68,64,68,132
+PXM Weightlifting Lift Off,2020-10-31,Open Men's 81kg,SELORM NORGBEY,75.9,48,50,52,60,62,64,52,64,116
+PXM Weightlifting Lift Off,2020-10-31,Open Women's 81kg,Maria Nowicki,78.4,46,49,51,58,60,63,51,63,114
+PXM Weightlifting Lift Off,2020-10-31,Open Women's 59kg,Leah Casey,58.6,43,46,46,65,65,65,46,65,111
+PXM Weightlifting Lift Off,2020-10-31,Open Women's 76kg,Alyson Battaglia,75.4,35,42,46,60,60,62,46,62,108

--- a/event_data/US/4640.csv
+++ b/event_data/US/4640.csv
@@ -1,0 +1,20 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+DoD Halloween In-House Meet,2020-10-31,Open Men's 102kg,Gordon Rains,100.6,128,-133,133,155,160,0,133,160,293
+DoD Halloween In-House Meet,2020-10-31,Open Men's 96kg,Tristan Faure,89.6,106,112,117,139,146,152,117,152,269
+DoD Halloween In-House Meet,2020-10-31,Open Men's 109kg,Tracy Helton,105.8,96,100,-105,120,123,127,100,127,227
+DoD Halloween In-House Meet,2020-10-31,Open Men's 89kg,Midtah Phenephom,84.1,84,87,95,120,125,-130,95,125,220
+DoD Halloween In-House Meet,2020-10-31,Open Men's 81kg,Hunter Orloff,79.4,92,96,-100,117,121,-126,96,121,217
+DoD Halloween In-House Meet,2020-10-31,Open Men's 89kg,Thomas Mentus,88.2,-95,-96,96,110,115,120,96,120,216
+DoD Halloween In-House Meet,2020-10-31,Open Men's 89kg,Joshua Marszalek,87.7,84,87,91,107,112,116,91,116,207
+DoD Halloween In-House Meet,2020-10-31,Open Men's 96kg,Melky Perez,93.9,84,87,-91,107,112,117,87,117,204
+DoD Halloween In-House Meet,2020-10-31,Men's Masters (45-49) 73kg,Brian Zimmerman,72.2,73,76,79,94,98,-101,79,98,177
+DoD Halloween In-House Meet,2020-10-31,Open Men's 89kg,Brett Ambrose,85.9,72,76,-80,-92,92,96,76,96,172
+DoD Halloween In-House Meet,2020-10-31,Open Women's 81kg,Mary Quigley,79.9,62,66,70,90,95,100,70,100,170
+DoD Halloween In-House Meet,2020-10-31,Open Women's 87kg,Samantha Campodonico,81.2,61,64,-67,74,-78,78,64,78,142
+DoD Halloween In-House Meet,2020-10-31,Open Women's 59kg,Tiffany Black,57.1,56,60,62,67,71,75,62,75,137
+DoD Halloween In-House Meet,2020-10-31,Open Women's +87kg,Carolyn Schneller,96.1,60,62,64,65,69,73,64,73,137
+DoD Halloween In-House Meet,2020-10-31,Open Women's 81kg,Brenda Banning,76.6,41,44,48,65,69,73,48,73,121
+DoD Halloween In-House Meet,2020-10-31,Open Women's 81kg,Kim Fairley,77.3,45,49,-53,53,57,62,49,62,111
+DoD Halloween In-House Meet,2020-10-31,Open Women's 71kg,Hanna Perry,68.3,40,43,-45,47,-52,-55,43,47,90
+DoD Halloween In-House Meet,2020-10-31,Open Women's 81kg,Heidi Ribskis,80.5,32,34,-36,37,40,43,34,43,77
+DoD Halloween In-House Meet,2020-10-31,Open Women's 76kg,Whitney Hodge,75.8,32,34,36,37,40,-43,36,40,76

--- a/event_data/US/4930.csv
+++ b/event_data/US/4930.csv
@@ -1,0 +1,57 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+South Carolina State Championships,2021-10-23,Junior Men's 89kg,Dade Stanley,89,118,124,130,145,155,-162,130,155,285
+South Carolina State Championships,2021-10-23,Open Men's 89kg,Mitchell Wagner,85,110,114,-118,142,-147,-151,114,142,256
+South Carolina State Championships,2021-10-23,Open Men's 102kg,Stew McEntire,97.95,105,110,115,140,-146,-150,115,140,255
+South Carolina State Championships,2021-10-23,Men's 16-17 Age Group 102kg,Ian Graham,101.9,100,105,-110,125,130,137,105,137,242
+South Carolina State Championships,2021-10-23,Men's Masters (40-44) 109kg,Brandon Duffner,103,-100,100,105,131,136,-143,105,136,241
+South Carolina State Championships,2021-10-23,Junior Men's 89kg,George Jordan,84.75,105,-110,110,130,-133,-133,110,130,240
+South Carolina State Championships,2021-10-23,Men's Masters (45-49) 109kg,Gregory Vallee,108,85,-92,95,120,130,135,95,135,230
+South Carolina State Championships,2021-10-23,Open Men's 96kg,Jaimerius Williams,90.45,90,96,103,113,119,125,103,125,228
+South Carolina State Championships,2021-10-23,Junior Men's 96kg,James Park,93,92,97,-102,117,122,126,97,126,223
+South Carolina State Championships,2021-10-23,Junior Men's 81kg,Camden Wisner,78,84,88,-97,111,119,125,88,125,213
+South Carolina State Championships,2021-10-23,Open Men's 67kg,CHRISTOPHER MENG,62.4,90,95,-100,110,115,-120,95,115,210
+South Carolina State Championships,2021-10-23,Men's Masters (40-44) 96kg,Max Sterling,94.35,88,-91,-93,110,115,-118,88,115,203
+South Carolina State Championships,2021-10-23,Open Men's 89kg,Nicklos Laster,87.5,82,85,88,105,110,114,88,114,202
+South Carolina State Championships,2021-10-23,Open Men's 67kg,Cesar Ramirez,66.15,90,95,-100,106,-114,-114,95,106,201
+South Carolina State Championships,2021-10-23,Open Men's 102kg,Charles Badawy,98.45,80,85,-90,107,114,-120,85,114,199
+South Carolina State Championships,2021-10-23,Open Men's 73kg,Mason Floyd,72.45,87,-90,-90,110,-116,-116,87,110,197
+South Carolina State Championships,2021-10-23,Open Men's 73kg,Matthew Helms,72.45,75,80,82,102,105,110,82,110,192
+South Carolina State Championships,2021-10-23,Open Men's +109kg,Roy Lemmons,115.3,70,75,82,100,106,-114,82,106,188
+South Carolina State Championships,2021-10-23,Men's Masters (55-59) 102kg,Mark Lado,98.75,75,-80,-80,111,-117,-119,75,111,186
+South Carolina State Championships,2021-10-23,Open Women's 81kg,Mary Quigley,80.25,70,75,80,101,106,-112,80,106,186
+South Carolina State Championships,2021-10-23,Open Men's 81kg,Davis Reed,79.45,75,78,82,92,98,103,82,103,185
+South Carolina State Championships,2021-10-23,Open Women's 76kg,Meghan Bundrick,75.35,78,-81,81,95,100,-103,81,100,181
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) 71kg,Melissa Odorisio,70.2,72,75,-78,-90,90,94,75,94,169
+South Carolina State Championships,2021-10-23,Open Men's 89kg,Brett Schenck,84.1,-70,70,-75,85,92,96,70,96,166
+South Carolina State Championships,2021-10-23,Open Men's +109kg,Michael Baker,141.7,66,-71,70,84,93,-100,70,93,163
+South Carolina State Championships,2021-10-23,Open Women's 59kg,Kristen Geist,59,67,70,-74,88,-91,-91,70,88,158
+South Carolina State Championships,2021-10-23,Open Men's 67kg,Christopher Hippenmeyer,65.3,64,68,72,75,80,85,72,85,157
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) 64kg,Olga Pisarskiy,62.2,64,-68,69,81,-85,-87,69,81,150
+South Carolina State Championships,2021-10-23,Men's 16-17 Age Group 89kg,Jacob Abney,88.25,60,63,66,76,79,82,66,82,148
+South Carolina State Championships,2021-10-23,Men's 14-15 Age Group 55kg,Tristan Moeller,53.85,60,-63,63,77,80,83,63,83,146
+South Carolina State Championships,2021-10-23,Open Women's 81kg,Samantha Campodonico,79.3,64,-68,-68,-80,81,0,64,81,145
+South Carolina State Championships,2021-10-23,Women's Masters (40-44) 71kg,A. Isabelle Miller,70.55,64,-67,67,78,-81,-81,67,78,145
+South Carolina State Championships,2021-10-23,Open Women's 59kg,Kara Keith,58.75,59,-62,62,72,75,77,62,77,139
+South Carolina State Championships,2021-10-23,Open Women's 64kg,Laurel Smoak,63.55,59,62,63,70,73,76,63,76,139
+South Carolina State Championships,2021-10-23,Open Women's 76kg,Jessica Lewis,75.75,55,-59,60,66,70,73,60,73,133
+South Carolina State Championships,2021-10-23,Open Women's 87kg,Rachel Oakley,85.8,57,-60,-60,70,-73,73,57,73,130
+South Carolina State Championships,2021-10-23,Women's Masters (40-44) 76kg,Carrie Pritchett,76,-53,53,55,-65,68,71,55,71,126
+South Carolina State Championships,2021-10-23,Junior Men's 102kg,Jose Restrepo,96.1,45,48,51,65,73,-78,51,73,124
+South Carolina State Championships,2021-10-23,Women's Masters (40-44) 64kg,Alison Roark,63.35,50,54,-57,65,68,-70,54,68,122
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) 59kg,Alana Gamundoy,56.85,47,51,-54,62,66,69,51,69,120
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) 55kg,Amanda Stolz,53.95,52,-54,54,62,65,-67,54,65,119
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) +87kg,Kera Koenig,123.65,46,50,54,56,59,63,54,63,117
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) 64kg,Jessica Thomas,64,50,-53,53,55,58,60,53,60,113
+South Carolina State Championships,2021-10-23,Junior Women's 76kg,Ashley  Zuchowski ,72.15,45,48,-52,54,59,-62,48,59,107
+South Carolina State Championships,2021-10-23,Junior Women's 59kg,Madelyn  Koon,55.5,38,-42,42,57,60,-63,42,60,102
+South Carolina State Championships,2021-10-23,Women's Masters (40-44) 55kg,Amber Butler,51.85,37,39,40,53,57,-59,40,57,97
+South Carolina State Championships,2021-10-23,Open Women's 71kg,Farris Weinberg,65.05,38,41,42,47,49,52,42,52,94
+South Carolina State Championships,2021-10-23,Women's 13 Under Age Group 64kg,Jacquelyn Roark,59.1,40,43,-45,45,46,49,43,49,92
+South Carolina State Championships,2021-10-23,Women's Masters (50-54) 71kg,Helen Shiver,64.35,32,35,-39,39,43,45,35,45,80
+South Carolina State Championships,2021-10-23,Women's 13 Under Age Group 55kg,Brynlee Pritchett,50.05,30,-32,-32,38,40,42,30,42,72
+South Carolina State Championships,2021-10-23,Women's Masters (35-39) 81kg,Sommer Mobley,79.7,25,28,30,35,37,40,30,40,70
+South Carolina State Championships,2021-10-23,Women's Masters (60-64) 71kg,Marissa Hardie,69.35,26,29,-31,36,39,-42,29,39,68
+South Carolina State Championships,2021-10-23,Men's 13 Under Age Group +73kg,Evan Madden,88.15,20,23,26,30,34,37,26,37,63
+South Carolina State Championships,2021-10-23,Women's 13 Under Age Group +64kg,Caroline Major,68.85,12,15,17,20,22,24,17,24,41
+South Carolina State Championships,2021-10-23,Open Men's 102kg,Stephen Butcher,98.65,117,-125,-130,0,0,0,117,0,0
+South Carolina State Championships,2021-10-23,Men's Masters (35-39) 102kg,Jordan Jacobs,100.25,110,115,120,-148,-152,-152,120,0,0

--- a/event_data/US/4942.csv
+++ b/event_data/US/4942.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+The Nike 2021 North American Open Series 2 powered by Rogue,2021-09-18,Open Women's 64kg,Jamie Hegg,63,100,0,0,300,0,0,100,300,400

--- a/event_data/US/5163.csv
+++ b/event_data/US/5163.csv
@@ -1,0 +1,178 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2022 January online qualifier,2022-01-19,Open Men's 96kg,Chrisanto D'Agostino,96,135,0,0,165,0,0,135,165,300
+2022 January online qualifier,2022-01-31,Open Men's 102kg,Zach Ferrenburg,100,85,0,0,205,0,0,85,205,290
+2022 January online qualifier,2022-01-20,Junior Men's 109kg,James Tice,108,129,0,0,154,0,0,129,154,283
+2022 January online qualifier,2022-01-20,Junior Men's 109kg,James Tice,108,129,0,0,154,0,0,129,154,283
+2022 January online qualifier,2022-01-20,Men's Masters (35-39) 102kg,Stewart Young,97,121,0,0,148,0,0,121,148,269
+2022 January online qualifier,2022-01-20,Open Men's 89kg,Scott Schuster,85,120,0,0,145,0,0,120,145,265
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 96kg,James DeNofa,95,115,0,0,145,0,0,115,145,260
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 96kg,James DeNofa,96,115,0,0,145,0,0,115,145,260
+2022 January online qualifier,2022-01-31,Junior Men's +109kg,Gage Senty,136,120,0,0,140,0,0,120,140,260
+2022 January online qualifier,2022-01-31,Junior Men's 96kg,Michael Ortega,93,115,0,0,143,0,0,115,143,258
+2022 January online qualifier,2022-01-19,Open Men's +109kg,Jacob Brenza,117,110,0,0,140,0,0,110,140,250
+2022 January online qualifier,2022-01-19,Open Men's +109kg,Jacob Brenza,117,110,0,0,140,0,0,110,140,250
+2022 January online qualifier,2022-01-19,Open Men's 89kg,David Graham,87,110,0,0,133,0,0,110,133,243
+2022 January online qualifier,2022-01-14,Open Men's 89kg,David Graham,87,110,0,0,133,0,0,110,133,243
+2022 January online qualifier,2022-01-31,Men's Masters (35-39) 109kg,Jose Cruz Richardson,105,114,0,0,128,0,0,114,128,242
+2022 January online qualifier,2022-01-31,Open Men's 102kg,Jhon fredy Duarte lizarazo,98,110,0,0,130,0,0,110,130,240
+2022 January online qualifier,2022-01-31,Men's 16-17 Age Group 102kg,Aleki Manutai,102,110,0,0,130,0,0,110,130,240
+2022 January online qualifier,2022-01-31,Open Men's 73kg,Johnny Cezar,72,108,0,0,132,0,0,108,132,240
+2022 January online qualifier,2022-01-31,Open Men's +109kg,Zachary Kidd,123,108,0,0,132,0,0,108,132,240
+2022 January online qualifier,2022-01-31,Junior Men's 109kg,Ryland Shriver,105,110,0,0,130,0,0,110,130,240
+2022 January online qualifier,2022-01-31,Open Men's 109kg,Andrew Mullins,108,103,0,0,135,0,0,103,135,238
+2022 January online qualifier,2022-01-20,Men's Masters (35-39) 81kg,Ramadan Sayed Rabeh,80,105,0,0,125,0,0,105,125,230
+2022 January online qualifier,2022-01-31,Open Men's 89kg,Etienne Daadi,86,104,0,0,123,0,0,104,123,227
+2022 January online qualifier,2022-01-19,Open Men's 96kg,Chris Beck,91,106,0,0,120,0,0,106,120,226
+2022 January online qualifier,2022-01-20,Open Men's 102kg,Jarmez Eason,101,100,0,0,126,0,0,100,126,226
+2022 January online qualifier,2022-01-19,Open Men's 102kg,Chris Johnson,102,100,0,0,126,0,0,100,126,226
+2022 January online qualifier,2022-01-31,Open Men's 89kg,William Hawkinson,85,95,0,0,130,0,0,95,130,225
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Richard Todd,77,103,0,0,120,0,0,103,120,223
+2022 January online qualifier,2022-01-19,Open Men's 96kg,William Lozier,95,96,0,0,126,0,0,96,126,222
+2022 January online qualifier,2022-01-31,Open Men's 96kg,Kevin Sena,95,95,0,0,126,0,0,95,126,221
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Brendan South,79,95,0,0,125,0,0,95,125,220
+2022 January online qualifier,2022-01-31,Junior Men's 89kg,Lander Wells,89,100,0,0,120,0,0,100,120,220
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 102kg,Wes Seeman,102,95,0,0,124,0,0,95,124,219
+2022 January online qualifier,2022-01-20,Open Men's 89kg,Devin Bray,88,97,0,0,120,0,0,97,120,217
+2022 January online qualifier,2022-01-19,Open Men's 89kg,Steven Taylor,86,101,0,0,115,0,0,101,115,216
+2022 January online qualifier,2022-01-31,Open Men's 89kg,Nicholas Hallmark,87,110,0,0,105,0,0,110,105,215
+2022 January online qualifier,2022-01-19,Men's Masters (40-44) 89kg,Jonathan Webster,85,95,0,0,120,0,0,95,120,215
+2022 January online qualifier,2022-01-31,Open Men's 96kg,Anthony Akinrinmola,95,100,0,0,112,0,0,100,112,212
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Jack Walbye,80,100,0,0,111,0,0,100,111,211
+2022 January online qualifier,2022-01-31,Men's Masters (35-39) 89kg,Jake Brawley,87,93,0,0,118,0,0,93,118,211
+2022 January online qualifier,2022-01-31,Open Men's 102kg,SHEAFFER SMITH,98,100,0,0,110,0,0,100,110,210
+2022 January online qualifier,2022-01-31,Open Men's +109kg,Maximilian Evanson,138,100,0,0,110,0,0,100,110,210
+2022 January online qualifier,2022-01-19,Open Men's 81kg,Randall Snipes,79,93,0,0,115,0,0,93,115,208
+2022 January online qualifier,2022-01-20,Open Men's 89kg,Mervin Lumba,85,93,0,0,115,0,0,93,115,208
+2022 January online qualifier,2022-01-19,Junior Men's 81kg,Daniel Austin,77,93,0,0,114,0,0,93,114,207
+2022 January online qualifier,2022-01-20,Open Men's 81kg,Benjamin Ketelaar,81,95,0,0,112,0,0,95,112,207
+2022 January online qualifier,2022-01-20,Men's Masters (35-39) 89kg,Michael Burr,88,87,0,0,120,0,0,87,120,207
+2022 January online qualifier,2022-01-20,Open Men's 109kg,Logan Kulinski,107,88,0,0,118,0,0,88,118,206
+2022 January online qualifier,2022-01-31,Open Men's 102kg,Thane Gallo,102,90,0,0,115,0,0,90,115,205
+2022 January online qualifier,2022-01-31,Open Men's 89kg,Logan Kulinski,86,95,0,0,110,0,0,95,110,205
+2022 January online qualifier,2022-01-31,Open Men's 67kg,Lukas Zielke,67,95,0,0,110,0,0,95,110,205
+2022 January online qualifier,2022-01-31,Open Men's 89kg,Tariq Miller,86,95,0,0,110,0,0,95,110,205
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Leo Ovalle,81,93,0,0,110,0,0,93,110,203
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Isaiah Miller,77,90,0,0,113,0,0,90,113,203
+2022 January online qualifier,2022-01-19,Open Women's 87kg,Shay Carlock,82,88,0,0,115,0,0,88,115,203
+2022 January online qualifier,2022-01-20,Open Men's 81kg,Donavan Carrasquillo,79,90,0,0,113,0,0,90,113,203
+2022 January online qualifier,2022-01-31,Open Men's 102kg,Thomas Sieban,100.8,92,0,0,108,0,0,92,108,200
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 96kg,Joel Quintong,96,85,0,0,115,0,0,85,115,200
+2022 January online qualifier,2022-01-31,Open Women's +87kg,thea campbell,88,100,0,0,100,0,0,100,100,200
+2022 January online qualifier,2022-01-20,Men's Masters (35-39) 89kg,Ryan Ayres,89,90,0,0,110,0,0,90,110,200
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 89kg,Christopher Chambers,86,93,0,0,105,0,0,93,105,198
+2022 January online qualifier,2022-01-19,Open Men's 73kg,Jonathan Kollars,70,84,0,0,112,0,0,84,112,196
+2022 January online qualifier,2022-01-31,Open Men's 73kg,Justin Littlewood,73,85,0,0,110,0,0,85,110,195
+2022 January online qualifier,2022-01-31,Junior Men's 96kg,William Heller,96,80,0,0,115,0,0,80,115,195
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 109kg,Angel D Diaz Cecilio,109,80,0,0,112,0,0,80,112,192
+2022 January online qualifier,2022-01-31,Open Men's 96kg,Ely Nez,92,85,0,0,107,0,0,85,107,192
+2022 January online qualifier,2022-01-31,Men's Masters (40-44) 109kg,Angel D Diaz Cecilio,109,80,0,0,112,0,0,80,112,192
+2022 January online qualifier,2022-01-19,Open Men's 81kg,Roy Kuhl,80,86,0,0,105,0,0,86,105,191
+2022 January online qualifier,2022-01-19,Open Men's 89kg,Yifu Zhu,82,85,0,0,106,0,0,85,106,191
+2022 January online qualifier,2022-01-19,Open Men's 89kg,Michael Steger,88,87,0,0,104,0,0,87,104,191
+2022 January online qualifier,2022-01-31,Junior Men's 81kg,Carson Brame,81,85,0,0,105,0,0,85,105,190
+2022 January online qualifier,2022-01-31,Open Men's 96kg,Tom Geairn III,93,85,0,0,105,0,0,85,105,190
+2022 January online qualifier,2022-01-20,Open Men's 81kg,Daniel Rodriguez,75,81,0,0,105,0,0,81,105,186
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Kaela Stephano,67,83,0,0,102,0,0,83,102,185
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Nicholas Kemmerle,80,90,0,0,95,0,0,90,95,185
+2022 January online qualifier,2022-01-31,Open Men's 81kg,Thomas Osborne Bird,81,78,0,0,104,0,0,78,104,182
+2022 January online qualifier,2022-01-31,Junior Men's 81kg,Dominick Basso,81,81,0,0,101,0,0,81,101,182
+2022 January online qualifier,2022-01-19,Junior Men's 73kg,Cole Resurreccion,71,80,0,0,102,0,0,80,102,182
+2022 January online qualifier,2022-01-31,Open Men's 73kg,Yoshikuni Okabe,71,80,0,0,100,0,0,80,100,180
+2022 January online qualifier,2022-01-31,Open Men's 73kg,Calvin La,73,90,0,0,90,0,0,90,90,180
+2022 January online qualifier,2022-01-20,Open Men's 73kg,cade owen,69,72,0,0,107,0,0,72,107,179
+2022 January online qualifier,2022-01-31,Junior Men's 81kg,Will Bernau,79,75,0,0,102,0,0,75,102,177
+2022 January online qualifier,2022-01-20,Open Men's 67kg,Steven Thomas,66,74,0,0,102,0,0,74,102,176
+2022 January online qualifier,2022-01-19,Open Women's 59kg,Monica Knowlton,58,75,0,0,100,0,0,75,100,175
+2022 January online qualifier,2022-01-20,Open Men's 67kg,Paul Ponmattam,66,78,0,0,95,0,0,78,95,173
+2022 January online qualifier,2022-01-20,Men's Masters (35-39) 81kg,Wayne Gilbert,76,78,0,0,93,0,0,78,93,171
+2022 January online qualifier,2022-01-20,Open Men's 73kg,Alan Hicks,71,73,0,0,98,0,0,73,98,171
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Emma Baumert,69,75,0,0,95,0,0,75,95,170
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Emma Baumert,69,75,0,0,95,0,0,75,95,170
+2022 January online qualifier,2022-01-20,Open Women's 76kg,Hailey Sonnenberg,75,72,0,0,97,0,0,72,97,169
+2022 January online qualifier,2022-01-20,Men's Masters (50-54) 73kg,Eric Ebuen,73,71,0,0,98,0,0,71,98,169
+2022 January online qualifier,2022-01-20,Men's Masters (50-54) 73kg,Eric Ebuen,72,71,0,0,95,0,0,71,95,166
+2022 January online qualifier,2022-01-31,Open Women's 87kg,Laura Barito,87,70,0,0,95,0,0,70,95,165
+2022 January online qualifier,2022-01-19,Open Women's 81kg,Charlie Sharp,77,73,0,0,90,0,0,73,90,163
+2022 January online qualifier,2022-01-31,Open Women's 64kg,Leann Fruits,62,75,0,0,86,0,0,75,86,161
+2022 January online qualifier,2022-01-31,Men's Masters (45-49) 73kg,Christopher DiStefano,72,70,0,0,91,0,0,70,91,161
+2022 January online qualifier,2022-01-31,Open Men's 67kg,Kohei Koja,66,70,0,0,90,0,0,70,90,160
+2022 January online qualifier,2022-01-31,Men's 16-17 Age Group 73kg,Dwayne Deang,73,75,0,0,85,0,0,75,85,160
+2022 January online qualifier,2022-01-31,Men's Masters (35-39) 67kg,Shawn Arnold,66,75,0,0,85,0,0,75,85,160
+2022 January online qualifier,2022-01-31,Junior Women's 59kg,Emma Nye,59,70,0,0,90,0,0,70,90,160
+2022 January online qualifier,2022-01-31,Junior Women's 64kg,Grace Young,64,70,0,0,85,0,0,70,85,155
+2022 January online qualifier,2022-01-19,Open Women's 49kg,Hannah Kaminski,49,70,0,0,85,0,0,70,85,155
+2022 January online qualifier,2022-01-19,Open Women's +87kg,Adria Pascal,101,70,0,0,85,0,0,70,85,155
+2022 January online qualifier,2022-01-19,Open Women's 87kg,Danica Anderson,86,68,0,0,85,0,0,68,85,153
+2022 January online qualifier,2022-01-31,Open Women's 76kg,Marley Wahler,76,65,0,0,85,0,0,65,85,150
+2022 January online qualifier,2022-01-19,Women's Masters (35-39) +87kg,Amanda Roberts,94,70,0,0,80,0,0,70,80,150
+2022 January online qualifier,2022-01-31,Open Women's +87kg,Andrea Tuttle,91,68,0,0,80,0,0,68,80,148
+2022 January online qualifier,2022-01-31,Open Women's +87kg,Marie Agbah Hughes,119,60,0,0,87,0,0,60,87,147
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 59kg,Amy Halperin,59,63,0,0,84,0,0,63,84,147
+2022 January online qualifier,2022-01-20,Open Women's 71kg,Yuliana Lopez,71,65,0,0,82,0,0,65,82,147
+2022 January online qualifier,2022-01-31,Junior Women's 87kg,Lenka Zembova Wells,87,70,0,0,75,0,0,70,75,145
+2022 January online qualifier,2022-01-20,Open Women's 76kg,Amy Ellis,74,67,0,0,78,0,0,67,78,145
+2022 January online qualifier,2022-01-31,Junior Women's 59kg,Leila Cook,57,62,0,0,81,0,0,62,81,143
+2022 January online qualifier,2022-01-31,Men's 16-17 Age Group 73kg,Aidan Nguyen,68,60,0,0,80,0,0,60,80,140
+2022 January online qualifier,2022-01-19,Open Men's 61kg,Aditya Joshi,58,60,0,0,80,0,0,60,80,140
+2022 January online qualifier,2022-01-20,Women's Masters (40-44) 76kg,Tanya Watson,74,65,0,0,75,0,0,65,75,140
+2022 January online qualifier,2022-01-31,Open Women's 87kg,Kali Fernandez,87,63,0,0,76,0,0,63,76,139
+2022 January online qualifier,2022-01-31,Open Women's 87kg,Shelbey Phelps,86,68,0,0,69,0,0,68,69,137
+2022 January online qualifier,2022-01-20,Open Women's +87kg,Kayla Basley,88,62,0,0,75,0,0,62,75,137
+2022 January online qualifier,2022-01-20,Open Women's 87kg,Yaneis Autumn,87,63,0,0,74,0,0,63,74,137
+2022 January online qualifier,2022-01-19,Open Women's 81kg,Arielle Rutledge,77,64,0,0,72,0,0,64,72,136
+2022 January online qualifier,2022-01-19,Open Women's 64kg,Monica Nelson,63,58,0,0,78,0,0,58,78,136
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 64kg,Jacqueline Menke,64,60,0,0,75,0,0,60,75,135
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 71kg,Jamie Hodder,67,64,0,0,71,0,0,64,71,135
+2022 January online qualifier,2022-01-19,Women's Masters (40-44) 81kg,Courtney Raiser,80,55,0,0,80,0,0,55,80,135
+2022 January online qualifier,2022-01-19,Open Women's 55kg,Presley Cruz,54,60,0,0,74,0,0,60,74,134
+2022 January online qualifier,2022-01-20,Open Women's 59kg,Emily Maxon,57,56,0,0,76,0,0,56,76,132
+2022 January online qualifier,2022-01-31,Open Women's 49kg,Rachel Conaway,49,58,0,0,73,0,0,58,73,131
+2022 January online qualifier,2022-01-31,Open Women's 55kg,Haylee Rawdin,55,55,0,0,75,0,0,55,75,130
+2022 January online qualifier,2022-01-20,Open Women's 71kg,Jenesis Fonder,67,60,0,0,70,0,0,60,70,130
+2022 January online qualifier,2022-01-20,Open Women's 71kg,Jordyn Miller,68,60,0,0,68,0,0,60,68,128
+2022 January online qualifier,2022-01-20,Open Women's 71kg,Emily Smith,66,58,0,0,70,0,0,58,70,128
+2022 January online qualifier,2022-01-31,Junior Women's 59kg,Zoe Pasetsky,59,55,0,0,72,0,0,55,72,127
+2022 January online qualifier,2022-01-31,Open Women's 59kg,Amanda DeStefano,59,54,0,0,73,0,0,54,73,127
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Elizabeth Gomez,71,55,0,0,71,0,0,55,71,126
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Samantha Kanterman,71,58,0,0,67,0,0,58,67,125
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Zadie Nix,71,55,0,0,70,0,0,55,70,125
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Zadie Nix,71,55,0,0,70,0,0,55,70,125
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 76kg,Reneshawn Whyte,76,55,0,0,68,0,0,55,68,123
+2022 January online qualifier,2022-01-31,Open Women's 59kg,Connie Yu,59,46,0,0,77,0,0,46,77,123
+2022 January online qualifier,2022-01-31,Open Women's 64kg,Hannah Alvis,64,61,0,0,61,0,0,61,61,122
+2022 January online qualifier,2022-01-31,Open Women's 64kg,Veronica Wagner,64,56,0,0,65,0,0,56,65,121
+2022 January online qualifier,2022-01-31,Women's 16-17 Age Group 81kg,Aykhia Williams,80,54,0,0,67,0,0,54,67,121
+2022 January online qualifier,2022-01-31,Open Women's 64kg,Dominique Carpio,64,54,0,0,64,0,0,54,64,118
+2022 January online qualifier,2022-01-19,Women's Masters (35-39) 64kg,Mary Dresser,64,53,0,0,65,0,0,53,65,118
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) +87kg,Nicole Crisostomo,104,46,0,0,70,0,0,46,70,116
+2022 January online qualifier,2022-01-20,Women's Masters (40-44) 76kg,Beth Livingston,76,54,0,0,62,0,0,54,62,116
+2022 January online qualifier,2022-01-20,Women's Masters (40-44) +87kg,Diana Thorne,111,48,0,0,68,0,0,48,68,116
+2022 January online qualifier,2022-01-31,Open Women's 59kg,Justice Angel,57,55,0,0,60,0,0,55,60,115
+2022 January online qualifier,2022-01-20,Women's Masters (45-49) 71kg,Tressie Mullins,71,55,0,0,60,0,0,55,60,115
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 71kg,Charissa Sutliff,71,53,0,0,61,0,0,53,61,114
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 76kg,Trista Breil,76,49,0,0,64,0,0,49,64,113
+2022 January online qualifier,2022-01-19,Open Women's 55kg,breanna wilde,50,50,0,0,63,0,0,50,63,113
+2022 January online qualifier,2022-01-31,Women's Masters (40-44) 81kg,Stephanie Marshall,80,50,0,0,62,0,0,50,62,112
+2022 January online qualifier,2022-01-19,Women's Masters (35-39) +87kg,Jen Segadelli,94,51,0,0,61,0,0,51,61,112
+2022 January online qualifier,2022-01-31,Women's Masters (40-44) 76kg,Ann Marie Hicho,75,47,0,0,64,0,0,47,64,111
+2022 January online qualifier,2022-01-20,Open Women's 59kg,Jessica Buck-Atkinson,58,49,0,0,60,0,0,49,60,109
+2022 January online qualifier,2022-01-31,Open Women's 55kg,Amanda Belmer,52,46,0,0,62,0,0,46,62,108
+2022 January online qualifier,2022-01-31,Open Women's 71kg,Lindsey Holtgraves,65,48,0,0,60,0,0,48,60,108
+2022 January online qualifier,2022-01-19,Open Women's 59kg,Finna Wang,58,48,0,0,57,0,0,48,57,105
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 81kg,Lindsy Pettinger,78,49,0,0,54,0,0,49,54,103
+2022 January online qualifier,2022-01-31,Junior Women's 55kg,Ella Holden,55,51,0,0,51,0,0,51,51,102
+2022 January online qualifier,2022-01-31,Open Women's 55kg,Jayda Jenkins,55,51,0,0,51,0,0,51,51,102
+2022 January online qualifier,2022-01-20,Women's Masters (40-44) 71kg,Kerrie Lane,66,38,0,0,63,0,0,38,63,101
+2022 January online qualifier,2022-01-19,Open Women's 55kg,Kelsey Abdallah,53,46,0,0,53,0,0,46,53,99
+2022 January online qualifier,2022-01-31,Women's Masters (50-54) 71kg,Jennifer Schaefer,65,44,0,0,54,0,0,44,54,98
+2022 January online qualifier,2022-01-31,Women's 16-17 Age Group 59kg,carissa alexander,59,45,0,0,51,0,0,45,51,96
+2022 January online qualifier,2022-01-20,Women's 16-17 Age Group 55kg,Abbie Green,55,43,0,0,53,0,0,43,53,96
+2022 January online qualifier,2022-01-31,Women's Masters (35-39) 64kg,Stephanie Fung,64,44,0,0,49,0,0,44,49,93
+2022 January online qualifier,2022-01-20,Women's Masters (50-54) 71kg,Tracy Poches,66,40,0,0,50,0,0,40,50,90
+2022 January online qualifier,2022-01-31,Open Men's 73kg,Christian Solano,71,38,0,0,46,0,0,38,46,84
+2022 January online qualifier,2022-01-31,Men's 13 Under Age Group 73kg,Tate Fegley,73,35,0,0,40,0,0,35,40,75
+2022 January online qualifier,2022-01-31,Open Men's 61kg,Micheal Chandler,61,34,0,0,40,0,0,34,40,74
+2022 January online qualifier,2022-01-31,Junior Women's 64kg,Emma hennigan,60,31,0,0,41,0,0,31,41,72
+2022 January online qualifier,2022-01-31,Men's Masters (70-74) 61kg,Robert Wyffels,55.05,32,0,0,36,0,0,32,36,68
+2022 January online qualifier,2022-01-31,Men's Masters (70-74) 61kg,Robert Wyffels,56,32,0,0,36,0,0,32,36,68
+2022 January online qualifier,2022-01-31,Open Women's 49kg,Joriah Acacio,46,29,0,0,37,0,0,29,37,66

--- a/event_data/US/5428.csv
+++ b/event_data/US/5428.csv
@@ -1,0 +1,19 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2021 The H and 5 Classic,2022-07-02,Open Men's 109kg,Samuel Christofferson,105.35,113,118,121,147,152,155,121,155,276
+2021 The H and 5 Classic,2022-07-02,Open Men's 96kg,Alexander Nordstrom,92.95,105,110,115,140,0,145,115,145,260
+2021 The H and 5 Classic,2022-07-02,Open Men's 109kg,Jeremy Gruensteiner,105.8,100,105,0,126,0,0,105,126,231
+2021 The H and 5 Classic,2022-07-02,Open Men's 96kg,Michael Shaleen,95.4,97,103,109,115,119,0,109,119,228
+2021 The H and 5 Classic,2022-07-02,Open Men's 81kg,Christopher Yang,74.09,98,101,0,120,0,0,101,120,221
+2021 The H and 5 Classic,2022-07-02,Open Men's 81kg,Alexander Rouhani,78.83,92,0,96,122,0,0,96,122,218
+2021 The H and 5 Classic,2022-07-02,Open Men's 81kg,Jacob Piwko,77.32,77,82,87,0,102,0,87,102,189
+2021 The H and 5 Classic,2022-07-02,Open Men's 81kg,Jacob Anderson,79.47,73,0,77,98,103,107,77,107,184
+2021 The H and 5 Classic,2022-07-02,Open Men's 102kg,Jonathan Immel,98.41,0,0,75,95,99,0,75,99,174
+2021 The H and 5 Classic,2022-07-02,Women's Masters (35-39) 71kg,Lasandra Wilson,67.7,67,72,76,80,86,0,76,86,162
+2021 The H and 5 Classic,2022-07-02,Open Men's 89kg,Aaron Dush,83.39,64,67,70,83,88,92,70,92,162
+2021 The H and 5 Classic,2022-07-02,Open Men's 89kg,Connor Phipps,81.5,54,57,0,80,85,0,57,85,142
+2021 The H and 5 Classic,2022-07-02,Open Women's 76kg,Lauren Goldstein,73.61,46,49,0,60,64,0,49,64,113
+2021 The H and 5 Classic,2022-07-02,Open Women's 76kg,Chandler DeBerg,71.6,0,0,46,57,61,0,46,61,107
+2021 The H and 5 Classic,2022-07-02,Open Women's 55kg,Erica Alley,51.71,37,40,0,55,58,60,40,60,100
+2021 The H and 5 Classic,2022-07-02,Open Women's 64kg,Malia Hart,63.19,37,0,40,43,46,0,40,46,86
+2021 The H and 5 Classic,2022-07-02,Open Women's +87kg,Breanna Siegler,113.29,35,0,0,45,48,51,35,51,86
+2021 The H and 5 Classic,2022-07-02,Open Women's +87kg,Theresa Krause,95.49,27,29,31,30,33,36,31,36,67

--- a/event_data/US/5469.csv
+++ b/event_data/US/5469.csv
@@ -1,0 +1,22 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Men's 96kg,Nathan McLane,95.3,111,-117,-118,136,140,-150,111,140,251
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Men's 96kg,Michael Delatte,95.9,103,108,-111,137,-141,142,108,142,250
+The 2021 Grim Reaper Qualifier,2021-10-31,Junior Men's 89kg,Dillon James,88.9,-95,-100,100,120,127,132,100,132,232
+The 2021 Grim Reaper Qualifier,2021-10-31,Junior Men's 73kg,Zachary Gonzalez,72.9,-105,105,-110,115,121,-125,105,121,226
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Men's 81kg,Thomas Osborne Bird,78,78,82,-85,102,106,110,82,110,192
+The 2021 Grim Reaper Qualifier,2021-10-31,Men's Masters (35-39) 102kg,Kevin Kerlin,98.5,-81,81,-84,97,103,-109,81,103,184
+The 2021 Grim Reaper Qualifier,2021-10-31,Men's Masters (40-44) +109kg,Ryan Cleere,131.7,73,-76,76,90,94,-98,76,94,170
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Men's 81kg,Luis Valcke,80.9,63,66,70,85,-90,90,70,90,160
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Women's 64kg,christine Dang-Luu,61.8,60,63,66,82,86,90,66,90,156
+The 2021 Grim Reaper Qualifier,2021-10-31,Men's 16-17 Age Group 96kg,Aiden Long,89.2,58,61,63,78,79,84,63,84,147
+The 2021 Grim Reaper Qualifier,2021-10-31,Women's Masters (35-39) 76kg,Jessica Castro,76,58,-60,60,75,78,80,60,80,140
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Women's 64kg,Rachel Teran,63.5,57,-61,-61,76,-80,80,57,80,137
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Women's 81kg,Taylor Phillip,76.9,57,60,-63,68,71,74,60,74,134
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Women's 55kg,Jilly Jaworske,54.89,49,51,54,61,66,72,54,72,126
+The 2021 Grim Reaper Qualifier,2021-10-31,Women's Masters (35-39) 81kg,Stephanie Streep-Tuley,80.4,49,52,55,67,71,-74,55,71,126
+The 2021 Grim Reaper Qualifier,2021-10-31,Men's Masters (35-39) 102kg,John Zapp Jr,98,47,50,53,56,62,70,53,70,123
+The 2021 Grim Reaper Qualifier,2021-10-31,Women's 16-17 Age Group 59kg,Victoria Abell,59,49,-52,52,60,64,-66,52,64,116
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Women's 55kg,Morgan Gosselin,54.6,48,-51,-53,60,64,68,48,68,116
+The 2021 Grim Reaper Qualifier,2021-10-31,Open Women's 71kg,Marissa Novotny,65.8,32,-33,33,40,43,45,33,45,78
+The 2021 Grim Reaper Qualifier,2021-10-31,Men's 13 Under Age Group 73kg,Austin Cleere,72.2,12,15,23,22,27,30,23,30,53
+The 2021 Grim Reaper Qualifier,2021-10-31,Men's 13 Under Age Group 32kg,Harland Propes,28.5,13,15,-17,18,21,-24,15,21,36

--- a/event_data/US/5527.csv
+++ b/event_data/US/5527.csv
@@ -1,0 +1,20 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Midwest Showdown,2022-10-08,Junior Men's 81kg,Wesley Chaffin,76.8,100,0,0,120,0,0,100,120,220
+Midwest Showdown,2022-10-08,Open Men's 81kg,Jayden Ivey,80.2,0,92,100,120,0,0,100,120,220
+Midwest Showdown,2022-10-08,Open Men's 109kg,Jordan Bowling,106.3,95,100,0,120,0,0,100,120,220
+Midwest Showdown,2022-10-08,Men's Masters (35-39) 81kg,Jordan Kroell,76.8,77,81,84,103,107,112,84,112,196
+Midwest Showdown,2022-10-08,Junior Men's 67kg,Brady Osborne,66.3,0,75,0,0,0,90,75,90,165
+Midwest Showdown,2022-10-08,Men's 16-17 Age Group 89kg,Jesse JR Atwell,87.8,63,65,70,0,0,86,70,86,156
+Midwest Showdown,2022-10-08,Junior Men's 67kg,Holdyn Carr,62.7,57,0,0,72,76,76,57,76,133
+Midwest Showdown,2022-10-08,Open Women's 64kg,Kelly Netzer,62.1,55,57,0,70,75,0,57,75,132
+Midwest Showdown,2022-10-08,Men's 14-15 Age Group 73kg,David  Atwell,72.4,55,57,58,69,70,72,58,72,130
+Midwest Showdown,2022-10-08,Men's Masters (50-54) 73kg,David Sayler,72.4,55,0,58,0,70,72,58,72,130
+Midwest Showdown,2022-10-08,Women's 13 Under Age Group +64kg,Eva Windsor,102.5,50,55,0,63,66,69,55,69,124
+Midwest Showdown,2022-10-08,Open Women's 87kg,Anne Marie  Anibal ,82.3,47,0,55,0,68,0,55,68,123
+Midwest Showdown,2022-10-08,Junior Women's 59kg,Lydia Redd,59,43,46,0,59,63,0,46,63,109
+Midwest Showdown,2022-10-08,Men's 13 Under Age Group 55kg,Levi Atwell,49.9,36,39,41,48,52,56,41,56,97
+Midwest Showdown,2022-10-08,Men's 14-15 Age Group 73kg,Gavin Lewis,69.9,40,42,44,40,50,0,44,50,94
+Midwest Showdown,2022-10-08,Women's Masters (50-54) 55kg,Kelly Roberts,50.7,25,27,0,0,29,33,27,33,60
+Midwest Showdown,2022-10-08,Men's 16-17 Age Group 67kg,Drake Cole,61.9,0,75,0,0,0,0,75,0,0
+Midwest Showdown,2022-10-08,Junior Women's 55kg,Lilly York,50.95,0,0,0,0,57,0,0,57,0
+Midwest Showdown,2022-10-08,Women's 14-15 Age Group 49kg,Brooklynn Lercher,47.85,0,0,0,54,0,0,0,54,0

--- a/event_data/US/5581.csv
+++ b/event_data/US/5581.csv
@@ -1,0 +1,8 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2022 NAOF Qualifier,2022-11-04,Open Men's 89kg,Francisco Oliveras,89,0,0,200,0,0,200,200,200,400
+2022 NAOF Qualifier,2022-11-04,Open Women's 55kg,Haylee Johnson,55,0,0,200,0,0,200,200,200,400
+2022 NAOF Qualifier,2022-11-04,Open Women's 87kg,Julia Ryan,87,0,0,200,0,0,200,200,200,400
+2022 NAOF Qualifier,2022-11-04,Open Men's 96kg,Alec Olson,96,0,0,200,0,0,200,200,200,400
+2022 NAOF Qualifier,2022-11-04,Women's Masters (40-44) 76kg,Jessica Watson,76,0,0,200,0,0,200,200,200,400
+2022 NAOF Qualifier,2022-11-04,Women's 13 Under Age Group 49kg,Kaelyn Ansley,49,0,0,200,0,0,200,200,200,400
+2022 NAOF Qualifier,2022-11-04,Men's Masters (45-49) 109kg,James Campbell,109,0,0,200,0,0,200,200,200,400

--- a/event_data/US/5618.csv
+++ b/event_data/US/5618.csv
@@ -1,0 +1,21 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+HBC CLosed Tamale Meet,2022-12-10,Open Men's 89kg,Alexander Erdelac,87.1,100,-105,105,130,135,137,105,137,242
+HBC CLosed Tamale Meet,2022-12-10,Open Men's 67kg,John Ellison,65,95,100,105,126,131,-136,105,131,236
+HBC CLosed Tamale Meet,2022-12-10,Junior Men's 73kg,Stephen Warner,70.2,-90,90,-95,115,120,-122,90,120,210
+HBC CLosed Tamale Meet,2022-12-10,Junior Men's 109kg,Peyton Bailey ,106.2,65,70,75,95,100,105,75,105,180
+HBC CLosed Tamale Meet,2022-12-10,Junior Men's 109kg,Garett Hayse,102.5,65,70,74,80,-85,85,74,85,159
+HBC CLosed Tamale Meet,2022-12-10,Junior Women's 64kg,Patricia Eliscupides,63.5,63,66,68,75,78,81,68,81,149
+HBC CLosed Tamale Meet,2022-12-10,Men's 14-15 Age Group 73kg,Hutton Simmons,70.3,55,60,5,70,75,80,60,80,140
+HBC CLosed Tamale Meet,2022-12-10,Junior Men's 96kg,Brenden  Hoffert ,89.3,52,57,-62,70,75,-80,57,75,132
+HBC CLosed Tamale Meet,2022-12-10,Men's 14-15 Age Group +89kg,Luke Northcutt,98.6,40,45,50,60,65,72,50,72,122
+HBC CLosed Tamale Meet,2022-12-10,Women's 16-17 Age Group 71kg,Stella Tintari,69.8,45,48,51,65,70,-75,51,70,121
+HBC CLosed Tamale Meet,2022-12-10,Men's 16-17 Age Group 67kg,Carson Spurlock,64,45,50,-55,60,65,70,50,70,120
+HBC CLosed Tamale Meet,2022-12-10,Men's 16-17 Age Group 73kg,Andrew Willoughby,67.5,45,-50,50,55,60,65,50,65,115
+HBC CLosed Tamale Meet,2022-12-10,Men's 14-15 Age Group 81kg,Ethan Abbott,73.9,40,-45,45,55,60,65,45,65,110
+HBC CLosed Tamale Meet,2022-12-10,Junior Women's 55kg,Addison Kiran,52.7,40,44,46,55,60,63,46,63,109
+HBC CLosed Tamale Meet,2022-12-10,Men's 14-15 Age Group 67kg,Britton Sorci,62.9,35,40,-45,55,60,65,40,65,105
+HBC CLosed Tamale Meet,2022-12-10,Women's 16-17 Age Group 45kg,Martina Eliscupides,44.9,37,-42,-42,55,60,-63,37,60,97
+HBC CLosed Tamale Meet,2022-12-10,Men's 14-15 Age Group 55kg,Joshua Eliscupides,53.6,35,40,-45,42,47,50,40,50,90
+HBC CLosed Tamale Meet,2022-12-10,Women's 16-17 Age Group 55kg,Madison Brown,50.3,25,30,-34,35,40,45,30,45,75
+HBC CLosed Tamale Meet,2022-12-10,Women's 14-15 Age Group 64kg,Vivian Keene,60.6,25,30,-34,35,40,45,30,45,75
+HBC CLosed Tamale Meet,2022-12-10,Women's 16-17 Age Group 59kg,Lillian  Caddick,56.7,25,30,-34,35,40,43,30,43,73

--- a/event_data/US/5794.csv
+++ b/event_data/US/5794.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2022 North American Open Finals (b),2022-12-03,Men's Masters (35-39) 102kg,Jose Cruz Richardson,99.89,-111,111,115,125,-129,129,115,129,244

--- a/event_data/US/6151.csv
+++ b/event_data/US/6151.csv
@@ -1,0 +1,26 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Men's 89kg,Jack Christophel,87.2,-110,111,116,135,140,144,116,144,260
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Men's 89kg,George Bakatsias,86.3,112,113,117,135,140,-145,117,140,257
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Men's +109kg,Robinpreet Dhillon,120,90,100,-110,120,130,140,100,140,240
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Men's 102kg,Michael Rosa,100,90,-93,95,120,125,130,95,130,225
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Junior Men's 89kg,LAWRENCE MINTZ,88.4,93,97,-101,118,122,125,97,125,222
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Junior Men's 102kg,Daniel Tymus,97.7,-82,82,-84,100,105,110,82,110,192
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Men's Masters (50-54) 73kg,Aleksey Khomenko,73,60,65,68,83,88,90,68,90,158
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Junior Men's 67kg,Jeremy Singh,66.4,55,60,64,-85,85,90,64,90,154
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Men's 96kg,Stephan Julien,91.4,-65,65,-73,75,-81,81,65,81,146
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Junior Women's 81kg,Marci Baldinger,78.1,60,63,-65,77,-80,-80,63,77,140
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Men's Masters (65-69) 96kg,Thomas Tedesco,91.6,55,57,59,65,67,69,59,69,128
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Men's +109kg,Erik osorio,111,40,45,48,50,60,68,48,68,116
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Junior Men's 81kg,Sean Rivera,79.6,-42,42,46,-63,63,68,46,68,114
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Men's 14-15 Age Group 81kg,Matthew Emer,77.5,45,-50,-50,55,60,68,45,68,113
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Women's 55kg,Lydia Seiling,52.4,40,43,46,50,56,60,46,60,106
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Women's 55kg,Kristen Egert,54.4,43,46,-49,47,50,53,46,53,99
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Women's 13 Under Age Group 59kg,Gabrielle Oliveri,55.9,34,37,41,46,-50,52,41,52,93
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Men's 14-15 Age Group 81kg,Kaleb Osorio,77.3,30,34,38,45,50,55,38,55,93
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Women's Masters (35-39) 76kg,Nicole Oliveri,72.5,28,31,33,45,50,-55,33,50,83
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Junior Women's 49kg,Angelina Mintz,46.5,32,34,-36,40,43,-45,34,43,77
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Women's 14-15 Age Group 55kg,Ariana Oliveri,53.8,25,28,32,-45,45,-50,32,45,77
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Women's 14-15 Age Group 64kg,Helenea Pizza,64,25,28,-31,36,40,42,28,42,70
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Women's Masters (70-74) 64kg,Linda Reesman,63.1,24,27,30,33,36,40,30,40,70
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Open Women's 71kg,Yamini Patel,65.3,25,27,29,33,37,-40,29,37,66
+2023 Nick Curry Memorial/Holiday open,2023-12-09,Women's 16-17 Age Group 55kg,Czarina Poserio,51.5,22,24,25,32,35,37,25,37,62

--- a/event_data/US/6171.csv
+++ b/event_data/US/6171.csv
@@ -1,0 +1,7 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Glass City Christmas Invitational,2023-12-16,Open Men's 89kg,Warren Reuther,88.4,82,85,-88,103,106,108,85,108,193
+Glass City Christmas Invitational,2023-12-16,Men's 14-15 Age Group 67kg,Caleb Sprenger,64.4,59,62,65,72,76,-80,65,76,141
+Glass City Christmas Invitational,2023-12-16,Women's Masters (40-44) 59kg,Emily Downing,59,54,57,60,-67,67,70,60,70,130
+Glass City Christmas Invitational,2023-12-16,Women's 14-15 Age Group 59kg,Teelilly Abrighach,57.9,43,46,48,55,58,-60,48,58,106
+Glass City Christmas Invitational,2023-12-16,Women's 13 Under Age Group 40kg,Hailey Sprenger,37.5,16,18,20,23,25,27,20,27,47
+Glass City Christmas Invitational,2023-12-16,Women's 16-17 Age Group +81kg,Alexis Schwartz,86.1,-40,42,-45,-55,-55,-55,42,0,0

--- a/event_data/US/6173.csv
+++ b/event_data/US/6173.csv
@@ -1,0 +1,5 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Mihaly Huszka Memorial Weightlifting Invitational,2023-12-09,Men's 16-17 Age Group 73kg,Seth Barba,71.8,85,90,-91,105,110,-112,90,110,200
+Mihaly Huszka Memorial Weightlifting Invitational,2023-12-09,Men's 14-15 Age Group 61kg,Miles Gongora,56.5,42,45,-47,50,55,58,45,58,103
+Mihaly Huszka Memorial Weightlifting Invitational,2023-12-09,Men's 16-17 Age Group 67kg,MICHAEL HUSZKA,63.6,0,0,0,0,0,0,0,0,0
+Mihaly Huszka Memorial Weightlifting Invitational,2023-12-09,Men's Masters (55-59) 89kg,Michael Huszka,88.6,0,0,0,0,0,0,0,0,0

--- a/event_data/US/6174.csv
+++ b/event_data/US/6174.csv
@@ -1,0 +1,13 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Men's 109kg,Alex Papale,105,95,103,-105,127,133,-142,103,133,236
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Men's 96kg,Donovan Agelvis,91.72,87,92,96,-112,115,125,96,125,221
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Men's 89kg,Jose Correa,88.27,75,80,85,100,104,108,85,108,193
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Men's 16-17 Age Group 73kg,jahvani vasquez,70.09,75,80,85,95,100,104,85,104,189
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Men's 16-17 Age Group 89kg,Palmer Agelvis,87,55,60,65,75,80,85,65,85,150
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Men's 16-17 Age Group 55kg,Anthony Dela Cruz,53.45,55,59,-61,67,73,77,59,77,136
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Women's +87kg,Madelyn Wilson,113.6,54,57,-60,76,-83,-83,57,76,133
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Men's 73kg,Brice Ford,68,50,54,60,60,68,71,60,71,131
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Women's 71kg,Courtnie Lee,70,55,-58,-58,65,70,73,55,73,128
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Women's 14-15 Age Group 64kg,Taylor Ford,64,40,46,50,60,68,72,50,72,122
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Junior Women's 49kg,Sarah Griffin,48.5,33,38,-41,43,53,-60,38,53,91
+Team Florida Gulfcoast Holiday Cup,2023-12-22,Men's 13 Under Age Group +73kg,Rylee Jacobsen,79.09,18,21,23,20,25,28,23,28,51

--- a/event_data/US/6175.csv
+++ b/event_data/US/6175.csv
@@ -1,0 +1,74 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 81kg,Lasitha Welianga,74.9,0,0,113,0,0,145,113,145,258
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 96kg,Trey Vaughan,96,0,0,115,0,0,140,115,140,255
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 81kg,Aaron Denney,79.7,0,0,115,0,0,135,115,135,250
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 102kg,Logan Lewis,102,0,0,109,0,0,138,109,138,247
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 96kg,Ray Santana,95.9,0,0,105,0,0,140,105,140,245
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (40-44) 81kg,Mike Cozza,80,0,0,110,0,0,130,110,130,240
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 81kg,Tony Perez,80,0,0,102,0,0,134,102,134,236
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 89kg,Carlin Vandendriessche,88.3,0,0,102,0,0,132,102,132,234
+2023 December online qualifier (NUQ),2024-12-01,Open Men's 67kg,Felix Lien,66.5,0,0,105,0,0,125,105,125,230
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 96kg,Joseph Fisher,91.1,0,0,102,0,0,120,102,120,222
+2023 December online qualifier (NUQ),2023-12-01,Junior Men's 89kg,Rafed Abbassi,82.8,0,0,95,0,0,125,95,125,220
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 102kg,Lucas Moylan,101.5,0,0,100,0,0,110,100,110,210
+2023 December online qualifier (NUQ),2023-12-01,Open Women's +87kg,Kimberlee Douglas,139.1,0,0,85,0,0,115,85,115,200
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (40-44) 89kg,Jose Curbelo ,86,0,0,88,0,0,112,88,112,200
+2023 December online qualifier (NUQ),2023-12-01,Junior Men's 96kg,Simon Thompson ,94.4,0,0,90,0,0,105,90,105,195
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 96kg,Ethan van Heerden,95.9,0,0,81,0,0,114,81,114,195
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (45-49) 89kg,Bryan Polsonetti,88.2,0,0,85,0,0,110,85,110,195
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (45-49) 102kg,Jason Willis,99.51,0,0,80,0,0,115,80,115,195
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (40-44) 73kg,Christian Reyes,71,0,0,83,0,0,112,83,112,195
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 81kg,Theron Hawkins,76.1,0,0,85,0,0,110,85,110,195
+2023 December online qualifier (NUQ),2023-12-01,Junior Men's 81kg,Cole Resurreccion,78.6,0,0,88,0,0,106,88,106,194
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 89kg,Efrain Cruz Torres,86,0,0,84,0,0,109,84,109,193
+2023 December online qualifier (NUQ),2023-12-01,Men's 16-17 Age Group 96kg,Mitchell Ferguson,92.2,0,0,91,0,0,100,91,100,191
+2023 December online qualifier (NUQ),2023-12-01,Junior Men's 81kg,Kevin Li,79.1,0,0,80,0,0,102,80,102,182
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (35-39) 81kg,Robert Tuck,75,0,0,80,0,0,102,80,102,182
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 73kg,Jonathan Larcom,72.74,0,0,86,0,0,95,86,95,181
+2023 December online qualifier (NUQ),2023-12-01,Men's 16-17 Age Group 96kg,Nathan Cleghorn,93,0,0,80,0,0,100,80,100,180
+2023 December online qualifier (NUQ),2023-12-01,Junior Men's 73kg,Gavin Dunkin,72.4,0,0,75,0,0,96,75,96,171
+2023 December online qualifier (NUQ),2023-12-01,Men's 14-15 Age Group 67kg,Flynn King,63,0,0,74,0,0,97,74,97,171
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (35-39) 73kg,Ahmad Almansoor,71.8,0,0,78,0,0,93,78,93,171
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (50-54) 102kg,David nogaki,102,0,0,75,0,0,93,75,93,168
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (40-44) 71kg,Jennifer White,68.1,0,0,75,0,0,86,75,86,161
+2023 December online qualifier (NUQ),2023-12-01,Open Men's 67kg,Joongbom Park,66,0,0,70,0,0,90,70,90,160
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 71kg,Monica Rios,70,0,0,67,0,0,92,67,92,159
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 71kg,Kelsey Butler,69.5,0,0,70,0,0,88,70,88,158
+2023 December online qualifier (NUQ),2023-12-01,Junior Women's +87kg,Renee Hutchins,100,0,0,71,0,0,85,71,85,156
+2023 December online qualifier (NUQ),2023-12-01,Men's Masters (50-54) 73kg,Ryo Osawa,73,0,0,68,0,0,88,68,88,156
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (45-49) 71kg,Aimee Anaya Everett,71,0,0,73,0,0,80,73,80,153
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 76kg,Bailey Barnick,72.9,0,0,72,0,0,81,72,81,153
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 64kg,Stephany Wilson,59.7,0,0,70,0,0,81,70,81,151
+2023 December online qualifier (NUQ),2023-12-01,Men's 16-17 Age Group 67kg,Cole Horn,61.9,0,0,63,0,0,82,63,82,145
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 71kg,Alexandra Prymek,70.9,0,0,65,0,0,79,65,79,144
+2023 December online qualifier (NUQ),2023-12-01,Men's 13 Under Age Group +73kg,Tate Fegley,86,0,0,61,0,0,80,61,80,141
+2023 December online qualifier (NUQ),2023-12-01,Junior Women's 71kg,Devin Craig-Schwartz,65.5,0,0,64,0,0,77,64,77,141
+2023 December online qualifier (NUQ),2023-12-01,Men's 16-17 Age Group 61kg,Cole Williams,60.2,0,0,70,0,0,70,70,70,140
+2023 December online qualifier (NUQ),2023-12-01,Open Women's +87kg,Skyler Peebles,119.6,0,0,62,0,0,75,62,75,137
+2023 December online qualifier (NUQ),2023-12-01,Men's 14-15 Age Group 81kg,Scott Mitchell,79.6,0,0,66,0,0,70,66,70,136
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 71kg,Madison Cook,67,0,0,63,0,0,72,63,72,135
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 64kg,Margaret Klimchuck,63.4,0,0,60,0,0,74,60,74,134
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 64kg,Laney Schol,63.95,0,0,59,0,0,75,59,75,134
+2023 December online qualifier (NUQ),2023-12-01,Men's 14-15 Age Group 61kg,TIMOTHY NEAL,58.8,0,0,57,0,0,75,57,75,132
+2023 December online qualifier (NUQ),2023-12-01,Junior Women's 64kg,Alissa Horton,64,0,0,62,0,0,69,62,69,131
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 64kg,Annie Gough,61.8,0,0,59,0,0,70,59,70,129
+2023 December online qualifier (NUQ),2023-12-01,Junior Women's 64kg,Karla  Ramon ,64,0,0,56,0,0,70,56,70,126
+2023 December online qualifier (NUQ),2023-12-01,Women's 16-17 Age Group 71kg,lucia page sander,69,0,0,60,0,0,65,60,65,125
+2023 December online qualifier (NUQ),2023-12-01,Junior Women's 71kg,Elizabeth Eiting,69.8,0,0,55,0,0,70,55,70,125
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 71kg,Amy Nolan,65,0,0,56,0,0,69,56,69,125
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 64kg,Haley Headrick,60.7,0,0,51,0,0,65,51,65,116
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 59kg,Susanna Eng,59,0,0,52,0,0,63,52,63,115
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (40-44) 71kg,Trina Sumodobila,67.75,0,0,52,0,0,62,52,62,114
+2023 December online qualifier (NUQ),2023-12-01,Women's 16-17 Age Group 71kg,Emma Yoder,64.8,0,0,53,0,0,61,53,61,114
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 81kg,Stephanie Broadbent,77,0,0,47,0,0,61,47,61,108
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 55kg,Paige Steuber,52.09,0,0,49,0,0,55,49,55,104
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 55kg,Gina Cantelmi,54.9,0,0,43,0,0,60,43,60,103
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (40-44) 64kg,Angela White,64,0,0,47,0,0,55,47,55,102
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (60-64) 81kg,Brandi Herring,79,0,0,40,0,0,61,40,61,101
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (60-64) 71kg,Litsa Olsson,69.73,0,0,43,0,0,56,43,56,99
+2023 December online qualifier (NUQ),2023-12-01,Women's 16-17 Age Group 71kg,Katelyn Bailey,69.8,0,0,42,0,0,57,42,57,99
+2023 December online qualifier (NUQ),2023-12-01,Open Women's 71kg,Maddy DeRita,66,0,0,42,0,0,57,42,57,99
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (50-54) 71kg,Diana Tidler,67,0,0,43,0,0,53,43,53,96
+2023 December online qualifier (NUQ),2023-12-01,Women's Masters (50-54) 64kg,Patti Kato,60,0,0,41,0,0,49,41,49,90
+2023 December online qualifier (NUQ),2023-12-01,Men's 14-15 Age Group 44kg,Tyler Stewart,43.1,0,0,30,0,0,38,30,38,68
+2023 December online qualifier (NUQ),2023-12-01,Men's 13 Under Age Group 67kg,Jackson Hungerford,64,0,0,27,0,0,33,27,33,60

--- a/event_data/US/6176.csv
+++ b/event_data/US/6176.csv
@@ -1,0 +1,22 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Rockford Barbell New Years Meet,2023-12-30,Open Men's 81kg,Cory Ebert,81,110,-113,114,147,-153,-153,114,147,261
+Rockford Barbell New Years Meet,2023-12-30,Open Men's 89kg,Jason Barrow,88.7,100,105,110,130,-135,137,110,137,247
+Rockford Barbell New Years Meet,2023-12-30,Open Men's 73kg,Felix Lien,71.7,102,106,-109,-120,125,-128,106,125,231
+Rockford Barbell New Years Meet,2023-12-30,Open Men's 73kg,Yuepheng Xiong,72.7,90,95,-100,125,-128,-128,95,125,220
+Rockford Barbell New Years Meet,2023-12-30,Open Men's 81kg,Jake Rutkowski,73.4,65,-70,70,100,-105,105,70,105,175
+Rockford Barbell New Years Meet,2023-12-30,Junior Women's 81kg,Allysen Byerley,80.9,59,61,64,82,84,86,64,86,150
+Rockford Barbell New Years Meet,2023-12-30,Men's 16-17 Age Group 73kg,Francis Avogo,71,55,60,64,75,80,86,64,86,150
+Rockford Barbell New Years Meet,2023-12-30,Men's 16-17 Age Group +102kg,Corbin Gray,128.8,55,58,61,73,77,80,61,80,141
+Rockford Barbell New Years Meet,2023-12-30,Open Men's 89kg,Jared Ellias,88,55,60,65,75,-80,-80,65,75,140
+Rockford Barbell New Years Meet,2023-12-30,Men's Masters (45-49) 89kg,Jason Geheber,85.7,48,53,-61,-75,75,80,53,80,133
+Rockford Barbell New Years Meet,2023-12-30,Men's 13 Under Age Group +73kg,Noah Hauser,142,45,48,-50,55,59,62,48,62,110
+Rockford Barbell New Years Meet,2023-12-30,Men's 14-15 Age Group 73kg,Morgan Race,69.1,30,33,38,45,50,55,38,55,93
+Rockford Barbell New Years Meet,2023-12-30,Men's 14-15 Age Group 55kg,Anthony Harris,55,35,38,41,45,50,-55,41,50,91
+Rockford Barbell New Years Meet,2023-12-30,Women's 14-15 Age Group +76kg,Aleesia Lopez,91.6,30,33,35,42,45,47,35,47,82
+Rockford Barbell New Years Meet,2023-12-30,Men's 13 Under Age Group 61kg,Andrell Singleton Jr.,58.1,32,35,-38,38,-40,40,35,40,75
+Rockford Barbell New Years Meet,2023-12-30,Women's 13 Under Age Group +64kg,Adrian Singleton,70.9,28,30,-32,35,37,41,30,41,71
+Rockford Barbell New Years Meet,2023-12-30,Men's 13 Under Age Group +73kg,Braylen Graham,76.7,25,27,29,29,32,34,29,34,63
+Rockford Barbell New Years Meet,2023-12-30,Men's 13 Under Age Group 61kg,Toby Harned,56,19,21,23,25,31,33,23,33,56
+Rockford Barbell New Years Meet,2023-12-30,Men's 13 Under Age Group 49kg,Kristopher Moore,47.5,18,20,22,23,-25,25,22,25,47
+Rockford Barbell New Years Meet,2023-12-30,Women's 13 Under Age Group 49kg,Erika Olascuaga,45.6,16,18,19,20,22,23,19,23,42
+Rockford Barbell New Years Meet,2023-12-30,Men's 13 Under Age Group 32kg,Tucker Campbell,31.9,16,17,-18,18,19,20,17,20,37

--- a/event_data/US/6190.csv
+++ b/event_data/US/6190.csv
@@ -1,0 +1,6 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Tucson Winter Weightling at GTX,2023-12-02,Open Men's 102kg,Race Williams,99.3,75,-80,80,107,112,116,80,116,196
+Tucson Winter Weightling at GTX,2023-12-02,Junior Men's 102kg,Dylan  Grandstaff ,101.4,43,47,-53,70,74,77,47,77,124
+Tucson Winter Weightling at GTX,2023-12-02,Women's 16-17 Age Group +81kg,Colie Molina ,125.7,32,34,36,40,43,46,36,46,82
+Tucson Winter Weightling at GTX,2023-12-02,Women's Masters (60-64) 87kg,Lenore Grijalva,83.2,32,34,36,40,43,46,36,46,82
+Tucson Winter Weightling at GTX,2023-12-02,Junior Women's 64kg,MiaBella Davis ,59.8,31,33,-35,47,-49,-49,33,47,80

--- a/event_data/US/6657.csv
+++ b/event_data/US/6657.csv
@@ -1,0 +1,8 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Annual Tamale Meet,2024-12-14,Junior Men's 96kg,Alexander Erdelac,94.7,110,115,120,135,145,150,120,150,270
+Annual Tamale Meet,2024-12-14,Men's 16-17 Age Group 81kg,Britton Sorci,77.4,-85,87,92,115,120,125,92,125,217
+Annual Tamale Meet,2024-12-14,Men's 16-17 Age Group 89kg,Ethan Abbott,88.4,85,90,-95,120,125,-130,90,125,215
+Annual Tamale Meet,2024-12-14,Junior Men's 96kg,Calvin Hua,92,92,-97,-97,-110,110,115,92,115,207
+Annual Tamale Meet,2024-12-14,Men's 16-17 Age Group 67kg,Joshua Eliscupides,62.5,87,-92,93,100,105,110,93,110,203
+Annual Tamale Meet,2024-12-14,Junior Women's 71kg,Patricia Eliscupides,68.9,75,78,-81,90,95,100,78,100,178
+Annual Tamale Meet,2024-12-14,Women's 16-17 Age Group 55kg,Corina Huizenga,54.3,35,38,-40,40,45,50,38,50,88

--- a/event_data/US/6670.csv
+++ b/event_data/US/6670.csv
@@ -1,0 +1,12 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+5th Annual Merry Liftmas,2024-12-14,Open Men's +109kg,Andrew Pupo,136.4,110,115,120,-150,165,-176,120,165,285
+5th Annual Merry Liftmas,2024-12-14,Open Men's +109kg,Michael Wall,111,110,115,-120,140,-150,-160,115,140,255
+5th Annual Merry Liftmas,2024-12-14,Men's 16-17 Age Group 73kg,Roy  Maher,73,105,108,-111,-135,135,-142,108,135,243
+5th Annual Merry Liftmas,2024-12-14,Women's Masters (40-44) 81kg,Jessica Watson,81,64,-67,-68,68,70,72,64,72,136
+5th Annual Merry Liftmas,2024-12-14,Women's Masters (35-39) 71kg,Katelyn Lipa,67,57,59,-61,65,69,-72,59,69,128
+5th Annual Merry Liftmas,2024-12-14,Women's 14-15 Age Group 76kg,Madeleine Maher,73,52,54,-56,-67,68,-70,54,68,122
+5th Annual Merry Liftmas,2024-12-14,Open Women's +87kg,Christine Harris,113,45,48,51,59,63,65,51,65,116
+5th Annual Merry Liftmas,2024-12-14,Men's Masters (65-69) 81kg,Steven Acenbrak,74.2,36,38,40,48,52,55,40,55,95
+5th Annual Merry Liftmas,2024-12-14,Women's 14-15 Age Group 64kg,Catherine  Cox,63,34,36,-39,45,47,49,36,49,85
+5th Annual Merry Liftmas,2024-12-14,Men's 14-15 Age Group 61kg,Desmond Carey,59,34,36,-39,-45,45,48,36,48,84
+5th Annual Merry Liftmas,2024-12-14,Women's 13 Under Age Group 45kg,Abigail Negron,44,26,28,30,-38,38,40,30,40,70

--- a/event_data/US/6671.csv
+++ b/event_data/US/6671.csv
@@ -1,0 +1,37 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 81kg,Owen Murphy,80.55,105,-111,-115,135,-140,141,105,141,246
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 102kg,Michael Rosa,101.7,92,-100,100,125,134,140,100,140,240
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 102kg,Robinpreet Dhillon,98.4,90,95,100,110,115,120,100,120,220
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's Masters (40-44) 96kg,Eric Combs,95.8,97,100,-103,115,118,119,100,119,219
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 96kg,Benjamin Stevens,95,90,-100,100,105,-115,115,100,115,215
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 73kg,Juliann Gabriel Poserio,72,85,-90,93,105,107,-111,93,107,200
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 73kg,Daniel Lema,72.6,75,81,-85,110,115,-117,81,115,196
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's Masters (35-39) 102kg,Mark Louros,96.95,80,85,-91,110,-115,0,85,110,195
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Men's 89kg,Mohammed Aiman Koli,87.85,82,-85,-85,109,-110,0,82,109,191
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Men's 96kg,Stephan Julien,92.15,82,-87,-91,100,-107,-112,82,100,182
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's 16-17 Age Group 81kg,Nathan Combs,76.7,67,-70,-70,92,-95,-95,67,92,159
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's Masters (55-59) 81kg,Aleksey Khomenko,74.93,65,-68,68,85,88,90,68,90,158
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's 16-17 Age Group 89kg,Matthew Emer,86.3,52,54,56,75,79,-82,56,79,135
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's 16-17 Age Group +81kg,Grace Wang,89.7,53,55,57,67,69,72,57,72,129
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's Masters (40-44) +87kg,CASSEY BURRELL,95.55,48,50,53,72,75,-78,53,75,128
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Men's 67kg,Yiming Huang,64,50,-55,-56,70,76,-82,50,76,126
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Women's 71kg,Brianna Forman,67.55,45,50,53,65,70,-73,53,70,123
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Women's 64kg,Mia  Mohr ,62.8,-49,49,53,68,-72,-72,53,68,121
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Women's 71kg,Kinali Patel,64.6,48,51,-54,70,-74,-74,51,70,121
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's 14-15 Age Group 89kg,Frank Mintz,84.6,43,46,49,62,66,69,49,69,118
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Women's 59kg,Gyuri Moon,58.55,44,47,-50,55,58,-61,47,58,105
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Women's 59kg,Lydia Seiling,58.9,40,43,45,55,58,60,45,60,105
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's Masters (75-79) 73kg,Gerard Dunne,72.7,38,41,-43,45,-53,53,41,53,94
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Women's 64kg,Ashley Visconti,60.4,33,-35,35,40,42,45,35,45,80
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Women's 59kg,Jennifer Portillo,57.3,34,35,36,40,42,-44,36,42,78
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Women's 49kg,Angelina Mintz,45.4,32,34,-36,39,42,-45,34,42,76
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's 16-17 Age Group 55kg,Czarina Poserio,53,30,33,-35,37,40,43,33,43,76
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's Masters (35-39) 87kg,Hafizah Omar,85.1,27,29,-30,37,40,43,29,43,72
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Open Women's 55kg,Jennifer Chacon Herrador,53.5,26,-28,30,40,-43,-44,30,40,70
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Men's 13 Under Age Group 55kg,Oliver Combs,52.55,26,28,30,35,38,40,30,40,70
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's 16-17 Age Group 55kg,Shawna Khuu,53.7,22,24,26,38,41,43,26,43,69
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's 16-17 Age Group 45kg,May Thu Khaing,42.9,23,25,27,33,-35,35,27,35,62
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's Masters (55-59) 81kg,Kathleen Porter,80.4,21,23,25,30,33,35,25,35,60
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Women's Masters (40-44) 55kg,Melanie Gatti,52.4,18,21,-23,25,28,30,21,30,51
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Men's 73kg,Justin Bongcaron,70.3,-85,-90,-90,105,-109,109,0,109,0
+2024 The Nick Curry Memorial / Holliday open,2024-12-15,Junior Men's 109kg,Daniel Tymus,104.9,-86,86,-92,-120,-120,0,86,0,0

--- a/event_data/US/6673.csv
+++ b/event_data/US/6673.csv
@@ -1,0 +1,33 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+A Clash of Kilos,2024-12-14,Men's Masters (35-39) +109kg,Jean Banos,134.45,113,117,-120,145,150,-155,117,150,267
+A Clash of Kilos,2024-12-14,Men's Masters (35-39) +109kg,Seth Day,112.35,100,105,111,140,146,150,111,150,261
+A Clash of Kilos,2024-12-14,Open Men's 96kg,Joshua Bryan,95.4,102,-107,-110,125,131,-137,102,131,233
+A Clash of Kilos,2024-12-14,Open Men's +109kg,Tim Oberhelman,112.05,-90,92,96,110,115,120,96,120,216
+A Clash of Kilos,2024-12-14,Open Men's 89kg,Michael Parrish,88.6,85,90,-95,110,-115,117,90,117,207
+A Clash of Kilos,2024-12-14,Men's Masters (35-39) 96kg,Victor Angulo,92.6,55,60,73,90,100,110,73,110,183
+A Clash of Kilos,2024-12-14,Men's Masters (45-49) 96kg,Rigoberto flores,90.1,60,-65,65,83,-93,93,65,93,158
+A Clash of Kilos,2024-12-14,Open Women's 71kg,Sydney Meyer,64.4,67,-70,71,78,82,85,71,85,156
+A Clash of Kilos,2024-12-14,Open Women's 71kg,Allison Kelley,71,-69,69,-71,-82,82,-85,69,82,151
+A Clash of Kilos,2024-12-14,Men's Masters (45-49) 81kg,chris fettig,79.8,64,-66,67,75,78,81,67,81,148
+A Clash of Kilos,2024-12-14,Women's Masters (45-49) 64kg,Venessa Halverson,63.2,62,-65,65,80,83,-85,65,83,148
+A Clash of Kilos,2024-12-14,Men's Masters (35-39) 81kg,Adam Hurst,78.2,55,58,60,75,79,83,60,83,143
+A Clash of Kilos,2024-12-14,Women's Masters (35-39) +87kg,Heather Hatchett,121.3,-52,52,60,64,70,-75,60,70,130
+A Clash of Kilos,2024-12-14,Open Women's 76kg,Yvonne Guajardo,76,46,48,50,65,70,75,50,75,125
+A Clash of Kilos,2024-12-14,Men's Masters (60-64) 81kg,Brian Schoepf,79.9,45,50,55,-61,63,70,55,70,125
+A Clash of Kilos,2024-12-14,Women's Masters (40-44) 76kg,Kristin Brimhall,75.95,47,49,51,67,69,72,51,72,123
+A Clash of Kilos,2024-12-14,Open Women's 87kg,Kayla Jefferies,85,49,-51,-53,66,68,71,49,71,120
+A Clash of Kilos,2024-12-14,Women's Masters (45-49) 81kg,Misty Hill,76.9,46,-48,50,60,63,65,50,65,115
+A Clash of Kilos,2024-12-14,Open Women's 55kg,Bindu Marasini,50.8,47,-51,-51,63,-66,-68,47,63,110
+A Clash of Kilos,2024-12-14,Women's Masters (35-39) 81kg,Laura Ihde,78.45,39,42,46,56,60,64,46,64,110
+A Clash of Kilos,2024-12-14,Open Women's +87kg,Shelby Williams,110.15,41,43,45,56,59,-62,45,59,104
+A Clash of Kilos,2024-12-14,Women's Masters (40-44) 64kg,Joanne Sanders,61.65,42,45,-47,55,58,-60,45,58,103
+A Clash of Kilos,2024-12-14,Women's Masters (45-49) 64kg,Natalie Dale,62.3,35,37,38,48,50,53,38,53,91
+A Clash of Kilos,2024-12-14,Open Women's 81kg,Jeannie Asuao,78,33,36,39,45,-48,51,39,51,90
+A Clash of Kilos,2024-12-14,Open Women's 76kg,Aishwarya Nandyala,75,35,40,-42,48,50,-55,40,50,90
+A Clash of Kilos,2024-12-14,Women's Masters (55-59) +87kg,Angie Gardi,101.4,37,-38,38,50,-55,-55,38,50,88
+A Clash of Kilos,2024-12-14,Open Women's 87kg,Alannah Eagle-King,84,35,37,-39,43,45,-47,37,45,82
+A Clash of Kilos,2024-12-14,Women's Masters (50-54) 81kg,Mahalia Locklin,77.25,30,32,-34,43,46,-49,32,46,78
+A Clash of Kilos,2024-12-14,Women's 13 Under Age Group 49kg,Elhiana Inez Perez,47,25,-28,28,34,37,39,28,39,67
+A Clash of Kilos,2024-12-14,Men's 13 Under Age Group 49kg,Felix Yandel Rivera,45,25,28,30,31,34,37,30,37,67
+A Clash of Kilos,2024-12-14,Open Women's 76kg,Savanna Gillen,72,25,27,-29,29,31,33,27,33,60
+A Clash of Kilos,2024-12-14,Women's 13 Under Age Group 36kg,Hadley Stewart,33.6,12,14,16,16,18,-20,16,18,34

--- a/event_data/US/6674.csv
+++ b/event_data/US/6674.csv
@@ -1,0 +1,83 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+SoCal Winter Classic,2024-12-14,Open Men's +109kg,Juan Alcazar,126.19,130,135,140,160,166,-172,140,166,306
+SoCal Winter Classic,2024-12-14,Open Men's +109kg,Patrick Whitmore,115.24,128,133,-139,163,168,-174,133,168,301
+SoCal Winter Classic,2024-12-14,Open Men's 102kg,Alan Ninobla,101.86,116,120,-123,160,165,170,120,170,290
+SoCal Winter Classic,2024-12-14,Open Men's 102kg,Julian Box,99.96,-105,108,116,125,-137,140,116,140,256
+SoCal Winter Classic,2024-12-14,Open Men's 96kg,Andrew Brantley,91.18,103,-106,106,134,138,140,106,140,246
+SoCal Winter Classic,2024-12-14,Open Men's +109kg,Blake Atwell,114,86,91,96,-132,-132,140,96,140,236
+SoCal Winter Classic,2024-12-14,Open Men's 67kg,Gerald Lebrilla,66.93,95,98,101,-130,-130,135,101,135,236
+SoCal Winter Classic,2024-12-14,Open Men's 89kg,Travis  Eirich ,88.02,88,94,-100,129,-136,137,94,137,231
+SoCal Winter Classic,2024-12-14,Men's Masters (40-44) 96kg,Matthew Kaplan,95.25,95,-99,99,125,130,-134,99,130,229
+SoCal Winter Classic,2024-12-14,Open Men's 96kg,Eric Chun,94.74,96,101,-105,116,121,-125,101,121,222
+SoCal Winter Classic,2024-12-14,Open Men's 73kg,Rafael Ramirez,71.57,95,-100,100,115,120,-125,100,120,220
+SoCal Winter Classic,2024-12-14,Open Men's 109kg,Kenneth Noriesta,108.25,89,92,95,117,120,123,95,123,218
+SoCal Winter Classic,2024-12-14,Open Men's 96kg,Darius Constancio,94.21,-94,94,97,117,121,-123,97,121,218
+SoCal Winter Classic,2024-12-14,Open Men's 109kg,Abraham Dominguez,108.2,-97,97,-101,115,120,-126,97,120,217
+SoCal Winter Classic,2024-12-14,Junior Men's 81kg,Jayden Son,73.06,85,90,-95,110,115,-118,90,115,205
+SoCal Winter Classic,2024-12-14,Open Men's 73kg,daniel Perez,71.42,-90,93,96,105,108,-115,96,108,204
+SoCal Winter Classic,2024-12-14,Men's Masters (35-39) 81kg,John Fasulo,80.5,81,84,87,110,113,117,87,117,204
+SoCal Winter Classic,2024-12-14,Open Men's +109kg,Eduardo Montes,116.45,75,80,-100,105,112,120,80,120,200
+SoCal Winter Classic,2024-12-14,Open Men's 109kg,Marco Ledezma,106.5,80,84,90,95,105,108,90,108,198
+SoCal Winter Classic,2024-12-14,Open Men's 89kg,Thomas Bilodeau,84.39,76,79,82,109,112,115,82,115,197
+SoCal Winter Classic,2024-12-14,Open Men's 89kg,Steven Marin,84.9,75,80,-81,110,-115,117,80,117,197
+SoCal Winter Classic,2024-12-14,Open Men's 96kg,Sergio Dillon,90.9,75,78,81,110,-115,115,81,115,196
+SoCal Winter Classic,2024-12-14,Men's Masters (35-39) 89kg,Braden Drake,87.1,80,83,-85,112,-115,-117,83,112,195
+SoCal Winter Classic,2024-12-14,Men's Masters (35-39) 96kg,Alphonso Jimenez,93.16,82,85,-88,103,107,110,85,110,195
+SoCal Winter Classic,2024-12-14,Men's Masters (45-49) 96kg,Anthony Sosa,93.45,79,-82,82,-104,104,-108,82,104,186
+SoCal Winter Classic,2024-12-14,Open Men's 73kg,Nima Hemmatian,71.92,77,80,-83,94,98,102,80,102,182
+SoCal Winter Classic,2024-12-14,Men's Masters (40-44) 102kg,Joseph  Gonzalez ,101.25,75,-79,80,100,-102,102,80,102,182
+SoCal Winter Classic,2024-12-14,Open Men's 109kg,Derec Thompson,105.7,71,75,80,94,97,100,80,100,180
+SoCal Winter Classic,2024-12-14,Men's Masters (35-39) 81kg,henry maung,80.8,-75,75,-81,99,-105,-107,75,99,174
+SoCal Winter Classic,2024-12-14,Women's Masters (45-49) 81kg,Deonna Lee,79.72,65,67,70,90,95,100,70,100,170
+SoCal Winter Classic,2024-12-14,Men's Masters (40-44) 61kg,Shunsuke Nakao,60.24,68,72,75,85,90,94,75,94,169
+SoCal Winter Classic,2024-12-14,Men's Masters (45-49) 73kg,Richard Banister,69.5,61,66,70,84,93,98,70,98,168
+SoCal Winter Classic,2024-12-14,Open Men's 73kg,Cody Castro,67.52,70,73,75,90,93,-95,75,93,168
+SoCal Winter Classic,2024-12-14,Open Women's 76kg,Annie Wozniak,74.5,70,-74,75,85,90,-94,75,90,165
+SoCal Winter Classic,2024-12-14,Open Women's 76kg,Salma Mahmoud,75.23,-70,70,-72,-88,88,92,70,92,162
+SoCal Winter Classic,2024-12-14,Men's Masters (35-39) 73kg,Kuo Hung Tseng,70.57,60,65,70,81,85,90,70,90,160
+SoCal Winter Classic,2024-12-14,Open Women's 64kg,Austria Cho,63.83,-71,71,-75,88,-92,-95,71,88,159
+SoCal Winter Classic,2024-12-14,Open Women's +87kg,Lauren Thiel,126.81,58,61,64,84,88,90,64,90,154
+SoCal Winter Classic,2024-12-14,Men's 14-15 Age Group 81kg,Jase Coss,79,-61,61,63,80,85,90,63,90,153
+SoCal Winter Classic,2024-12-14,Men's 14-15 Age Group 81kg,Mateo Jonah Limbo,76.5,-60,62,-65,80,85,91,62,91,153
+SoCal Winter Classic,2024-12-14,Women's Masters (35-39) 81kg,Justina Gutierrez,78.72,62,65,67,77,80,84,67,84,151
+SoCal Winter Classic,2024-12-14,Open Women's 55kg,Judy Zhou,54.34,-60,61,64,80,85,-87,64,85,149
+SoCal Winter Classic,2024-12-14,Open Men's 73kg,Alex Sanchez-Olvera,71.4,62,67,-72,75,82,-88,67,82,149
+SoCal Winter Classic,2024-12-14,Open Women's 59kg,Cynthia Brown,58.41,60,64,-67,80,-83,-83,64,80,144
+SoCal Winter Classic,2024-12-14,Men's Masters (45-49) 73kg,Francisco Saco,72.3,53,57,60,75,79,83,60,83,143
+SoCal Winter Classic,2024-12-14,Open Women's 64kg,Danlin Bao,59.8,60,63,65,74,78,-84,65,78,143
+SoCal Winter Classic,2024-12-14,Open Women's 81kg,Marielle Celi,78.36,62,64,-66,-76,76,78,64,78,142
+SoCal Winter Classic,2024-12-14,Open Women's +87kg,Lisbet Celestino,90.93,58,60,-63,75,78,81,60,81,141
+SoCal Winter Classic,2024-12-14,Women's Masters (35-39) 64kg,Marion Crowley,63.61,58,61,64,73,-76,76,64,76,140
+SoCal Winter Classic,2024-12-14,Open Women's 71kg,Alesia Guerrero Castillo,69.92,58,60,62,76,-78,-80,62,76,138
+SoCal Winter Classic,2024-12-14,Open Women's 81kg,Joan Lim,80.4,58,60,-63,75,78,-80,60,78,138
+SoCal Winter Classic,2024-12-14,Open Women's +87kg,Alexandra Navaja,90.63,53,55,57,78,80,-82,57,80,137
+SoCal Winter Classic,2024-12-14,Women's Masters (35-39) 71kg,Carola Manriquez,70.85,52,54,56,72,76,80,56,80,136
+SoCal Winter Classic,2024-12-14,Women's Masters (40-44) 71kg,Melissa  Ozuna,69,52,-54,55,72,74,-77,55,74,129
+SoCal Winter Classic,2024-12-14,Women's Masters (35-39) 64kg,Jessica Marie Ramirez,63.7,54,-56,57,68,71,-74,57,71,128
+SoCal Winter Classic,2024-12-14,Men's Masters (50-54) 102kg,Brian Dickinson,98,46,49,52,67,71,75,52,75,127
+SoCal Winter Classic,2024-12-14,Open Men's 61kg,Kyo Adachi,60.4,-58,-58,58,68,69,-73,58,69,127
+SoCal Winter Classic,2024-12-14,Open Women's 64kg,Ashley Alegria,60.9,53,-55,-55,65,68,71,53,71,124
+SoCal Winter Classic,2024-12-14,Open Women's 81kg,Elise Bach,79.81,50,52,-54,65,-68,68,52,68,120
+SoCal Winter Classic,2024-12-14,Women's Masters (35-39) 71kg,Jessica Lohse,66.46,44,48,-51,69,72,-76,48,72,120
+SoCal Winter Classic,2024-12-14,Open Women's 76kg,Karen Sarinana,73.89,47,50,-54,65,69,-72,50,69,119
+SoCal Winter Classic,2024-12-14,Open Women's 71kg,Connie Lam,68.15,-53,53,55,64,-67,-68,55,64,119
+SoCal Winter Classic,2024-12-14,Women's Masters (40-44) 71kg,Linda  Macias ,71,47,48,49,62,63,65,49,65,114
+SoCal Winter Classic,2024-12-14,Open Women's 55kg,Alice Hua,54.16,-47,47,-50,58,60,64,47,64,111
+SoCal Winter Classic,2024-12-14,Open Women's 87kg,ILDA Gonzalez,85.03,42,46,48,59,63,-66,48,63,111
+SoCal Winter Classic,2024-12-14,Women's Masters (40-44) 87kg,Mayra Berg,82.59,43,44,46,59,60,61,46,61,107
+SoCal Winter Classic,2024-12-14,Women's 16-17 Age Group 76kg,Adeleyna  Navarro,74.95,41,43,-46,56,60,63,43,63,106
+SoCal Winter Classic,2024-12-14,Open Women's +87kg,Carrissa McCafferty,94,-47,47,-48,57,58,-59,47,58,105
+SoCal Winter Classic,2024-12-14,Junior Women's 76kg,Jaylee Casiano,72,40,-43,43,51,55,58,43,58,101
+SoCal Winter Classic,2024-12-14,Open Women's 64kg,Elizabeth Johnson,64,-40,41,44,47,49,-51,44,49,93
+SoCal Winter Classic,2024-12-14,Women's Masters (50-54) 64kg,Evelyn Knight,60,37,39,41,45,48,50,41,50,91
+SoCal Winter Classic,2024-12-14,Open Women's 59kg,Yemima Wiridya Aji,58.53,36,39,-42,46,50,-52,39,50,89
+SoCal Winter Classic,2024-12-14,Women's Masters (45-49) 64kg,Josie Chavez,61,34,-38,39,45,49,-51,39,49,88
+SoCal Winter Classic,2024-12-14,Women's Masters (40-44) 55kg,Samantha  Mosher,54.63,35,-37,-37,45,-48,48,35,48,83
+SoCal Winter Classic,2024-12-14,Women's Masters (35-39) 71kg,Alexandria Anderson,66.13,30,31,32,45,49,50,32,50,82
+SoCal Winter Classic,2024-12-14,Women's 14-15 Age Group +76kg,Jaylie Leslie-Mcilvain,85,30,33,35,40,43,45,35,45,80
+SoCal Winter Classic,2024-12-14,Women's 16-17 Age Group 55kg,Elsie Williams,49.99,-25,25,26,31,32,34,26,34,60
+SoCal Winter Classic,2024-12-14,Men's 13 Under Age Group 32kg,Evin Nathan  Rager,31.33,20,22,23,26,28,30,23,30,53
+SoCal Winter Classic,2024-12-14,Women's 13 Under Age Group 45kg,Kira Reynolds,45,19,22,-23,-26,26,-30,22,26,48
+SoCal Winter Classic,2024-12-14,Women's Masters (45-49) 64kg,Brandi Fallica,62.69,-47,-47,-47,58,61,63,0,63,0
+SoCal Winter Classic,2024-12-14,Open Men's +109kg,Christopher Patterson,118.95,111,-116,-117,-135,-138,-140,111,0,0
+SoCal Winter Classic,2024-12-14,Open Women's +87kg,Raquel Celestino,91.02,64,-67,67,-80,-80,-80,67,0,0

--- a/event_data/US/6675.csv
+++ b/event_data/US/6675.csv
@@ -1,0 +1,108 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Hassle Free Winter Breakers,2024-12-15,Open Men's 96kg,Matthew Krause,95.1,125,130,135,160,170,175,135,175,310
+Hassle Free Winter Breakers,2024-12-15,Open Men's 109kg,Caleb Johnson,103.9,120,125,130,146,151,157,130,157,287
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Jeffy Li,83.1,-110,-111,111,130,140,148,111,148,259
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Sergiy Turchyn,88.05,102,-107,107,135,140,145,107,145,252
+Hassle Free Winter Breakers,2024-12-15,Open Men's 73kg,Sean Guterres,68.6,100,105,110,130,136,141,110,141,251
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Jedric Reyes,82.9,102,-107,110,130,135,140,110,140,250
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Christopher Robertson,87,107,-110,-110,125,129,132,107,132,239
+Hassle Free Winter Breakers,2024-12-15,Open Men's 73kg,James Woodley,68.5,-101,101,104,125,129,131,104,131,235
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Marek Sabata,88.04,100,104,-108,114,119,123,104,123,227
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Alphonse Ortega,83.6,-97,97,100,120,124,127,100,127,227
+Hassle Free Winter Breakers,2024-12-15,Open Men's 102kg,Dom Gomez,99.9,95,100,105,115,120,-125,105,120,225
+Hassle Free Winter Breakers,2024-12-15,Open Men's 102kg,Josh McClendon,102,94,97,100,122,-125,-125,100,122,222
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Kevin Woo,78.7,90,95,-100,112,117,122,95,122,217
+Hassle Free Winter Breakers,2024-12-15,Junior Men's 67kg,Casey Crothers,66.6,85,90,-95,115,120,125,90,125,215
+Hassle Free Winter Breakers,2024-12-15,Open Men's 67kg,Razmig Shahvekilian,67,87,90,93,115,118,-118,93,118,211
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (40-44) 89kg,Blake West,85,90,-95,-95,110,-115,116,90,116,206
+Hassle Free Winter Breakers,2024-12-15,Open Men's 96kg,Brendan Quock,90,-90,90,-92,108,112,116,90,116,206
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (35-39) 81kg,Kenton Chung,77.9,90,-95,-95,110,114,-118,90,114,204
+Hassle Free Winter Breakers,2024-12-15,Open Men's +109kg,braxton mason,112.4,86,-89,90,110,114,-120,90,114,204
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (35-39) 89kg,Kyle Willson,86.7,88,-93,93,110,-114,-114,93,110,203
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (40-44) 96kg,Marciano Pimentel,91.9,82,85,-89,-113,113,117,85,117,202
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Yishay Wasserstrum,79.5,80,84,87,110,115,-118,87,115,202
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Gary Lim,86.4,80,85,89,105,110,-115,89,110,199
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (40-44) 89kg,SANTANA SAYAVONGSA,84.1,75,80,85,100,105,110,85,110,195
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (40-44) 67kg,Kenneth Mao,66.9,87,-90,90,100,105,0,90,105,195
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (35-39) 81kg,Michael Redona,80,80,-83,84,106,111,-116,84,111,195
+Hassle Free Winter Breakers,2024-12-15,Men's 14-15 Age Group +89kg,Elliot Leet,95.5,75,78,81,105,110,-115,81,110,191
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (35-39) 67kg,Andrew Ramos,66.8,70,73,76,103,108,110,76,110,186
+Hassle Free Winter Breakers,2024-12-15,Open Men's +109kg,Chris Michael  Velasquez ,115.5,70,-80,-85,105,110,115,70,115,185
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Ken Liu,73.5,75,-79,81,90,98,103,81,103,184
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Brandon Beane,74.9,74,77,-80,100,-105,105,77,105,182
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (35-39) 89kg,Edrick Harvey Roxas,87.5,77,82,-90,95,100,-105,82,100,182
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Viet Vo,79.6,70,-74,76,93,97,100,76,100,176
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (40-44) 96kg,Geoffrey Price,89.1,75,78,-80,95,-98,-98,78,95,173
+Hassle Free Winter Breakers,2024-12-15,Open Men's 67kg,Ethan Fong,66.4,-72,72,77,-90,94,-97,77,94,171
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Damien Hernandez,73.1,78,-81,-81,89,91,93,78,93,171
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Billy McKinzey,80.1,68,71,74,90,93,96,74,96,170
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Joshua Limtiaco,87.5,65,-70,72,92,97,-100,72,97,169
+Hassle Free Winter Breakers,2024-12-15,Men's 16-17 Age Group 61kg,Jaren Jae Delos Reyes,60.5,72,-76,76,92,-97,-99,76,92,168
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Hunter Wolfe,87.4,70,73,-75,86,90,94,73,94,167
+Hassle Free Winter Breakers,2024-12-15,Women's 16-17 Age Group 55kg,Jade Morales,50.7,65,67,69,90,93,96,69,96,165
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (40-44) 89kg,Christopher Duerrmeier,88.8,-75,-75,75,87,90,-94,75,90,165
+Hassle Free Winter Breakers,2024-12-15,Junior Men's 81kg,Eli Wankel,79.5,65,68,73,-90,90,92,73,92,165
+Hassle Free Winter Breakers,2024-12-15,Open Women's +87kg,Emma Seyer,91,70,73,-76,83,87,90,73,90,163
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (55-59) 89kg,Michael Cicciarelli,88.4,58,61,64,88,92,96,64,96,160
+Hassle Free Winter Breakers,2024-12-15,Open Men's 61kg,Nate Peo,60.6,-66,66,-69,88,91,94,66,94,160
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,Jonathan Weiss,73.7,61,63,67,80,84,90,67,90,157
+Hassle Free Winter Breakers,2024-12-15,Open Men's 67kg,Osvaldo Garcia,64.8,63,66,68,-83,83,85,68,85,153
+Hassle Free Winter Breakers,2024-12-15,Junior Women's +87kg,Breanna Zide,90.2,-63,63,66,-83,83,86,66,86,152
+Hassle Free Winter Breakers,2024-12-15,Open Men's 81kg,ERICK RANGEL,76.4,-70,70,-75,75,78,81,70,81,151
+Hassle Free Winter Breakers,2024-12-15,Junior Women's +87kg,Kira Barad,94,60,-63,63,80,83,-87,63,83,146
+Hassle Free Winter Breakers,2024-12-15,Women's 16-17 Age Group 71kg,Zoe Rangel,65.6,-64,64,67,-78,78,-80,67,78,145
+Hassle Free Winter Breakers,2024-12-15,Open Men's 89kg,Aaron Arguelles,84,55,60,65,70,75,80,65,80,145
+Hassle Free Winter Breakers,2024-12-15,Open Women's 71kg,Ryleigh Frock,71,-58,61,-64,75,80,-85,61,80,141
+Hassle Free Winter Breakers,2024-12-15,Open Women's 64kg,Yungchu Sanchez,60.6,55,59,62,70,75,78,62,78,140
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (65-69) 81kg,Kevin McPhee,80.8,55,59,62,66,69,72,62,72,134
+Hassle Free Winter Breakers,2024-12-15,Open Women's 81kg,Regine Gabis,78.1,-52,56,58,65,71,75,58,75,133
+Hassle Free Winter Breakers,2024-12-15,Open Women's +87kg,Ariana Canalez,101,47,50,52,75,78,80,52,80,132
+Hassle Free Winter Breakers,2024-12-15,Open Women's 76kg,Sophia Miller,76,55,57,59,70,-73,73,59,73,132
+Hassle Free Winter Breakers,2024-12-15,Open Women's 71kg,Leslie Liu,70.2,50,54,-57,70,73,-76,54,73,127
+Hassle Free Winter Breakers,2024-12-15,Women's Masters (45-49) 59kg,Nadia Isidoro,57.9,50,55,-58,70,-73,-73,55,70,125
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 55kg,Allison Avalos,55,53,56,58,55,65,-70,58,65,123
+Hassle Free Winter Breakers,2024-12-15,Men's Masters (35-39) 81kg,Earl Aguilera,78,48,51,54,60,65,68,54,68,122
+Hassle Free Winter Breakers,2024-12-15,Women's Masters (40-44) 64kg,Nina Chan,63.3,50,53,-55,65,68,-70,53,68,121
+Hassle Free Winter Breakers,2024-12-15,Men's 16-17 Age Group 102kg,Issaias Cruz,102,45,50,55,55,60,65,55,65,120
+Hassle Free Winter Breakers,2024-12-15,Women's Masters (35-39) 71kg,Caylyn Major,71,45,48,51,64,68,-70,51,68,119
+Hassle Free Winter Breakers,2024-12-15,Junior Men's 55kg,Richard Zheng,55,47,50,53,58,62,66,53,66,119
+Hassle Free Winter Breakers,2024-12-15,Open Women's 76kg,Sherry Chen,72.3,-49,49,52,-63,66,-69,52,66,118
+Hassle Free Winter Breakers,2024-12-15,Open Women's 64kg,Victoria Kam,59.9,48,50,-52,60,63,66,50,66,116
+Hassle Free Winter Breakers,2024-12-15,Women's Masters (35-39) 59kg,Samantha Kopenski,57.5,47,51,54,45,60,-65,54,60,114
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group +64kg,Katea  Puamau,116.6,-43,43,46,58,62,66,46,66,112
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group +73kg,Luke Ardinez,80.8,40,45,48,57,62,64,48,64,112
+Hassle Free Winter Breakers,2024-12-15,Junior Women's 55kg,Kai Moore,55,45,-47,-47,60,63,-65,45,63,108
+Hassle Free Winter Breakers,2024-12-15,Open Women's +87kg,Cheryl Keener,89.3,43,45,47,56,61,-64,47,61,108
+Hassle Free Winter Breakers,2024-12-15,Open Women's 64kg,Leah Putlek,63.7,42,44,-46,59,63,-65,44,63,107
+Hassle Free Winter Breakers,2024-12-15,Open Women's 55kg,Athena Pham,53.8,43,-46,-46,60,-63,64,43,64,107
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 73kg,Jared Afu,70.1,40,43,46,55,58,61,46,61,107
+Hassle Free Winter Breakers,2024-12-15,Open Women's 64kg,Pratima Satish,62.8,39,41,-43,56,59,-62,41,59,100
+Hassle Free Winter Breakers,2024-12-15,Open Women's 55kg,Taneisha Arora,53,40,42,-45,55,58,-60,42,58,100
+Hassle Free Winter Breakers,2024-12-15,Open Women's 59kg,Bethan Cole,57,40,42,-43,55,58,-60,42,58,100
+Hassle Free Winter Breakers,2024-12-15,Open Women's 59kg,Sandra Guterres,55.7,34,38,41,47,51,55,41,55,96
+Hassle Free Winter Breakers,2024-12-15,Open Women's 59kg,Eve Li,56.4,38,41,43,50,-53,53,43,53,96
+Hassle Free Winter Breakers,2024-12-15,Open Women's 76kg,Rosaura Sandoval,71.8,36,38,40,48,51,53,40,53,93
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group +64kg,Amaya Huipe Hernandez,72.89,-34,34,38,45,48,51,38,51,89
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 55kg,Dylan Lee,52.5,35,37,-38,48,51,-52,37,51,88
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 59kg,Kayla Doherty,58.3,32,35,37,45,48,50,37,50,87
+Hassle Free Winter Breakers,2024-12-15,Open Women's 55kg,Michelle Singshi,54.7,33,35,37,41,43,45,37,45,82
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 55kg,Evelyn Moore,51.5,30,33,35,35,40,43,35,43,78
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group +64kg,Allana Smith,67.7,30,33,36,35,-38,39,36,39,75
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group +64kg,Isabella Huipe Hernandez,68.65,27,29,-31,30,33,35,29,35,64
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 45kg,Eloise Kostal,45,22,24,26,33,35,37,26,37,63
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 55kg,Meleoni Afu,54.25,21,23,25,32,34,36,25,36,61
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group +64kg,Katelyn Susana Afu,71.9,22,24,-26,33,35,36,24,36,60
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 45kg,Eveleen Kaur,42.3,20,23,26,25,28,30,26,30,56
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 39kg,Everett Lee,37.25,17,19,20,22,24,26,20,26,46
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 32kg,Clyde Moore,31.5,15,17,19,21,23,25,19,25,44
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 32kg,liam afa,29.4,13,15,15,19,21,23,15,23,38
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 55kg,Santiago Puamau,49.5,14,15,16,18,20,22,16,22,38
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 39kg,Christopher Myers,37,11,12,13,18,20,22,13,22,35
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 49kg,Liliana Layman,45.16,12,14,15,16,18,-19,15,18,33
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 39kg,Noah Wagner,37.5,10,11,12,15,17,18,12,18,30
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 49kg,James Gargan,48,10,11,12,15,16,17,12,17,29
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 32kg,Joel Flores,27.65,9,10,11,15,17,-18,11,17,28
+Hassle Free Winter Breakers,2024-12-15,Women's 13 Under Age Group 30kg,Emilyrose Myers,25.25,10,-11,11,12,14,16,11,16,27
+Hassle Free Winter Breakers,2024-12-15,Men's 13 Under Age Group 32kg,Sebastian Flores,21.6,10,-11,11,10,12,-14,11,12,23
+Hassle Free Winter Breakers,2024-12-15,Women's Masters (35-39) 81kg,Angelica Rosales,77.7,-67,-67,-68,90,-93,93,0,93,0
+Hassle Free Winter Breakers,2024-12-15,Open Men's 73kg,Alex Gonzales,70.2,72,-76,-76,-94,-94,-98,72,0,0

--- a/event_data/US/6676.csv
+++ b/event_data/US/6676.csv
@@ -1,0 +1,8 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+East Alabama Club meet and Christmas Party,2024-12-21,Open Men's 89kg,Michael Pietkiewicz,89,110,115,-120,143,-150,150,115,150,265
+East Alabama Club meet and Christmas Party,2024-12-21,Open Men's 96kg,Joshua Cobia,91.85,85,88,91,110,115,-121,91,115,206
+East Alabama Club meet and Christmas Party,2024-12-21,Women's Masters (40-44) 81kg,Keli Holley,79.75,59,-62,-65,65,70,-75,59,70,129
+East Alabama Club meet and Christmas Party,2024-12-21,Women's 14-15 Age Group 64kg,Natalie Wilson,60.25,32,35,40,53,55,57,40,57,97
+East Alabama Club meet and Christmas Party,2024-12-21,Women's 14-15 Age Group 49kg,Penelope Devereux,47.7,36,38,-42,51,54,-56,38,54,92
+East Alabama Club meet and Christmas Party,2024-12-21,Women's Masters (40-44) 71kg,Amanda Devereux,65.75,34,36,38,42,45,47,38,47,85
+East Alabama Club meet and Christmas Party,2024-12-21,Women's 16-17 Age Group 64kg,Anna Ward,60.3,30,32,35,44,46,48,35,48,83

--- a/event_data/US/6677.csv
+++ b/event_data/US/6677.csv
@@ -1,0 +1,8 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+In House Meet,2024-12-21,Women's 16-17 Age Group +81kg,Gillian Peaden,81.5,65,70,73,86,91,93,73,93,166
+In House Meet,2024-12-21,Women's 16-17 Age Group 59kg,Jaci Renfro,56.7,62,66,70,77,-82,-82,70,77,147
+In House Meet,2024-12-21,Men's 14-15 Age Group 73kg,Camden Vaughn,71.4,54,60,-63,74,-77,77,60,77,137
+In House Meet,2024-12-21,Junior Women's 55kg,Grace Masters,54.4,43,46,50,55,60,65,50,65,115
+In House Meet,2024-12-21,Women's 14-15 Age Group 59kg,Mia Dieppa-Corbin,57,42,-45,-45,57,61,-67,42,61,103
+In House Meet,2024-12-21,Women's 16-17 Age Group 71kg,Ella Sapp,69.7,34,-37,-37,54,57,-62,34,57,91
+In House Meet,2024-12-21,Women's 16-17 Age Group 55kg,Marianne Masters,51,30,34,37,45,48,-51,37,48,85

--- a/event_data/US/6678.csv
+++ b/event_data/US/6678.csv
@@ -1,0 +1,18 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Snata's Barbell Bash,2024-12-21,Open Men's 89kg,Calvin Barcena,85.7,113,-118,-121,145,151,157,113,157,270
+Snata's Barbell Bash,2024-12-21,Men's Masters (35-39) 73kg,Derek Nguyen,71,110,115,-120,140,145,0,115,145,260
+Snata's Barbell Bash,2024-12-21,Open Men's 96kg,Kevin Nelson,93.6,103,-108,-110,133,138,141,103,141,244
+Snata's Barbell Bash,2024-12-21,Open Men's 81kg,Aaron  Cruz-Llamas,78.5,-103,-104,104,125,128,136,104,136,240
+Snata's Barbell Bash,2024-12-21,Open Men's 109kg,Alex Carravetta,109,102,-106,108,125,130,-137,108,130,238
+Snata's Barbell Bash,2024-12-21,Open Men's 102kg,Andrew Stephen,97.9,96,100,-104,130,134,137,100,137,237
+Snata's Barbell Bash,2024-12-21,Open Men's 89kg,Christian Johnson,85.5,80,84,-89,110,114,-118,84,114,198
+Snata's Barbell Bash,2024-12-21,Junior Men's 73kg,Brice Palmer,70.15,83,88,91,91,98,106,91,106,197
+Snata's Barbell Bash,2024-12-21,Open Men's 81kg,Adam Schwartz,81,70,75,80,97,102,107,80,107,187
+Snata's Barbell Bash,2024-12-21,Men's Masters (35-39) 81kg,Kevin Johnston,79.7,70,75,-81,96,101,-105,75,101,176
+Snata's Barbell Bash,2024-12-21,Junior Men's 67kg,Ashton Ridgeway,61.3,65,68,-73,75,80,88,68,88,156
+Snata's Barbell Bash,2024-12-21,Women's 16-17 Age Group 64kg,Alexandra Hibbs,62.9,55,58,60,64,67,71,60,71,131
+Snata's Barbell Bash,2024-12-21,Open Women's 64kg,Kammy Pena,60.9,55,-60,-61,65,70,73,55,73,128
+Snata's Barbell Bash,2024-12-21,Open Women's 71kg,Brittany Turcott,70.1,51,54,-57,71,74,-77,54,74,128
+Snata's Barbell Bash,2024-12-21,Women's 13 Under Age Group +64kg,Thea Sarhan,91.45,-40,40,43,50,-53,53,43,53,96
+Snata's Barbell Bash,2024-12-21,Women's 16-17 Age Group 71kg,Natalia Pignatello,65.65,36,-38,38,49,-53,-53,38,49,87
+Snata's Barbell Bash,2024-12-21,Men's 16-17 Age Group 73kg,Jonathan Zinger,69.85,85,-90,-92,-102,-106,-106,85,0,0

--- a/event_data/US/6679.csv
+++ b/event_data/US/6679.csv
@@ -1,0 +1,27 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Men's 102kg,Jacob LaCoste,100.1,120,127,134,158,167,177,134,177,311
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Men's 89kg,Rhashan Brazelton,81.75,108,0,0,133,0,135,108,135,243
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 14-15 Age Group 89kg,Baron Baker,84,95,100,105,130,135,0,105,135,240
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Men's 96kg,Abram Davis ,95.75,80,85,90,115,0,0,90,115,205
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 13 Under Age Group 67kg,Liam Bujanda,64.8,78,80,83,95,100,0,83,100,183
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Women's 71kg,Shelby Krassilowsky,71,80,83,0,92,95,98,83,98,181
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 16-17 Age Group 55kg,Nathan Martin,54.9,68,0,0,90,95,0,68,95,163
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 14-15 Age Group 73kg,Caden Brownell,69.8,45,50,55,80,85,0,55,85,140
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's Masters (60-64) +109kg,Kevin Kreamer,111.3,55,60,0,70,78,0,60,78,138
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Women's +87kg,Madisyn Hudson,116.1,0,58,60,73,0,0,60,73,133
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Junior Women's 71kg,Shelby Miller,69.7,0,53,56,75,77,0,56,77,133
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 13 Under Age Group 61kg,Elijah Holmes,55.55,50,53,0,65,70,75,53,75,128
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's Masters (45-49) 87kg,Amy Glockner,87,45,49,52,63,68,72,52,72,124
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Women's 71kg,Kelli Bethea,67.7,45,50,0,60,0,65,50,65,115
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's Masters (35-39) 59kg,Laura Rainier,57.8,0,43,46,57,59,63,46,63,109
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Open Women's 55kg,Jaiden Avila,54.8,45,47,0,57,60,0,47,60,107
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's Masters (45-49) 59kg,Dawn Sharp,57.9,40,0,42,53,56,60,42,60,102
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 13 Under Age Group 49kg,Cameron Comeaux,46.6,35,38,0,53,55,58,38,58,96
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's Masters (40-44) 64kg,Felicia  Flake ,61.7,30,33,36,38,42,45,36,45,81
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's 13 Under Age Group 45kg,Aurelia Bujanda,41.1,32,34,35,0,45,0,35,45,80
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's 13 Under Age Group 49kg,Emily Terito,48.2,32,34,35,0,0,45,35,45,80
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 13 Under Age Group 49kg,Mack Sharp,44.8,22,0,25,34,36,38,25,38,63
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Men's 13 Under Age Group 32kg,Nixon  Catalano,27.5,19,22,25,28,31,34,25,34,59
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Women's 13 Under Age Group 30kg,Emma Martin,29.6,17,19,22,25,26,27,22,27,49
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Junior Men's 102kg,Noah Gawarecki,99.1,95,100,105,0,0,0,105,0,0
+73rd Annual Gayle Hatch Christmas Meet,2024-12-14,Junior Men's 96kg,Javan Patton,96,100,105,0,0,0,0,105,0,0

--- a/event_data/US/6680.csv
+++ b/event_data/US/6680.csv
@@ -1,0 +1,69 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (40-44) 109kg,Jared Coon,108.65,125,130,-135,155,165,170,130,170,300
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (35-39) 96kg,Peter Gooding,96,125,130,-133,155,-160,-162,130,155,285
+2024 Westerly Barbell Open,2024-12-22,Open Men's 109kg,Christopher Keegan,107.95,115,120,125,140,145,150,125,150,275
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Nicholas Connell,88.4,104,110,115,146,149,153,115,153,268
+2024 Westerly Barbell Open,2024-12-22,Open Men's 102kg,Ben Ruskin,101.05,115,-119,-120,145,150,-154,115,150,265
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Isaiah Kelly,87.2,-115,115,-123,147,-152,-154,115,147,262
+2024 Westerly Barbell Open,2024-12-22,Junior Men's 81kg,Brayden Irving,79.9,104,108,112,140,145,-150,112,145,257
+2024 Westerly Barbell Open,2024-12-22,Junior Men's 109kg,Brian Liu,106.95,107,112,-115,132,-137,-137,112,132,244
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (35-39) 109kg,Eric Brandom,104.35,102,106,110,120,125,130,110,130,240
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Jacob Wynn,87.5,95,100,103,128,132,135,103,135,238
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Anthony Yasan,88.05,100,105,-110,120,125,-130,105,125,230
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Jeffrey Krishak,87.7,92,96,100,114,118,-122,100,118,218
+2024 Westerly Barbell Open,2024-12-22,Open Men's 81kg,Lucas Bastin,79.65,84,88,92,113,117,122,92,122,214
+2024 Westerly Barbell Open,2024-12-22,Open Men's 109kg,Georgios Vassilakis,107.95,85,90,93,110,115,120,93,120,213
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (35-39) 81kg,Corey Fenton,78.95,-80,85,91,-108,112,116,91,116,207
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (40-44) 89kg,Geoffrey Sullivan,88.95,82,-86,-91,-115,115,119,82,119,201
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (35-39) 109kg,Adam Kusser,106.35,80,84,88,100,105,110,88,110,198
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (45-49) 81kg,Steven Brough,74.95,-80,80,84,100,106,110,84,110,194
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (40-44) 73kg,Edwin Johnson,70.65,78,83,85,-98,98,103,85,103,188
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Joe Ciarla,83.75,70,75,78,100,105,110,78,110,188
+2024 Westerly Barbell Open,2024-12-22,Junior Men's 81kg,Evan Vassilakis,76.3,-78,-80,80,100,103,106,80,106,186
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Owen Doyle,84.95,72,76,80,102,-106,106,80,106,186
+2024 Westerly Barbell Open,2024-12-22,Open Men's 96kg,Nick  Bloom,95.25,70,75,-80,100,105,108,75,108,183
+2024 Westerly Barbell Open,2024-12-22,Open Men's +109kg,Justin Chauvin,110.85,-71,71,76,99,103,107,76,107,183
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (35-39) +109kg,Jared Feist,113.35,77,80,82,90,95,100,82,100,182
+2024 Westerly Barbell Open,2024-12-22,Open Men's 89kg,Bradford  Law,83.8,60,65,70,90,95,100,70,100,170
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (45-49) 102kg,Mark Sieczkowski,99,68,-71,-72,86,90,95,68,95,163
+2024 Westerly Barbell Open,2024-12-22,Open Women's 81kg,Amanda Harmon,78.9,68,71,74,88,-91,0,74,88,162
+2024 Westerly Barbell Open,2024-12-22,Men's 16-17 Age Group 81kg,Liam Cincotta,74.75,70,73,76,80,-84,85,76,85,161
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (35-39) 76kg,Rachel Morse,74.15,60,63,66,82,85,-88,66,85,151
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (45-49) +109kg,Josh Frank,115.55,65,-68,68,78,81,-84,68,81,149
+2024 Westerly Barbell Open,2024-12-22,Open Women's 81kg,Ayana Acevedo,81,62,65,68,76,80,-84,68,80,148
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (50-54) 96kg,eric paradis,95.25,52,-54,-54,72,74,76,52,76,128
+2024 Westerly Barbell Open,2024-12-22,Open Women's 64kg,Sara Ernst,61.65,52,-55,-58,-72,72,75,52,75,127
+2024 Westerly Barbell Open,2024-12-22,Open Women's 59kg,Kristina Yu,58.15,-53,54,-57,67,71,-74,54,71,125
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (45-49) 71kg,Jennifer Riley,70.8,55,-57,57,67,-70,-70,57,67,124
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (35-39) 59kg,Erin Blette,59,-50,-51,51,-71,-71,71,51,71,122
+2024 Westerly Barbell Open,2024-12-22,Women's 16-17 Age Group 81kg,Lily Dickinson,79.5,54,-56,-57,65,68,-70,54,68,122
+2024 Westerly Barbell Open,2024-12-22,Open Women's 87kg,Jessica Arabi,86.1,48,51,54,60,64,67,54,67,121
+2024 Westerly Barbell Open,2024-12-22,Men's Masters (60-64) 67kg,Thomas Farina,66.4,-47,47,49,70,-72,72,49,72,121
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (35-39) 55kg,Danielle Funaro,53.1,50,-53,-54,60,65,70,50,70,120
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (40-44) 71kg,Emily Hausman,69.55,-52,-52,52,64,67,-70,52,67,119
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (35-39) +87kg,Sasha Sarmento,98.5,47,-50,-51,60,65,68,47,68,115
+2024 Westerly Barbell Open,2024-12-22,Open Women's 59kg,Jordana Brinckman,59,42,45,48,-59,59,63,48,63,111
+2024 Westerly Barbell Open,2024-12-22,Open Women's 76kg,Sara Miller,74.5,-47,48,51,54,57,60,51,60,111
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (35-39) 64kg,Maryann Teichman,63.25,44,46,48,56,59,62,48,62,110
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (50-54) 64kg,Jennifer Schaefer,61.9,-45,-45,45,54,56,-59,45,56,101
+2024 Westerly Barbell Open,2024-12-22,Junior Women's 59kg,Caroline Kent,57.55,38,40,42,48,51,54,42,54,96
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (45-49) 71kg,Tracey Norman,68.35,34,37,40,-50,50,53,40,53,93
+2024 Westerly Barbell Open,2024-12-22,Women's 14-15 Age Group 55kg,Anna Kent,54.4,38,40,42,48,51,-54,42,51,93
+2024 Westerly Barbell Open,2024-12-22,Open Women's 76kg,Sophia Rabb,74.2,36,38,40,49,52,-54,40,52,92
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (40-44) 76kg,Christine Bastien,75.85,37,39,-41,46,47,48,39,48,87
+2024 Westerly Barbell Open,2024-12-22,Open Women's +87kg,Emily Louras,126.5,30,32,34,45,48,51,34,51,85
+2024 Westerly Barbell Open,2024-12-22,Women's 14-15 Age Group 76kg,Grace Parenti,73,30,32,34,45,48,51,34,51,85
+2024 Westerly Barbell Open,2024-12-22,Men's 13 Under Age Group 55kg,Anthony  Samuel,52.95,34,36,38,43,45,47,38,47,85
+2024 Westerly Barbell Open,2024-12-22,Men's 14-15 Age Group 55kg,Nathaniel Brennick,51.25,32,34,36,44,47,-50,36,47,83
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (65-69) 71kg,Dolores Smith,66.45,30,33,35,45,-47,47,35,47,82
+2024 Westerly Barbell Open,2024-12-22,Women's 13 Under Age Group +64kg,Taylor Karabetsos,80,33,35,-38,43,-45,45,35,45,80
+2024 Westerly Barbell Open,2024-12-22,Junior Women's 76kg,Eva Hershey,73.75,27,29,31,35,-38,38,31,38,69
+2024 Westerly Barbell Open,2024-12-22,Open Women's 59kg,Anneke Velthuizen,58.25,-27,27,-30,37,-40,-43,27,37,64
+2024 Westerly Barbell Open,2024-12-22,Women's 13 Under Age Group 55kg,Arya Vural,54.85,22,24,26,31,33,35,26,35,61
+2024 Westerly Barbell Open,2024-12-22,Women's 16-17 Age Group 59kg,Caroline Brennick,59,20,22,24,33,35,37,24,37,61
+2024 Westerly Barbell Open,2024-12-22,Women's 16-17 Age Group 55kg,Kaitlyn Garron,54.75,24,25,26,30,32,34,26,34,60
+2024 Westerly Barbell Open,2024-12-22,Women's 14-15 Age Group 59kg,Siena Mazza,57.5,22,24,26,27,29,-31,26,29,55
+2024 Westerly Barbell Open,2024-12-22,Men's 13 Under Age Group 36kg,Ravi Schackner,33.25,17,18,19,22,25,-26,19,25,44
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (40-44) 71kg,Jessica Cummings,66.65,-70,-72,-72,0,0,0,0,0,0
+2024 Westerly Barbell Open,2024-12-22,Women's Masters (45-49) 64kg,Sarah Barlow,62.7,48,-50,-50,-67,-67,-67,48,0,0
+2024 Westerly Barbell Open,2024-12-22,Women's 13 Under Age Group 49kg,Ramona Frank,45.75,-20,-20,-20,23,25,-27,0,25,0

--- a/event_data/US/6681.csv
+++ b/event_data/US/6681.csv
@@ -1,0 +1,34 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Liftmas,2024-12-21,Open Men's 89kg,Vinnie Hoffman,82.6,115,118,-121,148,152,155,118,155,273
+Liftmas,2024-12-21,Open Men's +109kg,Devin Cloud,118.21,95,100,105,150,155,160,105,160,265
+Liftmas,2024-12-21,Open Men's 102kg,Isaac Piper,97.75,115,120,-125,130,-135,-136,120,130,250
+Liftmas,2024-12-21,Men's Masters (40-44) 102kg,Oliver Buccicone,100.9,105,110,-115,-135,136,-140,110,136,246
+Liftmas,2024-12-21,Open Men's 109kg,Joseph McNulty,103.6,102,106,-110,128,132,-140,106,132,238
+Liftmas,2024-12-21,Open Men's 73kg,Soren Bullock,71.75,94,-99,-102,115,-120,122,94,122,216
+Liftmas,2024-12-21,Open Men's 89kg,Chad Workman,88.95,-88,88,92,115,118,-121,92,118,210
+Liftmas,2024-12-21,Men's Masters (45-49) +109kg,Jonathan Schultz,124.7,83,86,89,112,116,-120,89,116,205
+Liftmas,2024-12-21,Junior Women's 76kg,Catessa Guadagnoli,75.9,72,75,77,95,101,-103,77,101,178
+Liftmas,2024-12-21,Open Women's +87kg,Emmalee Harding,101.65,70,73,-76,-92,92,95,73,95,168
+Liftmas,2024-12-21,Open Men's 61kg,Joe Dang,55.8,65,68,70,85,88,90,70,90,160
+Liftmas,2024-12-21,Open Women's 71kg,Leah  Vertullo,70.35,70,73,75,82,85,-88,75,85,160
+Liftmas,2024-12-21,Open Women's 76kg,Madison Lapp,73.9,59,62,65,86,91,94,65,94,159
+Liftmas,2024-12-21,Open Women's +87kg,Devin Carr,111,60,65,70,70,75,80,70,80,150
+Liftmas,2024-12-21,Women's Masters (35-39) 71kg,Minna Ranjeva,68.8,-60,-60,60,75,-78,-78,60,75,135
+Liftmas,2024-12-21,Women's 14-15 Age Group 59kg,Sadie Bischoff,57.1,-50,50,53,63,66,-68,53,66,119
+Liftmas,2024-12-21,Men's Masters (60-64) 81kg,Anton Plakseychuk,78.67,52,-55,-55,62,64,66,52,66,118
+Liftmas,2024-12-21,Men's 14-15 Age Group 89kg,Blake Dobbs,88.6,48,52,-55,57,60,63,52,63,115
+Liftmas,2024-12-21,Open Women's 55kg,ANALY PINEDA,54.7,45,48,-50,60,65,-70,48,65,113
+Liftmas,2024-12-21,Women's Masters (45-49) 71kg,Elizabeth Hoffman,67.95,42,45,-47,57,60,63,45,63,108
+Liftmas,2024-12-21,Open Women's 64kg,Korinne Piper,62.8,40,43,-46,55,59,-63,43,59,102
+Liftmas,2024-12-21,Women's Masters (40-44) +87kg,Christina Collins,88.75,40,44,48,48,52,-57,48,52,100
+Liftmas,2024-12-21,Women's Masters (35-39) 81kg,Kehla  Norris ,77.7,35,38,41,51,54,-57,41,54,95
+Liftmas,2024-12-21,Open Women's +87kg,Rachel Webber,107,35,37,40,45,48,52,40,52,92
+Liftmas,2024-12-21,Women's Masters (35-39) 87kg,Tiffany Martincic,82.85,35,38,0,48,51,54,38,54,92
+Liftmas,2024-12-21,Women's Masters (45-49) +87kg,Caroline Brindo,92.8,35,37,39,46,50,-53,39,50,89
+Liftmas,2024-12-21,Open Women's +87kg,Alyssa Burgmaster,97.6,32,34,37,45,48,51,37,51,88
+Liftmas,2024-12-21,Women's Masters (40-44) +87kg,Colleen Hruska,92.8,-35,35,37,40,43,-46,37,43,80
+Liftmas,2024-12-21,Women's Masters (40-44) 55kg,Kristin Burton,50.9,26,29,32,40,43,45,32,45,77
+Liftmas,2024-12-21,Men's 13 Under Age Group 44kg,Rory Magaro,39.15,14,15,16,16,18,19,16,19,35
+Liftmas,2024-12-21,Women's 13 Under Age Group 36kg,Kaitlyn Reynolds,36,12,13,15,14,15,16,15,16,31
+Liftmas,2024-12-21,Women's 13 Under Age Group 36kg,Ryleigh Reynolds,34.65,12,13,15,14,15,16,15,16,31
+Liftmas,2024-12-21,Women's 13 Under Age Group 30kg,Makenna Reynolds,24.25,5,6,7,5,6,7,7,7,14

--- a/event_data/US/6682.csv
+++ b/event_data/US/6682.csv
@@ -1,0 +1,21 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Polar Express - Train Through Meet,2024-12-21,Men's Masters (35-39) 89kg,Erik Davidson,83.6,80,84,-86,108,111,-115,84,111,195
+Polar Express - Train Through Meet,2024-12-21,Open Men's 81kg,Jeremiah Gorman,80.75,83,88,-93,98,-103,-103,88,98,186
+Polar Express - Train Through Meet,2024-12-21,Open Men's 96kg,Seth Bixler,91.55,77,-80,80,97,100,102,80,102,182
+Polar Express - Train Through Meet,2024-12-21,Open Men's +109kg,JJ Harry,124.55,75,-80,-80,85,90,100,75,100,175
+Polar Express - Train Through Meet,2024-12-21,Open Men's 89kg,Christian Lancaster,85.1,68,-72,72,87,90,94,72,94,166
+Polar Express - Train Through Meet,2024-12-21,Men's Masters (45-49) 81kg,Michael Fontanini,80.95,63,66,70,85,90,-95,70,90,160
+Polar Express - Train Through Meet,2024-12-21,Open Women's 76kg,Jessica Ferrari,73.8,67,70,-73,84,87,-90,70,87,157
+Polar Express - Train Through Meet,2024-12-21,Open Women's +87kg,Erika Evans,95,-61,61,-64,80,84,88,61,88,149
+Polar Express - Train Through Meet,2024-12-21,Men's Masters (50-54) 81kg,Eser Unlu,75.25,54,57,60,65,69,74,60,74,134
+Polar Express - Train Through Meet,2024-12-21,Women's Masters (40-44) 71kg,Jessica Castro,69.85,50,54,58,70,75,-80,58,75,133
+Polar Express - Train Through Meet,2024-12-21,Women's Masters (40-44) 59kg,Teresa Garza,58.9,54,-58,58,-68,68,-71,58,68,126
+Polar Express - Train Through Meet,2024-12-21,Open Women's +87kg,Audrey Reinert,95.6,45,48,51,65,-70,70,51,70,121
+Polar Express - Train Through Meet,2024-12-21,Women's Masters (35-39) 81kg,Mary Bays,80.95,43,46,50,53,56,-60,50,56,106
+Polar Express - Train Through Meet,2024-12-21,Women's Masters (55-59) 71kg,Kristin Johnson,68.15,42,45,47,54,57,59,47,59,106
+Polar Express - Train Through Meet,2024-12-21,Open Women's 64kg,Elizabeth Grubbs,61,-36,36,39,50,54,57,39,57,96
+Polar Express - Train Through Meet,2024-12-21,Open Men's 89kg,Jiting Shen,81.15,32,34,36,40,43,46,36,46,82
+Polar Express - Train Through Meet,2024-12-21,Open Women's 71kg,Helen Benton,71,35,-36,-37,-43,45,47,35,47,82
+Polar Express - Train Through Meet,2024-12-21,Women's 14-15 Age Group 64kg,Sasha McClain,60,23,26,30,35,38,42,30,42,72
+Polar Express - Train Through Meet,2024-12-21,Open Women's 64kg,Siyu Liu,62.15,25,26,28,35,38,40,28,40,68
+Polar Express - Train Through Meet,2024-12-21,Women's 14-15 Age Group 49kg,Irelyn McClain,47.25,15,17,20,23,25,28,20,28,48

--- a/event_data/US/6683.csv
+++ b/event_data/US/6683.csv
@@ -1,0 +1,11 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Friday Night Lights & Bar Resolutions,2024-12-28,Men's Masters (35-39) 89kg,Chad Seltzer,82.5,-95,-97,97,125,-128,128,97,128,225
+Friday Night Lights & Bar Resolutions,2024-12-27,Open Men's +109kg,Henry Manukyan,182.8,100,-107,-108,-120,123,0,100,123,223
+Friday Night Lights & Bar Resolutions,2024-12-27,Men's Masters (35-39) +109kg,Jeffrey Luzod,170.5,80,-85,87,112,-117,120,87,120,207
+Friday Night Lights & Bar Resolutions,2024-12-27,Open Men's 89kg,James  Zoucha III,85.15,92,-96,-98,-110,113,-115,92,113,205
+Friday Night Lights & Bar Resolutions,2024-12-27,Open Men's 89kg,Mark Maldonado,87.8,64,-67,-67,64,68,75,64,75,139
+Friday Night Lights & Bar Resolutions,2024-12-27,Open Women's 87kg,SOPHIA McClendon,83,45,48,55,60,67,75,55,75,130
+Friday Night Lights & Bar Resolutions,2024-12-27,Women's Masters (40-44) 64kg,Cristina Garcia-Versteegh,63.8,39,41,43,-59,60,63,43,63,106
+Friday Night Lights & Bar Resolutions,2024-12-28,Women's Masters (55-59) 64kg,Susannah Perez,61.05,45,48,-51,54,57,-60,48,57,105
+Friday Night Lights & Bar Resolutions,2024-12-28,Women's Masters (55-59) 76kg,Vicki Myers,71.7,36,38,40,47,-50,-50,40,47,87
+Friday Night Lights & Bar Resolutions,2024-12-28,Women's Masters (45-49) 64kg,Leandra Smith,62.45,36,-39,-39,46,49,-51,36,49,85

--- a/event_data/US/6684.csv
+++ b/event_data/US/6684.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Texas-Oklahoma WSO Championships 4,2024-08-30,Open Women's 71kg,Helen Benton,71,33,-36,36,40,43,45,36,45,81

--- a/event_data/US/6685.csv
+++ b/event_data/US/6685.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2024 Canadian Masters Weightlifting Championships,2024-07-12,Women's Masters (40-44) 81kg,Christina Quaile,80.08,0,0,55,0,0,80,55,80,135

--- a/event_data/US/6686.csv
+++ b/event_data/US/6686.csv
@@ -1,0 +1,39 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Rockford Barbell New Years Meet,2024-12-28,Men's Masters (35-39) +109kg,Aniceto Ruiz,129.6,115,122,126,150,155,164,126,164,290
+Rockford Barbell New Years Meet,2024-12-28,Open Men's +109kg,Zachary Kunda,118.7,110,115,120,147,153,-157,120,153,273
+Rockford Barbell New Years Meet,2024-12-28,Men's Masters (35-39) 89kg,Alexander Arquilla,88.8,100,105,110,120,128,135,110,135,245
+Rockford Barbell New Years Meet,2024-12-28,Open Men's 109kg,Liam Sutton,107.6,90,100,105,115,120,130,105,130,235
+Rockford Barbell New Years Meet,2024-12-28,Open Men's 89kg,Brice Brown,83.6,90,95,100,-115,118,121,100,121,221
+Rockford Barbell New Years Meet,2024-12-28,Men's Masters (35-39) 96kg,Gregory Malnassy,93,88,92,96,123,-129,-130,96,123,219
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 76kg,Riley Stefan,75.1,80,83,-86,105,108,111,83,111,194
+Rockford Barbell New Years Meet,2024-12-28,Men's Masters (35-39) 109kg,alex paduch,102.3,75,79,84,94,-98,98,84,98,182
+Rockford Barbell New Years Meet,2024-12-28,Junior Men's 73kg,Sean Mork,72.2,70,-75,-76,90,-95,100,70,100,170
+Rockford Barbell New Years Meet,2024-12-28,Junior Women's +87kg,Josie Lawrence,96.2,66,70,74,84,88,92,74,92,166
+Rockford Barbell New Years Meet,2024-12-28,Men's Masters (50-54) 89kg,Monty Moran,82.1,70,-75,-76,-90,91,95,70,95,165
+Rockford Barbell New Years Meet,2024-12-28,Open Men's 89kg,Elazar Roco,81.5,-61,-61,61,88,91,93,61,93,154
+Rockford Barbell New Years Meet,2024-12-28,Junior Men's 73kg,Josh Wager,71.7,62,66,70,-80,83,-86,70,83,153
+Rockford Barbell New Years Meet,2024-12-28,Men's Masters (50-54) 102kg,Nick Lombardi,96.4,60,-65,-67,-90,90,-92,60,90,150
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 64kg,Anna Alvarez,63.7,63,67,-71,-79,80,-83,67,80,147
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 64kg,Anell Duran,64,55,58,61,75,78,81,61,81,142
+Rockford Barbell New Years Meet,2024-12-28,Open Men's 102kg,Luis Nieves,99.3,52,55,58,82,-85,-85,58,82,140
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (35-39) 71kg,Vanessa Matthews,66.9,57,59,61,65,68,71,61,71,132
+Rockford Barbell New Years Meet,2024-12-28,Men's 14-15 Age Group +89kg,Noah Hauser,166.5,48,53,55,65,70,75,55,75,130
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (35-39) 71kg,Nicole Nodi,64.7,50,-53,53,66,70,73,53,73,126
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 81kg,Danielle Tyler,76.5,52,55,58,59,63,67,58,67,125
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (45-49) 64kg,Nikee Pomper,62,55,-58,-58,65,68,70,55,70,125
+Rockford Barbell New Years Meet,2024-12-28,Open Men's 89kg,Michael Gonzalez,83.7,49,52,55,61,64,67,55,67,122
+Rockford Barbell New Years Meet,2024-12-28,Men's 14-15 Age Group 81kg,Alexander Sacdyphoud,80.4,40,45,50,50,58,65,50,65,115
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (45-49) 64kg,Nicole Tucker,63.7,45,48,50,58,62,-64,50,62,112
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 87kg,Stephanie Beasley,86.6,35,42,50,50,55,60,50,60,110
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (35-39) 59kg,Tiffany Klinger,58.7,40,44,50,54,56,60,50,60,110
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (35-39) 76kg,Jessica  Biga ,72.8,43,46,-48,56,59,-61,46,59,105
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 71kg,Olivia Nahorniak,69.5,42,45,49,51,54,-58,49,54,103
+Rockford Barbell New Years Meet,2024-12-28,Men's 14-15 Age Group 73kg,Andrell Singleton Jr.,69,35,40,45,45,50,55,45,55,100
+Rockford Barbell New Years Meet,2024-12-28,Open Women's 59kg,Lily Le,55.8,42,45,-47,52,55,-58,45,55,100
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (55-59) 59kg,Carmen Llop Kassinger,57.5,35,38,-41,53,55,58,38,58,96
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (35-39) 59kg,Sarah Kangas,59,36,38,41,50,54,-58,41,54,95
+Rockford Barbell New Years Meet,2024-12-28,Women's 14-15 Age Group +76kg,Aleesia Lopez,90.5,35,38,40,49,51,54,40,54,94
+Rockford Barbell New Years Meet,2024-12-28,Women's Masters (45-49) 81kg,Bridgot Gysbers,79.6,36,39,-42,-50,50,54,39,54,93
+Rockford Barbell New Years Meet,2024-12-28,Men's 13 Under Age Group +73kg,Braylen Graham,78.4,31,33,36,42,45,50,36,50,86
+Rockford Barbell New Years Meet,2024-12-28,Women's 13 Under Age Group +64kg,Kenya Pierce,127.6,30,31,33,38,40,-42,33,40,73
+Rockford Barbell New Years Meet,2024-12-28,Men's 13 Under Age Group 61kg,Asher Sacdyphoud,55.5,20,23,25,25,28,30,25,30,55

--- a/event_data/US/6687.csv
+++ b/event_data/US/6687.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Texas-Oklahoma WSO Championships 5,2024-08-29,Women's Masters (45-49) 76kg,Danielle Eberhart,73.99,38,-40,40,50,53,-55,40,53,93

--- a/event_data/US/6688.csv
+++ b/event_data/US/6688.csv
@@ -1,0 +1,19 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Bexar Lift-Mas,2024-12-21,Open Men's 96kg,Grant Pierson,95.1,128,132,-136,167,172,-175,132,172,304
+Bexar Lift-Mas,2024-12-21,Open Men's +109kg,Damon Gandy,115,102,108,114,138,144,150,114,150,264
+Bexar Lift-Mas,2024-12-21,Open Men's 89kg,Jeremiah  Munoz,87,102,105,110,130,-135,135,110,135,245
+Bexar Lift-Mas,2024-12-21,Open Men's 89kg,Jobel Bulaong,84.5,91,94,-97,119,123,-127,94,123,217
+Bexar Lift-Mas,2024-12-21,Junior Men's 89kg,Binh Dang,87,85,-95,-95,115,-120,123,85,123,208
+Bexar Lift-Mas,2024-12-21,Open Men's 96kg,Max Valenzuela,93.2,90,95,98,105,110,-115,98,110,208
+Bexar Lift-Mas,2024-12-21,Open Women's +87kg,Karla Tapia,111.3,76,78,81,94,97,-100,81,97,178
+Bexar Lift-Mas,2024-12-21,Men's Masters (40-44) 89kg,Neil Skorka,87.7,67,69,71,92,96,100,71,100,171
+Bexar Lift-Mas,2024-12-21,Open Women's +87kg,Gentry Stevenson,91.5,67,-69,-70,98,-102,102,67,102,169
+Bexar Lift-Mas,2024-12-21,Open Women's 76kg,Taylor Fetzer,75.3,67,-69,70,90,94,97,70,97,167
+Bexar Lift-Mas,2024-12-21,Open Women's 64kg,Zoe Pasetsky,62,65,67,-69,-87,87,-90,67,87,154
+Bexar Lift-Mas,2024-12-21,Open Women's 87kg,Crystal Coppersmith,84.1,55,60,65,70,75,80,65,80,145
+Bexar Lift-Mas,2024-12-21,Open Women's 87kg,Lacey Tople,84.6,54,57,60,69,72,-75,60,72,132
+Bexar Lift-Mas,2024-12-21,Open Women's 81kg,Catrina Ang,79.1,54,57,-60,-66,66,-69,57,66,123
+Bexar Lift-Mas,2024-12-21,Open Women's 64kg,Melanie Lin,64,38,40,42,55,58,-61,42,58,100
+Bexar Lift-Mas,2024-12-21,Open Women's 64kg,Brenda Savariego,64,38,40,-43,-52,52,-55,40,52,92
+Bexar Lift-Mas,2024-12-21,Junior Women's 55kg,IRINA CORONA,54.5,35,37,-39,50,52,54,37,54,91
+Bexar Lift-Mas,2024-12-21,Women's Masters (60-64) 64kg,Jami Willette-Brown,59.3,26,28,30,35,37,38,30,38,68

--- a/event_data/US/6690.csv
+++ b/event_data/US/6690.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2024 Belgium Weightlifting Championship Open,2024-11-20,Open Women's 55kg,Susie Su Husar,54.19,-62,-62,63,85,88,90,63,90,153

--- a/event_data/US/6698.csv
+++ b/event_data/US/6698.csv
@@ -1,0 +1,86 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Stone Larson,80.4,107,114,-115,-140,140,-147,114,140,254
+Prior Lake Invite,2024-12-14,Junior Men's 81kg,Caleb Grawe,78.35,90,95,100,120,125,132,100,132,232
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Joshua Delk,79,91,94,97,114,118,122,97,122,219
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group +102kg,Carter Wendorff,113.4,80,84,-87,105,110,113,84,113,197
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 96kg,Daniel Ricklick,91.7,72,77,-80,107,111,115,77,115,192
+Prior Lake Invite,2024-12-14,Junior Men's 96kg,Owen Eicher,91.6,80,-82,-83,100,103,106,80,106,186
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Ethan Anderson,74.3,80,-84,-86,100,-104,-104,80,100,180
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Henry Tyrrell,79.15,75,80,-86,100,-110,-120,80,100,180
+Prior Lake Invite,2024-12-14,Junior Men's 89kg,Dylan Holt,88.5,65,-70,73,95,100,106,73,106,179
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 89kg,Aiden Zubia,87.7,75,78,-80,-90,90,93,78,93,171
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Nathan Beyer,80.35,65,68,70,95,-100,100,70,100,170
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 67kg,Isaac Rodriguez ,65,65,67,70,93,-96,96,70,96,166
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 73kg,Christian Anderson,71.9,68,71,74,88,92,-96,74,92,166
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,John Maines,77.2,57,62,71,89,95,-102,71,95,166
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group +102kg,Peyt Grandbois,118.9,60,65,70,85,90,95,70,95,165
+Prior Lake Invite,2024-12-14,Junior Men's 67kg,Ian Bamford,66.6,68,71,-74,90,94,-97,71,94,165
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 73kg,Caleb Trueblood,69,67,72,75,85,89,-94,75,89,164
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 73kg,Noah Delk,69,66,69,71,87,90,92,71,92,163
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 89kg,Joshua Goerdt,85.3,65,68,-70,92,-95,-95,68,92,160
+Prior Lake Invite,2024-12-14,Junior Men's 67kg,Seth Knutson,65.35,70,-74,-75,82,85,89,70,89,159
+Prior Lake Invite,2024-12-14,Junior Men's 61kg,Stephen Feig,60.1,65,-70,0,-85,85,89,65,89,154
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 67kg,Logan Kraby,64,-65,65,67,-83,83,85,67,85,152
+Prior Lake Invite,2024-12-14,Junior Men's 96kg,Brayton Loftus,92.8,65,68,70,75,78,-81,70,78,148
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group +81kg,Alaina French,105.7,55,60,-65,78,80,85,60,85,145
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 67kg,Mason Muench,62.8,60,-63,63,75,79,82,63,82,145
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 73kg,Grant Paulsen,68.15,-61,-61,61,75,80,82,61,82,143
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 61kg,Romeo Rocha,57.9,58,-61,61,78,81,-85,61,81,142
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 96kg,Joe Noreen,94.6,60,-62,62,-80,80,-82,62,80,142
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 89kg,Ellis Wohlhuter,86.5,57,60,-63,-77,77,80,60,80,140
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group +89kg,Evan Hedeen,111.5,-52,52,54,80,83,86,54,86,140
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 67kg,Bryce Niedzielski,66.1,57,59,61,72,75,78,61,78,139
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Daniel Moran Nieves,77.5,57,59,-62,-77,77,80,59,80,139
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 81kg,Samuel Schulz,77.8,-60,60,-62,-77,77,79,60,79,139
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Sutton Vetter,77.6,50,53,-57,75,78,80,53,80,133
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 71kg,Lila Volovsek,67.15,56,61,-65,65,68,71,61,71,132
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 96kg,Regan Winter,93.9,50,53,56,70,73,76,56,76,132
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Noah Baker,78.4,-55,55,-57,72,75,-80,55,75,130
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Turey Velez-Miller,78.7,50,-53,54,70,75,-78,54,75,129
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 102kg,Benjamin  Herrington ,101.9,52,54,56,63,66,70,56,70,126
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 64kg,Addison Eicher,60.55,52,-54,55,68,70,-73,55,70,125
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 55kg,Oskar Jensen,53.9,-50,50,53,64,66,69,53,69,122
+Prior Lake Invite,2024-12-14,Junior Men's 73kg,Gavin Beutler,69.4,47,-52,55,62,-66,66,55,66,121
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 73kg,Mason Anderson,69.4,-50,50,-55,67,70,-72,50,70,120
+Prior Lake Invite,2024-12-14,Junior Men's 67kg,Tyler Sedlacek,65.6,55,-57,57,58,60,63,57,63,120
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 61kg,Ethan Gersky,59,48,50,52,60,64,67,52,67,119
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 81kg,Chloe Krinkie,76.9,50,52,54,60,63,-66,54,63,117
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 64kg,Hanna Ebbighausen,62.2,45,-47,49,57,60,64,49,64,113
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 89kg,Maddox Ditty,88.3,45,-47,48,60,63,-66,48,63,111
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 71kg,Elliot Ness,68.5,42,46,-50,60,64,-68,46,64,110
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 67kg,Mason Stene,65,44,46,48,57,59,61,48,61,109
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Donald Wilkinson,78.9,45,47,-50,60,62,-65,47,62,109
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 73kg,Dillon Hachfeld,71.4,48,-50,-50,60,-62,-62,48,60,108
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 61kg,Joseph Myers,59.7,43,46,-48,55,57,60,46,60,106
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 71kg,Helen Jager,67.95,45,-47,47,52,55,58,47,58,105
+Prior Lake Invite,2024-12-14,Men's 14-15 Age Group 61kg,Breck Mongeon,56,40,43,45,55,58,-61,45,58,103
+Prior Lake Invite,2024-12-14,Junior Women's 81kg,Indigo Benner,80.4,43,44,45,54,-56,56,45,56,101
+Prior Lake Invite,2024-12-14,Men's 13 Under Age Group 44kg,Simeon Anderson,41.3,43,45,-47,53,55,-57,45,55,100
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 81kg,Connor Buchanan,76.8,41,-44,-45,52,54,57,41,57,98
+Prior Lake Invite,2024-12-14,Junior Women's 55kg,Hannah Trueblood,50.9,38,40,43,50,53,-56,43,53,96
+Prior Lake Invite,2024-12-14,Men's 13 Under Age Group 55kg,Jackson  Hermanson,54.9,37,39,-41,52,54,56,39,56,95
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 61kg,Gavin Ngo,61,-36,36,38,52,54,56,38,56,94
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 96kg,Jackson Goraczkowski,95,38,40,42,43,46,49,42,49,91
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 71kg,Samantha Zerwas,64.8,35,38,-40,47,50,52,38,52,90
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 71kg,Wendy Ascencio Bravo,67,-38,38,-43,52,-56,-56,38,52,90
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 76kg,Sarah Banitt,73.7,39,41,-43,48,-50,-51,41,48,89
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 59kg,Teagan Bishop,58.1,32,34,37,43,46,50,37,50,87
+Prior Lake Invite,2024-12-14,Junior Women's 87kg,Monica Humphrey,83.1,36,-38,38,47,49,-52,38,49,87
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 59kg,Makenzie Gerhardt,57.45,34,36,38,46,48,-50,38,48,86
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 45kg,Kacie Cordova,43.75,-35,-35,35,45,-47,48,35,48,83
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group +81kg,Eliza Bondhus,87,36,39,41,37,40,42,41,42,83
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 64kg,Lauren Hawkins,61.7,27,29,32,42,45,48,32,48,80
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 76kg,Stephanie Hernandez,74.5,33,35,-37,42,-45,45,35,45,80
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 71kg,Haley Koenen,67.6,32,35,37,37,40,43,37,43,80
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 45kg,Jazlyn Benitez,43.4,33,-35,-35,43,46,-49,33,46,79
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 55kg,Penelope Roiger,53.7,32,-34,34,40,43,-45,34,43,77
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 59kg,Abigail Zeien,56.9,28,30,32,37,40,43,32,43,75
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 59kg,Charlotte Doeden,58.05,27,-29,29,40,43,46,29,46,75
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group 55kg,Emily Zeien,53.2,-29,29,31,37,41,44,31,44,75
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 59kg,Elise Hopkins,57,27,29,31,38,42,-45,31,42,73
+Prior Lake Invite,2024-12-14,Women's 16-17 Age Group +81kg,Eleanor Olson,87.5,28,30,32,35,38,-40,32,38,70
+Prior Lake Invite,2024-12-14,Women's 14-15 Age Group 55kg,Elaina Volovsek,54.05,25,27,-30,32,-33,34,27,34,61
+Prior Lake Invite,2024-12-14,Women's 13 Under Age Group 40kg,Jubilee Anderson,37.2,-20,20,22,25,27,-29,22,27,49
+Prior Lake Invite,2024-12-14,Men's 13 Under Age Group 39kg,Alekzander Benitez,39,13,14,16,14,-16,16,16,16,32
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 67kg,Elijah Hathaway,65.3,-80,-80,-80,95,-100,0,0,95,0
+Prior Lake Invite,2024-12-14,Men's 16-17 Age Group 73kg,Sawyer Haglund,67.8,-88,-88,88,-111,-111,-111,88,0,0

--- a/event_data/US/7174.csv
+++ b/event_data/US/7174.csv
@@ -1,0 +1,35 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2025 Hawaii State Weightlifting Championships,2025-12-27,Junior Men's 110kg,Hanale Kauha'aha'a,106.3,123,131,-137,157,167,-173,131,167,298
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 94kg,Elias Hamp,93.55,-127,127,-133,140,-150,150,127,150,277
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 94kg,Will Said,93.85,-120,120,-125,155,-160,-160,120,155,275
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 79kg,Dallas Tada,77,110,113,-116,-143,151,159,113,159,272
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's Masters (35-39) 79kg,Andrew Tipon,79,-115,117,120,143,-152,-152,120,143,263
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 79kg,Ryan Padron,78,101,-106,107,145,150,-155,107,150,257
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's Masters (40-44) 110kg,Nathan Oki,102.9,95,100,103,110,120,125,103,125,228
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 88kg,John Martin,79.3,-96,96,-105,-127,-127,127,96,127,223
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's Masters (35-39) 71kg,Johnny Cezar,71,-95,95,0,115,120,-125,95,120,215
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 16-17 Age Group 88kg,Tai Ferrer,85.45,90,-93,-95,105,110,-120,90,110,200
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 94kg,Daniel Fontanilla,90.6,75,-80,82,110,-115,-115,82,110,192
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 16-17 Age Group 79kg,Justice Gonsalves,73.3,60,70,75,90,95,105,75,105,180
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 14-15 Age Group 79+kg,Rio Russell,85.5,60,65,70,90,95,-103,70,95,165
+2025 Hawaii State Weightlifting Championships,2025-12-27,Junior Men's 110+kg,Jon Brooks,152.6,60,65,-72,80,87,93,65,93,158
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Women's 53kg,Tiffani Lee,53,65,67,-70,-88,88,90,67,90,157
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Women's 69kg,Amelia Obra,68,58,61,63,78,81,-84,63,81,144
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's Masters (50-54) 110kg,Bertram Kikuchi,100.4,57,60,63,65,70,73,63,73,136
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 16-17 Age Group 65kg,Allen Balbas,61,45,50,-55,70,77,82,50,82,132
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 14-15 Age Group 60kg,Urijah Ragudo,58,45,50,55,70,77,-82,55,77,132
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's Masters (45-49) 69kg,Stephanie Grams,68.9,52,55,58,63,66,69,58,69,127
+2025 Hawaii State Weightlifting Championships,2025-12-27,Junior Women's 58kg,Kaylee Yagi,58,52,55,-56,65,70,72,55,72,127
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Women's 86kg,Danielle Mariano,84.2,52,-55,55,-62,62,65,55,65,120
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's Masters (45-49) 63kg,Linda Nguyen,63,40,42,-45,60,63,66,42,66,108
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 14-15 Age Group 52kg,Tyler Chang,50.6,40,-43,43,55,59,62,43,62,105
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's 16-17 Age Group 77kg,Truth Kamaunu,72.15,40,-42,42,-50,50,54,42,54,96
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Women's 58kg,Loretta Kikuchi,55.7,30,35,-38,40,45,50,35,50,85
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's Masters (50-54) 58kg,Donna Lyn Au,57,30,32,35,40,43,-46,35,43,78
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's Masters (65-69) 53kg,Valerie Matsunaga,52.28,25,27,-28,35,37,-40,27,37,64
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's Masters (60-64) 53kg,Brendalee Salgado-DeMello,53,23,24,25,33,34,35,25,35,60
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 11 Under Age Group 40kg,Elyjah Pastrana,39.4,13,16,17,20,25,30,17,30,47
+2025 Hawaii State Weightlifting Championships,2025-12-27,Men's 11 Under Age Group 32kg,Josyah Pastrana,23.7,10,12,13,15,18,20,13,20,33
+2025 Hawaii State Weightlifting Championships,2025-12-27,Women's 13 Under Age Group 63+kg,Elisabeth Moritz,76.3,-42,-43,-43,55,63,65,0,65,0
+2025 Hawaii State Weightlifting Championships,2025-12-27,Junior Men's 94kg,Brady Grams,88.5,-105,-105,-105,120,125,-130,0,125,0
+2025 Hawaii State Weightlifting Championships,2025-12-27,Open Men's 88kg,Nainoa Victor-Kailianu,86.8,102,-107,109,-127,-132,-133,109,0,0

--- a/event_data/US/7175.csv
+++ b/event_data/US/7175.csv
@@ -1,0 +1,15 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Glass City Holiday Invitational,2025-12-21,Open Men's 94kg,Michael Shoup,92.5,90,95,100,115,120,125,100,125,225
+Glass City Holiday Invitational,2025-12-21,Men's 16-17 Age Group 79kg,Caleb Sprenger,72.1,88,92,-95,105,-110,-110,92,105,197
+Glass City Holiday Invitational,2025-12-21,Men's 14-15 Age Group 65kg,Brock Bates,63.7,65,68,71,86,89,91,71,91,162
+Glass City Holiday Invitational,2025-12-21,Men's 14-15 Age Group 65kg,Grayor Opfer,61.9,65,68,70,83,87,-91,70,87,157
+Glass City Holiday Invitational,2025-12-21,Open Women's 77kg,Renee Schroeder,70.3,62,64,66,82,85,88,66,88,154
+Glass City Holiday Invitational,2025-12-21,Women's Masters (35-39) 63kg,Britta Castillo,62.5,63,66,-68,71,75,77,66,77,143
+Glass City Holiday Invitational,2025-12-21,Women's 16-17 Age Group 63kg,Teelilly Abrighach,61.7,57,-60,61,76,-80,80,61,80,141
+Glass City Holiday Invitational,2025-12-21,Women's 14-15 Age Group 63kg,Amiya Drury,61.8,61,63,-65,70,73,76,63,76,139
+Glass City Holiday Invitational,2025-12-21,Women's Masters (40-44) 63kg,Emily Downing,60.5,55,57,60,64,67,70,60,70,130
+Glass City Holiday Invitational,2025-12-21,Women's 13 Under Age Group 48kg,Hailey Sprenger,47,-46,46,-49,57,60,-62,46,60,106
+Glass City Holiday Invitational,2025-12-21,Women's 14-15 Age Group 58kg,Hazyl Castillo,57.7,48,-50,-50,58,-61,-61,48,58,106
+Glass City Holiday Invitational,2025-12-21,Women's 13 Under Age Group 63+kg,Ella Barnard,70.7,38,40,42,-55,55,-58,42,55,97
+Glass City Holiday Invitational,2025-12-21,Women's 13 Under Age Group 44kg,Kate Yetter,43.6,33,35,37,42,44,46,37,46,83
+Glass City Holiday Invitational,2025-12-21,Women's 13 Under Age Group 36kg,Quinn Drury,35.1,22,23,-24,29,31,33,23,33,56

--- a/event_data/US/7176.csv
+++ b/event_data/US/7176.csv
@@ -1,0 +1,122 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Landon Schulz,99,-110,110,-115,140,143,146,110,146,256
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,logan walkins,128.5,97,102,106,110,-119,119,106,119,225
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 88kg,Miguel Romero Colon,86.5,85,-89,92,120,126,132,92,132,224
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Elijah Hathaway,70,98,-102,102,108,111,114,102,114,216
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 88kg,Liam Andvik,84,77,81,-85,108,113,-118,81,113,194
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Andy Arntson,101.5,77,80,84,97,106,-112,84,106,190
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Ethan Vossen,70,75,80,-91,-102,102,109,80,109,189
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Daniel Ricklick,95,70,74,76,105,108,111,76,111,187
+Little Falls HS Invite,2025-12-13,Junior Men's 88kg,Daniel Dietrich,86,80,-90,-90,106,-116,-116,80,106,186
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Aiden Struck,113.5,69,73,77,96,102,108,77,108,185
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Bryce Niedzielski,77.5,-75,75,80,97,-100,101,80,101,181
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Caleb Zimmerman,143,65,70,-74,104,110,-113,70,110,180
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Elijah Bjur,125.5,78,-80,-81,99,100,102,78,102,180
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79+kg,Samuel Schulz,91.5,77,-80,80,-95,95,99,80,99,179
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94kg,Ethan Iverson,89.5,70,75,-78,100,-106,-112,75,100,175
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 60kg,Eli Vossen,59,79,84,-91,88,90,-95,84,90,174
+Little Falls HS Invite,2025-12-13,Junior Men's 88kg,Anders Clemon,87.5,70,74,-77,95,98,100,74,100,174
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Jasper Etter,111,-69,71,75,-96,96,-100,75,96,171
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94kg,Evan Flick,92.5,69,72,75,90,95,-100,75,95,170
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Nathaniel Giroux,119,69,73,-77,92,96,-108,73,96,169
+Little Falls HS Invite,2025-12-13,Junior Men's 110kg,Cole Munson,103,66,70,-80,-87,87,90,70,90,160
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Mason Gilson,77,61,-66,66,85,91,94,66,94,160
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Evan Lindenfelser,68.5,60,65,70,85,90,-95,70,90,160
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 79kg,Wyatt  Petersen ,72.5,62,65,69,78,82,87,69,87,156
+Little Falls HS Invite,2025-12-13,Junior Men's 79kg,Sutton Vetter,76.5,63,65,68,80,85,-88,68,85,153
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79+kg,Jackson Nelson,124,60,63,66,80,85,-88,66,85,151
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 71kg,Keagan Card,68.5,56,58,61,83,86,89,61,89,150
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Brock Abbott,68,57,60,63,78,82,87,63,87,150
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 79kg,Riley Maier,76.5,56,61,66,74,80,83,66,83,149
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 71kg,Jefferson Mboutchom,69.5,55,57,62,79,83,-87,62,83,145
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77+kg,Ava Roberts,82,52,57,-60,75,80,87,57,87,144
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 88kg,Caden Bigelow,86,-63,63,-65,75,-79,81,63,81,144
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Owen Goodman,95.5,54,58,63,73,77,80,63,80,143
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Mason Anderson,69.5,-58,58,61,77,80,-82,61,80,141
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 63kg,Addison Eicher,60.5,55,58,-61,70,75,80,58,80,138
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Hunter Damewood ,78,48,53,-57,79,-83,-83,53,79,132
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 88kg,Noah Baker,85,54,56,58,70,73,-76,58,73,131
+Little Falls HS Invite,2025-12-13,Junior Men's 110kg,Steven Carlson,106,52,56,60,61,66,70,60,70,130
+Little Falls HS Invite,2025-12-13,Junior Women's 86kg,Chloe Krinkie,83.5,55,57,60,67,69,70,60,70,130
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Joshua Asleson,69.5,50,54,57,66,-71,71,57,71,128
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 65kg,Breck Mongeon,63.5,45,48,51,70,73,75,51,75,126
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77+kg,Atarah Tofibam,107.5,48,51,53,66,69,72,53,72,125
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 56kg,Jake Johnson,54,50,53,-55,65,70,72,53,72,125
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Raymond Ruby,107.5,49,52,-57,68,71,-74,52,71,123
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Tyler  Robertson-Sessing ,70,51,-54,-55,-59,61,72,51,72,123
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79+kg,Daniel Johnson,91.5,43,46,50,67,70,73,50,73,123
+Little Falls HS Invite,2025-12-13,Junior Women's 86kg,Adriana Clemon,78,51,53,55,60,63,67,55,67,122
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 65kg,Grant Flaten,61,51,55,-58,67,-71,-75,55,67,122
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Samuel Mitzel,68,48,51,-53,64,67,69,51,69,120
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Monroe Judd,74,44,48,52,62,-67,68,52,68,120
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 60kg,Theodore Gindele,57.5,48,-51,51,-61,61,65,51,65,116
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 63kg,Hanna Ebbighausen,62,46,48,-51,60,63,67,48,67,115
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 60kg,Grady Vosika,57,40,43,46,60,63,67,46,67,113
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 60kg,Levi Torgerson,60,45,-48,48,58,60,62,48,62,110
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 69kg,Ellie Abbott,67,38,41,44,58,62,65,44,65,109
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77kg,Helen Jager,69.5,42,45,48,55,59,-62,48,59,107
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 53kg,Kaylee Cromwell,52,-43,-43,43,57,60,63,43,63,106
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 88kg,Austyn Offerdahl,85.5,44,48,-52,49,54,58,48,58,106
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79+kg,Max Mosser,89.5,40,43,-47,55,59,63,43,63,106
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94kg,Jaxen Gunkel,92.5,40,44,48,49,53,56,48,56,104
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 69+kg,Elena Hamre,72,38,40,42,54,58,62,42,62,104
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 71kg,Deegan Parker,65.5,39,42,45,54,57,59,45,59,104
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 65kg,Anton Surma,61,39,42,45,-54,54,58,45,58,103
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 53kg,Marin Bast,51.5,42,-46,-48,60,-64,-64,42,60,102
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Alexander Culkins,75,40,43,-45,53,56,58,43,58,101
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Weston Rosenfeldt,75.5,38,40,43,54,58,-62,43,58,101
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94kg,Ben Satterberg,92,40,-43,43,53,55,57,43,57,100
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 63kg,Macie Olson,61,42,44,46,52,54,-56,46,54,100
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77+kg,Anjalie Lor,80.5,39,41,-44,53,56,59,41,59,100
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 53kg,Anella Sahr,52.5,35,38,41,55,58,-60,41,58,99
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 69+kg,Anna Jacobson,73,35,38,41,53,58,-63,41,58,99
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 65kg,Ezra Bjur,64,38,41,42,52,54,56,42,56,98
+Little Falls HS Invite,2025-12-13,Junior Women's 58kg,Madison Olson,55.5,40,43,-44,48,51,53,43,53,96
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 71kg,Tyson Macken,66,40,-42,-43,50,53,56,40,56,96
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Ian Schneider,75.5,39,42,-45,-54,54,-58,42,54,96
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 48kg,Kacie Cordova,47,37,-40,40,50,53,55,40,55,95
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 60kg,Isaac Reinhiller,59.5,-38,40,-43,-54,55,-57,40,55,95
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 69+kg,Bella Koth,104.5,36,-39,39,-55,-55,55,39,55,94
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 63kg,Maiya  Poppen,61,32,36,39,50,53,-55,39,53,92
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 58kg,Rylie Richards,57,35,37,40,50,52,-57,40,52,92
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 56kg,Carter Shelquist,53.5,34,38,41,51,-54,-57,41,51,92
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Gabriel  Nedrebo ,78.5,32,35,-38,52,55,57,35,57,92
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 60kg,Vincent Dahnert,57.5,36,38,40,45,47,50,40,50,90
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77+kg,Janayla Martin,78.5,32,35,38,48,51,-54,38,51,89
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 65kg,Kolton  Ahrenholtz,61.5,31,-32,33,-51,52,55,33,55,88
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 71kg,Caleb Meyer,69,35,38,-41,42,46,50,38,50,88
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 63kg,Eve Ebbighausen,62.5,34,36,-38,45,48,51,36,51,87
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 69kg,Autumn Boelter,65.5,37,-39,-40,-46,-46,46,37,46,83
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77kg,Caylin Ahrenholtz,77,-35,35,37,-45,-45,45,37,45,82
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 71kg,Benny Kilsdonk,70,34,37,40,42,-46,-46,40,42,82
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 69+kg,Taliyah Arias,81.5,27,29,32,42,45,49,32,49,81
+Little Falls HS Invite,2025-12-13,Junior Men's 60kg,Landon Janich ,58.5,31,33,35,44,46,-48,35,46,81
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 65kg,River Jacobson,63,31,33,37,-38,-38,44,37,44,81
+Little Falls HS Invite,2025-12-13,Men's 13 Under Age Group 60kg,Gabriel Jacobsen,59.5,-35,35,37,40,-42,43,37,43,80
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 58kg,Trinity Curtis,57,25,28,31,43,46,48,31,48,79
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 69kg,Madelyn Ray,66,31,32,33,42,45,-46,33,45,78
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77kg,Molly Greelis,72.5,27,29,32,42,-45,46,32,46,78
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77+kg,Ayla Hlad,80.5,29,32,36,39,42,-46,36,42,78
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 53kg,Marissa Rerick,50,33,-35,35,-40,40,42,35,42,77
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77kg,Viktoria Leaf,76,27,29,-32,42,46,48,29,48,77
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 58kg,Abigail Zeien,57.5,28,31,-34,39,42,45,31,45,76
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77kg,Lucy Leno,75.5,-27,29,30,-42,42,-44,30,42,72
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77+kg,Mya Nickson,87.5,-27,27,30,42,-45,-45,30,42,72
+Little Falls HS Invite,2025-12-13,Men's 13 Under Age Group 48kg,Landon Noe,44.5,29,31,33,36,39,-42,33,39,72
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Oliver Swenson,78.5,32,33,-36,35,37,39,33,39,72
+Little Falls HS Invite,2025-12-13,Women's 13 Under Age Group 58kg,Emma Votaw,55.5,24,27,-32,35,38,41,27,41,68
+Little Falls HS Invite,2025-12-13,Men's 13 Under Age Group 60kg,Ethan Petersen,60,24,26,29,-34,36,39,29,39,68
+Little Falls HS Invite,2025-12-13,Women's 14-15 Age Group 63kg,Caylee Larson,59,25,27,-29,39,-40,40,27,40,67
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 44kg,Anaya Garza,43.5,25,27,-28,38,-42,-42,27,38,65
+Little Falls HS Invite,2025-12-13,Men's 13 Under Age Group 48kg,Brice Jager,46,-28,28,-30,34,37,-40,28,37,65
+Little Falls HS Invite,2025-12-13,Women's 13 Under Age Group 53kg,Kennedy Mayer,50.5,27,29,-31,31,33,35,29,35,64
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,Gavin Dagenais,73,21,25,27,30,32,35,27,35,62
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 79kg,John Kjera,76,-25,25,26,30,33,36,26,36,62
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 58kg,Zoe Jacobsen,56,25,-27,-27,31,-33,34,25,34,59
+Little Falls HS Invite,2025-12-13,Men's 14-15 Age Group 48kg,Gavin Miller,42.5,23,26,-29,-32,33,-37,26,33,59
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 60kg,Mason  Forsberg,59,24,-27,-27,34,-35,35,24,35,59
+Little Falls HS Invite,2025-12-13,Women's 13 Under Age Group 63+kg,Viviana Arias,68,22,-25,25,25,28,31,25,31,56
+Little Falls HS Invite,2025-12-13,Men's 13 Under Age Group 52kg,Corban Swenson,51.5,20,23,-26,30,-32,-32,23,30,53
+Little Falls HS Invite,2025-12-13,Women's 11 Under Age Group 30kg,Navia Mongeon,29,15,17,19,25,26,29,19,29,48
+Little Falls HS Invite,2025-12-13,Men's 16-17 Age Group 94+kg,Alexander Schneider,149,78,-83,83,-110,-110,-110,83,0,0
+Little Falls HS Invite,2025-12-13,Women's 16-17 Age Group 77kg,Alexis Scheid,76.5,-46,-46,-46,-57,-57,-57,0,0,0

--- a/event_data/US/7178.csv
+++ b/event_data/US/7178.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+West Mids Summer Open,2025-07-27,Women's Masters (55-59) 86kg,Rebecca Pawlikiewicz-Peacock,77.6,30,-33,-35,35,40,45,30,45,75

--- a/event_data/US/7184.csv
+++ b/event_data/US/7184.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Belgian National U17,2025-11-30,Women's 16-17 Age Group 69kg,Lise Sterckx,65.75,0,0,78,0,0,98,78,98,176

--- a/event_data/US/7196.csv
+++ b/event_data/US/7196.csv
@@ -1,0 +1,2 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+2026 Pan-American Championships (Results),2025-07-18,Open Women's 69kg,Casey Aguilar-Gervase,65.6,-87,-87,87,-107,107,-112,87,107,194

--- a/event_data/US/7387.csv
+++ b/event_data/US/7387.csv
@@ -1,0 +1,14 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Jingle Barbells Winter Classic,2025-12-20,Men's 14-15 Age Group 71kg,Ashton McAllister,65.15,-85,85,90,110,116,-120,90,116,206
+Jingle Barbells Winter Classic,2025-12-20,Men's 16-17 Age Group 56kg,Tristan Stokum,55.95,52,-55,55,70,75,-85,55,75,130
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 63+kg,Lily Ontiveros,89.45,52,-55,56,67,70,-73,56,70,126
+Jingle Barbells Winter Classic,2025-12-20,Men's 14-15 Age Group 79+kg,Kane  Caywood ,84.25,42,45,50,-70,70,75,50,75,125
+Jingle Barbells Winter Classic,2025-12-20,Women's 14-15 Age Group 58kg,Reagan Case,57.55,52,54,-57,65,68,-71,54,68,122
+Jingle Barbells Winter Classic,2025-12-20,Women's 14-15 Age Group 58kg,Meg Sherwood,56.2,35,-37,37,48,50,55,37,55,92
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 63kg,Scarlett Caywood,60.25,35,-37,-37,-46,46,48,35,48,83
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 48kg,Marie (Paige) Stull,48,28,31,-33,38,41,44,31,44,75
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 36kg,Brielle Barton,35.55,-24,24,26,31,33,35,26,35,61
+Jingle Barbells Winter Classic,2025-12-20,Men's 13 Under Age Group 40kg,Bode Dahle,36.85,21,24,27,30,32,34,27,34,61
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 63+kg,Lillian Carter,79.15,21,23,25,30,33,35,25,35,60
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 53kg,Harper Marini,51,19,21,23,30,-33,-33,23,30,53
+Jingle Barbells Winter Classic,2025-12-20,Women's 13 Under Age Group 33kg,Gianna Palmer,33.05,20,-22,-24,27,-30,-30,20,27,47

--- a/event_data/US/7486.csv
+++ b/event_data/US/7486.csv
@@ -1,0 +1,40 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+The Indy Open 2026,2026-08-15,Open Men's 110kg,Trevor Kimm,107.7,140,150,155,170,180,-191,155,180,335
+The Indy Open 2026,2026-08-15,Open Men's 110kg,Jon Vore,100.3,116,120,-125,133,137,143,120,143,263
+The Indy Open 2026,2026-08-15,Men's Masters (35-39) 110+kg,Kyle Wilp,140.9,100,110,-126,140,150,-189,110,150,260
+The Indy Open 2026,2026-08-15,Open Men's 95kg,Billy Wurch,93.3,102,107,112,132,136,-138,112,136,248
+The Indy Open 2026,2026-08-15,Junior Men's 110kg,Jackson White,99.7,103,-107,110,120,130,-135,110,130,240
+The Indy Open 2026,2026-08-15,Open Men's 95kg,John Thomas Silvers,93.5,110,-113,-120,130,-137,-137,110,130,240
+The Indy Open 2026,2026-08-15,Open Men's 110kg,Corbin King,98.3,105,110,-115,125,130,-135,110,130,240
+The Indy Open 2026,2026-08-15,Open Men's 110kg,Jacob Day,101.4,100,-105,105,120,126,130,105,130,235
+The Indy Open 2026,2026-08-15,Junior Men's 95kg,Nate Goss,95,90,95,100,-115,120,-125,100,120,220
+The Indy Open 2026,2026-08-15,Junior Men's 70kg,Jack Mann,67.5,95,-98,-100,110,115,118,95,118,213
+The Indy Open 2026,2026-08-15,Open Men's 95kg,Bryce Hoffman,93.6,90,-95,-95,-115,-120,120,90,120,210
+The Indy Open 2026,2026-08-15,Men's 16-17 Age Group 75kg,Caleb Hunter,72.15,80,-85,-85,105,-111,-111,80,105,185
+The Indy Open 2026,2026-08-15,Open Men's 85kg,Luke Thomas,81.5,80,85,-92,100,-105,-110,85,100,185
+The Indy Open 2026,2026-08-15,Men's Masters (35-39) 110+kg,Michael Nead,111.85,75,-82,84,90,95,100,84,100,184
+The Indy Open 2026,2026-08-15,Open Women's 86kg,Kelly Roe,79.6,78,82,85,98,-103,-103,85,98,183
+The Indy Open 2026,2026-08-15,Men's Masters (55-59) 110+kg,Anthony Walker,112.45,72,76,80,90,95,98,80,98,178
+The Indy Open 2026,2026-08-15,Men's Masters (35-39) 110+kg,Joseph Adkins,123.65,63,66,69,88,91,95,69,95,164
+The Indy Open 2026,2026-08-15,Open Women's 57kg,Jaycee Mann,54.1,72,74,-76,88,90,-92,74,90,164
+The Indy Open 2026,2026-08-15,Open Men's 85kg,Justus Foster,81.65,63,66,-68,83,-86,86,66,86,152
+The Indy Open 2026,2026-08-15,Open Men's 65kg,Anthony  Koon,62.25,57,60,63,83,86,-88,63,86,149
+The Indy Open 2026,2026-08-15,Women's Masters (50-54) 77kg,Jennifer Wilson,75.9,56,59,62,75,78,81,62,81,143
+The Indy Open 2026,2026-08-15,Open Women's 69kg,Emily Martin,68.4,53,56,60,68,71,75,60,75,135
+The Indy Open 2026,2026-08-15,Women's Masters (35-39) 57kg,Kelsey Abdallah,56,56,59,62,66,69,-72,62,69,131
+The Indy Open 2026,2026-08-15,Open Women's 77kg,Jackeline Martinez ,72.9,50,53,-56,73,-75,-75,53,73,126
+The Indy Open 2026,2026-08-15,Junior Women's 57kg,Liliana  Ray,55.7,47,49,-51,59,-63,-63,49,59,108
+The Indy Open 2026,2026-08-15,Men's 13 Under Age Group 70+kg,Bridger Soden,80.65,38,41,44,55,58,-60,44,58,102
+The Indy Open 2026,2026-08-15,Men's Masters (65-69) 70kg,Chuck Lynch,68.85,40,42,-44,52,55,-58,42,55,97
+The Indy Open 2026,2026-08-15,Women's Masters (55-59) 57kg,Christine  LaGore,53.2,35,38,41,50,-53,53,41,53,94
+The Indy Open 2026,2026-08-15,Women's Masters (55-59) 77kg,Kristen Berens,76.7,40,-42,-42,48,-52,52,40,52,92
+The Indy Open 2026,2026-08-15,Men's 16-17 Age Group 55kg,Liam McCullough,52.55,-36,-38,40,48,51,-53,40,51,91
+The Indy Open 2026,2026-08-15,Women's 16-17 Age Group 77+kg,Colleen Soden,86.2,35,38,41,40,43,46,41,46,87
+The Indy Open 2026,2026-08-15,Open Women's 61kg,Faith Beecher,58.7,33,35,-38,40,43,46,35,46,81
+The Indy Open 2026,2026-08-15,Women's 13 Under Age Group 45kg,Taylor Kunkel,43,35,37,-39,41,-43,-43,37,41,78
+The Indy Open 2026,2026-08-15,Women's Masters (55-59) 69kg,Michelle Hart,65.3,30,33,-35,-40,43,-46,33,43,76
+The Indy Open 2026,2026-08-15,Men's 13 Under Age Group 36kg,Grayson Ibrahim,35.45,27,-29,-31,35,-37,-37,27,35,62
+The Indy Open 2026,2026-08-15,Women's Masters (70-74) 77kg,Donna Barnes,72.7,20,21,22,25,27,29,22,29,51
+The Indy Open 2026,2026-08-15,Women's 11 Under Age Group 30kg,Vera Ibrahim,26.4,15,-17,17,20,22,-25,17,22,39
+The Indy Open 2026,2026-08-15,Men's 16-17 Age Group 70kg,Caden Awishes,69.05,68,70,72,-87,-90,-90,72,0,0
+The Indy Open 2026,2026-08-15,Open Women's 86kg,Alyssa White,80.2,-60,-60,-60,-79,-79,79,0,79,0

--- a/event_data/US/7489.csv
+++ b/event_data/US/7489.csv
@@ -1,0 +1,23 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Back 2 School Barbell Bash,2026-08-29,Men's 16-17 Age Group 85kg,Kainoa Everhart,82,72,77,80,102,-106,106,80,106,186
+Back 2 School Barbell Bash,2026-08-29,Men's 16-17 Age Group 85kg,Jace Doty,76.4,76,-80,80,91,96,100,80,100,180
+Back 2 School Barbell Bash,2026-08-29,Junior Men's 70kg,Nathan Crouch,67,63,67,70,83,87,90,70,90,160
+Back 2 School Barbell Bash,2026-08-29,Men's 14-15 Age Group 65kg,Titus Clinger,62.7,53,57,60,74,79,82,60,82,142
+Back 2 School Barbell Bash,2026-08-29,Women's 14-15 Age Group 61kg,Evelyn Lilo,61,-55,-55,55,75,79,82,55,82,137
+Back 2 School Barbell Bash,2026-08-29,Junior Women's 57kg,Sophia Willoughby,56.4,47,50,-54,69,72,-75,50,72,122
+Back 2 School Barbell Bash,2026-08-29,Men's 14-15 Age Group 65kg,Johnathan  Overman ,61.9,45,48,51,62,66,70,51,70,121
+Back 2 School Barbell Bash,2026-08-29,Women's 16-17 Age Group 69kg,Lucia Miller,62.3,42,45,48,62,-66,-66,48,62,110
+Back 2 School Barbell Bash,2026-08-29,Junior Women's 86kg,Madison McArthur,82.3,41,44,-47,-60,60,64,44,64,108
+Back 2 School Barbell Bash,2026-08-29,Men's 14-15 Age Group 55kg,Jonathan Nelson,52.3,43,46,-49,49,53,56,46,56,102
+Back 2 School Barbell Bash,2026-08-29,Men's 14-15 Age Group 60kg,Wyatt Johnson,60,35,37,40,47,50,-54,40,50,90
+Back 2 School Barbell Bash,2026-08-29,Women's 14-15 Age Group 45kg,Mariana Miller,43.9,32,35,40,38,41,45,40,45,85
+Back 2 School Barbell Bash,2026-08-29,Junior Women's 77kg,Savannah Kish,71.9,32,35,38,41,44,-47,38,44,82
+Back 2 School Barbell Bash,2026-08-29,Junior Women's 49kg,Klara Dobosz,44.6,28,31,33,37,40,43,33,43,76
+Back 2 School Barbell Bash,2026-08-29,Women's 16-17 Age Group 61kg,Alexa Hutchins,59.5,27,30,33,36,39,42,33,42,75
+Back 2 School Barbell Bash,2026-08-29,Women's 16-17 Age Group 77+kg,Sara Garland,81.1,25,28,31,37,40,43,31,43,74
+Back 2 School Barbell Bash,2026-08-29,Women's 14-15 Age Group 53kg,Henley Nagel,53,25,28,-31,37,40,-43,28,40,68
+Back 2 School Barbell Bash,2026-08-29,Women's 14-15 Age Group 69kg,Jadelyn McArthur,61.8,26,29,31,32,36,-39,31,36,67
+Back 2 School Barbell Bash,2026-08-29,Men's 16-17 Age Group 55kg,Nick Mantia,46.9,18,21,24,27,31,35,24,35,59
+Back 2 School Barbell Bash,2026-08-29,Men's 14-15 Age Group 50kg,Brendan Harris,43.1,14,17,20,25,-28,28,20,28,48
+Back 2 School Barbell Bash,2026-08-29,Men's 11 Under Age Group 32kg,Kohen Harkema,29.6,13,16,18,20,23,26,18,26,44
+Back 2 School Barbell Bash,2026-08-29,Men's 11 Under Age Group 32kg,Saul Silva Lopez,32,11,15,17,17,21,23,17,23,40

--- a/event_data/US/7490.csv
+++ b/event_data/US/7490.csv
@@ -1,0 +1,15 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Diablo Fall Classic,2026-08-22,Men's Masters (35-39) 110+kg,Ian Luna,134.68,107,112,118,142,150,-156,118,150,268
+Diablo Fall Classic,2026-08-22,Men's Masters (45-49) 110kg,ADAM LORIMER,101.7,74,-80,80,102,109,112,80,112,192
+Diablo Fall Classic,2026-08-22,Men's Masters (40-44) 110+kg,Kevin Taylor,116.45,71,75,-78,85,91,97,75,97,172
+Diablo Fall Classic,2026-08-22,Men's Masters (35-39) 75kg,Timothy McGowan,72.2,77,-80,80,88,92,-97,80,92,172
+Diablo Fall Classic,2026-08-22,Women's Masters (40-44) 86kg,Carrie Pon,82.45,52,55,58,73,76,80,58,80,138
+Diablo Fall Classic,2026-08-22,Open Women's 86kg,Susanna Hintergardt,82.95,61,-63,65,67,70,-74,65,70,135
+Diablo Fall Classic,2026-08-22,Women's Masters (55-59) 69kg,Joanna Mangiante,67.36,43,44,46,58,-61,62,46,62,108
+Diablo Fall Classic,2026-08-22,Women's Masters (35-39) 69kg,Leah Putlek,65.14,44,-46,-48,50,55,-60,44,55,99
+Diablo Fall Classic,2026-08-22,Women's Masters (50-54) 69kg,Marium Holland,67.22,40,42,44,48,51,-53,44,51,95
+Diablo Fall Classic,2026-08-22,Women's Masters (55-59) 61kg,Salalinee  Ekchit ,57.63,38,-40,-40,50,54,-57,38,54,92
+Diablo Fall Classic,2026-08-22,Junior Men's 85kg,Logan Gomes,83.27,30,35,40,45,50,-52,40,50,90
+Diablo Fall Classic,2026-08-22,Women's Masters (60-64) 57kg,Denise Steckel,56.5,30,33,36,40,45,-48,36,45,81
+Diablo Fall Classic,2026-08-22,Women's 16-17 Age Group 69kg,Hayleigh Huntley,66.09,25,28,-31,-36,36,39,28,39,67
+Diablo Fall Classic,2026-08-22,Women's Masters (70-74) 77kg,Deborah Kyle Hintergardt,71.9,20,23,-25,23,26,29,23,29,52

--- a/event_data/US/7491.csv
+++ b/event_data/US/7491.csv
@@ -1,0 +1,17 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Ann Arbor Youth Series,2026-08-29,Men's 16-17 Age Group 65kg,August Ewing-Sohtun,63.77,65,70,75,80,85,90,75,90,165
+Ann Arbor Youth Series,2026-08-29,Men's 14-15 Age Group 95kg,Neil Fuenmayor,92.65,58,60,62,72,74,76,62,76,138
+Ann Arbor Youth Series,2026-08-29,Women's 16-17 Age Group 61kg,Amiya Drury,59.23,64,-66,-66,68,-70,70,64,70,134
+Ann Arbor Youth Series,2026-08-29,Men's 14-15 Age Group 85kg,Hayden Nguyen,78.27,48,51,54,59,62,68,54,68,122
+Ann Arbor Youth Series,2026-08-29,Women's 13 Under Age Group 53kg,Hailey Sprenger,49.17,-47,-49,49,58,60,62,49,62,111
+Ann Arbor Youth Series,2026-08-29,Women's Masters (45-49) 77kg,Andrea Eberle,73.79,31,33,35,43,46,48,35,48,83
+Ann Arbor Youth Series,2026-08-29,Women's Masters (45-49) 86kg,Amy Burns,82.15,30,32,-34,43,45,-47,32,45,77
+Ann Arbor Youth Series,2026-08-29,Women's 13 Under Age Group 61+kg,Penelope Burns,85.57,28,30,32,34,37,40,32,40,72
+Ann Arbor Youth Series,2026-08-29,Men's 13 Under Age Group 45kg,Henley Nguyen,42.35,29,-31,31,-38,38,41,31,41,72
+Ann Arbor Youth Series,2026-08-29,Women's 14-15 Age Group 45kg,Sophia  Mathews ,43.98,-26,26,27,36,38,40,27,40,67
+Ann Arbor Youth Series,2026-08-29,Women's 11 Under Age Group 37kg,Quinn Drury,36.33,24,26,28,32,34,36,28,36,64
+Ann Arbor Youth Series,2026-08-29,Women's 11 Under Age Group 41kg,Charli Grueshaber,38.13,24,26,28,32,34,36,28,36,64
+Ann Arbor Youth Series,2026-08-29,Men's 11 Under Age Group 45kg,Ronan Telin,44.45,20,22,24,25,27,29,24,29,53
+Ann Arbor Youth Series,2026-08-29,Women's 13 Under Age Group 49kg,Harper Lawrence,48.02,18,20,21,26,28,29,21,29,50
+Ann Arbor Youth Series,2026-08-29,Women's 11 Under Age Group 33kg,Rylee Liao,31.5,16,19,21,17,20,22,21,22,43
+Ann Arbor Youth Series,2026-08-29,Women's 11 Under Age Group 30kg,Evelyn Seguin,25.9,13,15,17,15,17,19,17,19,36

--- a/event_data/US/7492.csv
+++ b/event_data/US/7492.csv
@@ -1,0 +1,43 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Omaha Classic,2026-08-29,Open Men's 110kg,Alfred Grenon,106.75,-125,128,132,160,168,-172,132,168,300
+Omaha Classic,2026-08-29,Men's Masters (35-39) 85kg,Javan Freyenberger,83.75,112,116,120,142,146,150,120,150,270
+Omaha Classic,2026-08-29,Open Men's 95kg,William Sullivan,85.9,-112,112,116,143,148,153,116,153,269
+Omaha Classic,2026-08-29,Open Men's 95kg,Maximilian Califf,94.25,102,107,112,142,147,152,112,152,264
+Omaha Classic,2026-08-29,Men's Masters (35-39) 110+kg,Zackery VanDenHout,110.5,105,110,-115,142,147,152,110,152,262
+Omaha Classic,2026-08-29,Open Men's 110+kg,Neal Eckhoff,132.65,95,100,104,136,140,144,104,144,248
+Omaha Classic,2026-08-29,Open Men's 110+kg,Kim Palmquist,113.6,90,95,100,115,120,125,100,125,225
+Omaha Classic,2026-08-29,Men's Masters (35-39) 110+kg,Kaid Funk,132.25,90,95,-100,-120,-120,121,95,121,216
+Omaha Classic,2026-08-29,Open Men's 75kg,brady parkis,72.45,87,-90,90,117,121,125,90,125,215
+Omaha Classic,2026-08-29,Open Women's 69kg,Siera Schuster,63.85,75,78,-81,94,97,100,78,100,178
+Omaha Classic,2026-08-29,Women's 16-17 Age Group 77+kg,Anahlis Rubio,117.45,69,72,77,96,100,-105,77,100,177
+Omaha Classic,2026-08-29,Men's Masters (45-49) 85kg,Corey Johnson,80.85,73,76,-80,95,99,-103,76,99,175
+Omaha Classic,2026-08-29,Women's Masters (35-39) 86+kg,Angela Ledford,100.4,65,68,71,87,91,-95,71,91,162
+Omaha Classic,2026-08-29,Open Women's 69kg,Jenna Godfrey,69,67,70,73,84,88,-91,73,88,161
+Omaha Classic,2026-08-29,Open Women's 77kg,Olivia Russo,72.8,64,67,-71,88,92,-95,67,92,159
+Omaha Classic,2026-08-29,Open Women's 69kg,Kayla Bouckhuyt,66.9,61,64,68,83,-87,88,68,88,156
+Omaha Classic,2026-08-29,Open Women's 77kg,Alicyn DeLoa,69.3,61,-64,64,83,-86,87,64,87,151
+Omaha Classic,2026-08-29,Men's 16-17 Age Group 60kg,Angel Rubio,57.45,-57,60,63,78,81,85,63,85,148
+Omaha Classic,2026-08-29,Women's Masters (40-44) 86+kg,Stephanie Dickhute,90.6,60,63,67,70,74,80,67,80,147
+Omaha Classic,2026-08-29,Open Women's 86kg,Carissa Holt,82.6,-58,59,62,75,79,82,62,82,144
+Omaha Classic,2026-08-29,Open Women's 77kg,Allison Davis,70.1,53,57,-62,70,75,78,57,78,135
+Omaha Classic,2026-08-29,Open Men's 70kg,Nathan McPhillamy,67.65,56,60,-65,64,-69,72,60,72,132
+Omaha Classic,2026-08-29,Open Women's 77kg,Daniella  Sotland ,73.4,55,-57,58,69,72,-74,58,72,130
+Omaha Classic,2026-08-29,Open Women's 69kg,Devan Sedlacek,62.3,48,51,-54,69,72,-75,51,72,123
+Omaha Classic,2026-08-29,Open Women's 77kg,Taylor Johnson,76.7,42,45,48,56,60,64,48,64,112
+Omaha Classic,2026-08-29,Women's Masters (40-44) 77kg,Kristin Cicha,71.6,42,45,48,60,63,-67,48,63,111
+Omaha Classic,2026-08-29,Women's Masters (45-49) 69kg,Tamara  Draper,68.6,40,42,45,56,58,60,45,60,105
+Omaha Classic,2026-08-29,Men's 16-17 Age Group 55kg,Teagan Paulus,54.3,42,44,-46,55,58,-61,44,58,102
+Omaha Classic,2026-08-29,Women's Masters (55-59) 61kg,Carol Trees,59.15,40,42,44,54,56,58,44,58,102
+Omaha Classic,2026-08-29,Women's Masters (45-49) 69kg,Cheryl Banks,63.55,35,37,39,50,53,56,39,56,95
+Omaha Classic,2026-08-29,Women's 14-15 Age Group 77kg,Scarlett Mahaffey,71.6,36,39,42,46,49,52,42,52,94
+Omaha Classic,2026-08-29,Women's 13 Under Age Group 49kg,Francesca Putz,46.95,35,37,39,45,48,51,39,51,90
+Omaha Classic,2026-08-29,Women's Masters (55-59) 86+kg,Laura Grams,110.2,30,32,35,50,53,55,35,55,90
+Omaha Classic,2026-08-29,Junior Women's 77kg,Abby  Scritchfield,74,32,35,38,45,48,51,38,51,89
+Omaha Classic,2026-08-29,Women's Masters (35-39) 86kg,Andrea Hennings,81.8,35,37,39,42,45,48,39,48,87
+Omaha Classic,2026-08-29,Women's Masters (45-49) 57kg,Merenciana Paulus,55.1,34,36,-38,42,44,46,36,46,82
+Omaha Classic,2026-08-29,Men's 11 Under Age Group 36kg,Tristan Schuster,34.95,21,23,25,30,32,35,25,35,60
+Omaha Classic,2026-08-29,Men's 13 Under Age Group 70+kg,Archer Heiden,86.85,20,22,24,25,27,-29,24,27,51
+Omaha Classic,2026-08-29,Women's 13 Under Age Group 49kg,Quin Hanna,48.05,17,18,19,22,24,26,19,26,45
+Omaha Classic,2026-08-29,Women's 13 Under Age Group 49kg,Thérèse Pica,49,17,18,19,22,24,26,19,26,45
+Omaha Classic,2026-08-29,Junior Women's 86kg,Victoria Carter,81.2,-70,-70,-72,85,90,-95,0,90,0
+Omaha Classic,2026-08-29,Men's Masters (35-39) 110kg,Corey Friesen,101.5,106,-112,113,-121,-121,-123,113,0,0

--- a/event_data/US/7493.csv
+++ b/event_data/US/7493.csv
@@ -1,0 +1,68 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Paramount GRAND PRIX!,2026-08-29,Open Men's 95kg,Daniel Wiitanen,94.45,160,165,170,180,-188,-190,170,180,350
+Paramount GRAND PRIX!,2026-08-29,Open Men's 95kg,Jason Young,91.95,124,128,-131,147,153,-157,128,153,281
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (45-49) 110kg,Jason Dinius,106.15,117,-122,122,140,145,150,122,150,272
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 110kg,Shawn Hiebert,107.95,101,105,109,148,153,158,109,158,267
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 110kg,Andrew Robinson,100.55,117,122,-126,137,-142,-144,122,137,259
+Paramount GRAND PRIX!,2026-08-29,Open Men's 110kg,Jose Tolentino,96.6,102,-107,110,135,-143,147,110,147,257
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 95kg,Grady McGuire,89.25,-96,97,102,121,127,131,102,131,233
+Paramount GRAND PRIX!,2026-08-29,Open Men's 75kg,Ellijah Gardaya,74.15,97,100,-103,128,131,-135,100,131,231
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 85kg,Joshua Levinson,83.45,-90,90,95,120,128,135,95,135,230
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (40-44) 110+kg,Michael Olsen,131.85,102,-105,-105,124,-127,128,102,128,230
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (45-49) 110kg,Josh Miller,101.25,93,98,-103,123,-131,131,98,131,229
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 85kg,Richard Yin,80.35,-95,95,98,120,125,-128,98,125,223
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (50-54) 95kg,David Chow,92.75,88,92,95,115,120,125,95,125,220
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (40-44) 95kg,Kellan Bulman,92.95,90,-94,94,-115,115,120,94,120,214
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 86+kg,Uchechi Esonu,87.95,84,87,-89,114,118,-122,87,118,205
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (50-54) 95kg,Justin Lassy ,92.45,78,82,-85,111,118,-125,82,118,200
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (40-44) 110+kg,Daniel Toone,123.65,82,85,-90,110,113,-120,85,113,198
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (40-44) 95kg,Tim Lease,89.25,85,-91,91,100,-112,0,91,100,191
+Paramount GRAND PRIX!,2026-08-30,Open Women's 69kg,Grayson Corrales,65,79,82,-85,98,102,105,82,105,187
+Paramount GRAND PRIX!,2026-08-30,Open Women's 86kg,Dana Arbova,83.85,79,81,-83,-100,100,104,81,104,185
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 75kg,Andy Nam,74.65,-75,75,78,95,-98,-98,78,95,173
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 77kg,Minnie Copp,76.05,73,76,-80,95,-100,-101,76,95,171
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (40-44) 110kg,Tony Macias,99.95,60,65,70,90,95,100,70,100,170
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 77kg,Kimberly Andrew,76.45,75,-78,-80,88,91,94,75,94,169
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (60-64) 110kg,William Marken,97.25,71,73,-75,91,94,-100,73,94,167
+Paramount GRAND PRIX!,2026-08-29,Men's 16-17 Age Group 85kg,noah harris ,81.85,70,-75,-75,95,-100,-100,70,95,165
+Paramount GRAND PRIX!,2026-08-30,Open Women's 69kg,Carlie Herron,67.05,66,69,-73,87,90,-93,69,90,159
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 61kg,Ashley Dvorin,59.75,70,73,75,81,-84,-86,75,81,156
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 77kg,Desirae Lyall,71.65,56,60,65,83,86,90,65,90,155
+Paramount GRAND PRIX!,2026-08-29,Open Men's 85kg,Daniel O'Shea,83.75,61,65,-69,82,85,88,65,88,153
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 77kg,Joanne Whitmer,75,61,64,67,76,79,-82,67,79,146
+Paramount GRAND PRIX!,2026-08-30,Open Women's 61kg,Carringtin Dietz,60.35,54,58,62,74,78,-81,62,78,140
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (50-54) 69kg,Christine Moore,67.6,60,62,64,70,73,76,64,76,140
+Paramount GRAND PRIX!,2026-08-30,Open Women's 57kg,Kam Clardy,55.85,58,61,-64,76,78,-80,61,78,139
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 77kg,Andrea Callahan,70.95,54,57,60,70,73,78,60,78,138
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 86kg,Jessica Marshall,77.95,-62,62,-64,-75,-75,75,62,75,137
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 86+kg,Jen Segadelli,89.65,56,-59,59,73,77,-82,59,77,136
+Paramount GRAND PRIX!,2026-08-29,Men's 14-15 Age Group 70kg,Zachary Hiebert,65.95,53,56,60,67,71,75,60,75,135
+Paramount GRAND PRIX!,2026-08-30,Open Women's 86kg,Sydney Gardner,84.65,53,55,-58,75,-78,-78,55,75,130
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (35-39) 110kg,Kenneth Wickham,96.15,50,52,54,70,73,76,54,76,130
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (70-74) 85kg,Bill McLoughlin,82.75,52,54,56,63,66,70,56,70,126
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 57kg,Lesley Gaskin,54.75,48,50,52,67,70,73,52,73,125
+Paramount GRAND PRIX!,2026-08-30,Women's 14-15 Age Group 49kg,Lila Mangan,48.65,48,50,52,61,64,66,52,66,118
+Paramount GRAND PRIX!,2026-08-30,Open Women's 77kg,Morgan Barton,76.25,50,53,54,60,62,64,54,64,118
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 69kg,Julia Applegate,65.25,51,-53,-54,65,67,-70,51,67,118
+Paramount GRAND PRIX!,2026-08-30,Women's 14-15 Age Group 53kg,Kyla Byron,51,52,-54,-54,62,-64,64,52,64,116
+Paramount GRAND PRIX!,2026-08-30,Women's 16-17 Age Group 77+kg,Ella Irwin,79.85,45,47,49,58,61,65,49,65,114
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 86kg,Lisa Lease,81.2,52,-55,-55,59,62,-65,52,62,114
+Paramount GRAND PRIX!,2026-08-30,Open Women's 77kg,Tali Shlafer,73,40,43,48,55,58,62,48,62,110
+Paramount GRAND PRIX!,2026-08-30,Open Women's 61kg,Laura Davis,59.25,41,43,45,58,61,64,45,64,109
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 86+kg,Kayla Sua,97.05,43,-46,-46,60,63,66,43,66,109
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 86kg,Erica  Miller ,84.35,38,41,45,55,58,63,45,63,108
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (40-44) 69kg,Ashley Farley,67.6,40,43,-45,56,59,-61,43,59,102
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (60-64) 61kg,Kelly Garber,60,42,44,46,50,52,54,46,54,100
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (65-69) 77kg,Litsa Olsson,70.05,38,40,43,53,56,-60,43,56,99
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (55-59) 69kg,Jennifer Sprague,62.65,36,39,-45,47,50,54,39,54,93
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (35-39) 77kg,Atinna Gunawan,71.05,36,-39,39,49,51,53,39,53,92
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (60-64) 57kg,Suzanne Evans,56.25,37,39,41,47,49,-51,41,49,90
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (60-64) 57kg,Debbie Bennett,53.15,31,-33,33,43,45,48,33,48,81
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (55-59) 69kg,Jackie Stam,65.75,31,33,-35,42,44,46,33,46,79
+Paramount GRAND PRIX!,2026-08-30,Women's 11 Under Age Group 53kg,Autumn Whitmer,51.45,29,31,34,38,40,42,34,42,76
+Paramount GRAND PRIX!,2026-08-29,Men's Masters (80-84) 110kg,Albert Dunlap,98.15,27,29,31,35,36,39,31,39,70
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (65-69) 61kg,Patricia Ray,60.35,24,26,27,32,34,36,27,36,63
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (65-69) 77kg,Lynne Mester,74.55,25,27,29,28,30,32,29,32,61
+Paramount GRAND PRIX!,2026-08-29,Men's 11 Under Age Group 36kg,Tayos Mudaliar,35.45,22,-24,25,28,30,33,25,33,58
+Paramount GRAND PRIX!,2026-08-30,Women's Masters (55-59) 69kg,Kristi Morgan,64.55,16,18,20,20,22,24,20,24,44
+Paramount GRAND PRIX!,2026-08-29,Open Men's 95kg,Joon (Andrew) Yu,90.05,-103,-103,-111,120,126,131,0,131,0

--- a/event_data/US/769.csv
+++ b/event_data/US/769.csv
@@ -1,0 +1,129 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+East Coast Classic,2013-05-04,Open Men's+105 kg,David Jorge,106.58,125,132,-137,153,158,-165,132,158,290
+East Coast Classic,2013-05-04,Open Men's 105 kg,Russell McDonnell,101.14,110,114,-117,135,139,150,114,150,264
+East Coast Classic,2013-05-04,Open Men's 85 kg,Adam Beytin,82.09,105,110,-116,145,150,-155,110,150,260
+East Coast Classic,2013-05-04,Open Men's 77 kg,Jon Zajac,73.22,110,114,117,130,135,140,117,140,257
+East Coast Classic,2013-05-04,Open Men's 85 kg,Tyler Miller,83.5,105,-110,112,140,145,-150,112,145,257
+East Coast Classic,2013-05-04,Open Men's 105 kg,Aaron Naccarato,96.7,-115,-115,115,135,-140,140,115,140,255
+East Coast Classic,2013-05-04,Open Men's 105 kg,Daniel Marrone,99.24,110,113,116,132,-136,-136,116,132,248
+East Coast Classic,2013-05-04,Open Men's 94 kg,Peter Van de Water,89.86,-107,107,-111,130,135,140,107,140,247
+East Coast Classic,2013-05-04,Open Men's 94 kg,Matthew Willard,93.3,107,-112,113,121,126,131,113,131,244
+East Coast Classic,2013-05-04,Open Men's+105 kg,Paul Tompkins,152.22,105,-108,110,125,132,-141,110,132,242
+East Coast Classic,2013-05-04,Open Men's 85 kg,Jose Cardenas,83.4,98,104,108,122,-126,128,108,128,236
+East Coast Classic,2013-05-04,Open Men's+105 kg,Dietrich Homer,125.26,95,99,102,123,128,134,102,134,236
+East Coast Classic,2013-05-04,Open Men's 105 kg,David Lee,103.72,95,100,105,120,125,130,105,130,235
+East Coast Classic,2013-05-04,Open Men's 85 kg,Christopher Taber,84.2,-100,100,105,125,130,-133,105,130,235
+East Coast Classic,2013-05-04,Open Men's 77 kg,Chris McGinnis,76.76,98,-102,103,120,125,128,103,128,231
+East Coast Classic,2013-05-04,Open Men's 94 kg,Paul DeTurk,93.68,95,100,106,115,120,-125,106,120,226
+East Coast Classic,2013-05-04,Open Men's 77 kg,Peter Ferrari,75.99,-96,-96,96,-118,118,124,96,124,220
+East Coast Classic,2013-05-04,Open Men's 94 kg,Joel Maher,88.3,88,92,95,120,125,-130,95,125,220
+East Coast Classic,2013-05-04,Open Men's 105 kg,Bradley Dayett,104.63,95,100,105,115,-120,-123,105,115,220
+East Coast Classic,2013-05-04,Open Men's+105 kg,Erik Miller,118.29,89,93,96,110,116,120,96,120,216
+East Coast Classic,2013-05-04,Open Men's 85 kg,Lee Koontz,81.5,-90,90,95,115,120,-125,95,120,215
+East Coast Classic,2013-05-04,Open Men's 85 kg,Alex McInnes,83.5,90,95,-100,115,120,-123,95,120,215
+East Coast Classic,2013-05-04,Open Men's 85 kg,Garrett Shultz,80.3,-100,-100,100,115,-120,-120,100,115,215
+East Coast Classic,2013-05-04,Open Men's 105 kg,Robert Smith,102.42,84,86,90,110,115,120,90,120,210
+East Coast Classic,2013-05-04,Open Men's 85 kg,Matthew Berni,83,-90,90,-95,120,-130,-130,90,120,210
+East Coast Classic,2013-05-04,Open Men's 69 kg,David Luk,68.34,94,-97,-97,115,-120,0,94,115,209
+East Coast Classic,2013-05-04,Open Men's 77 kg,Jesse Judy,76.46,88,90,94,-110,110,115,94,115,209
+East Coast Classic,2013-05-04,Open Men's 85 kg,Inwon Choi,80.92,85,90,93,105,110,116,93,116,209
+East Coast Classic,2013-05-04,Open Men's+105 kg,Daniel Kocotas,110,90,95,-100,105,-110,111,95,111,206
+East Coast Classic,2013-05-04,Open Men's 85 kg,Timothy Crew,80.58,85,90,-95,115,-120,-120,90,115,205
+East Coast Classic,2013-05-04,Open Men's 85 kg,Brian Pitts,80.91,90,-95,-96,110,115,-120,90,115,205
+East Coast Classic,2013-05-04,Open Men's 85 kg,Rob Izsa,82.6,90,-95,-95,115,-120,-120,90,115,205
+East Coast Classic,2013-05-04,Open Men's 94 kg,Paul Archambault,92.89,-86,-86,86,110,114,118,86,118,204
+East Coast Classic,2013-05-04,Open Men's 105 kg,Scott Redden,103.98,89,-94,94,99,105,110,94,110,204
+East Coast Classic,2013-05-04,Open Men's+105 kg,Kevin Montgomery,111.1,84,87,-89,113,-116,116,87,116,203
+East Coast Classic,2013-05-04,Open Men's 77 kg,Chris Smith,75.51,85,-90,-90,105,110,117,85,117,202
+East Coast Classic,2013-05-04,Open Men's 77 kg,Ben Chianchiano,75.08,87,-91,91,110,-115,-118,91,110,201
+East Coast Classic,2013-05-04,Open Men's 77 kg,John Bova,76.97,85,-93,-95,-104,108,115,85,115,200
+East Coast Classic,2013-05-04,Open Men's 77 kg,Patrick Rawle,76.1,85,-90,90,110,-115,-116,90,110,200
+East Coast Classic,2013-05-04,Open Men's 62 kg,Jeffrey Walters,60.9,83,-87,-87,110,114,-117,83,114,197
+East Coast Classic,2013-05-04,Open Men's 77 kg,Jay Tobia,74.99,82,-88,90,-105,105,-112,90,105,195
+East Coast Classic,2013-05-04,Open Men's 105 kg,Ryan Whittemore,102.43,85,-90,-90,105,110,-113,85,110,195
+East Coast Classic,2013-05-04,Open Men's 105 kg,Don Golden,99.81,85,-90,90,100,105,-110,90,105,195
+East Coast Classic,2013-05-04,Open Men's 85 kg,Joseph Kim,78.69,80,84,91,102,-107,-111,91,102,193
+East Coast Classic,2013-05-04,Open Men's 85 kg,Bryan Stevens,84.88,83,-87,-88,100,106,-113,83,106,189
+East Coast Classic,2013-05-04,Open Men's 85 kg,Anthony Euculano,84.99,75,-82,82,100,105,-110,82,105,187
+East Coast Classic,2013-05-04,Women's 16-17 Age Group +75 kg,Deirdre Lenzsch,86.79,-80,-80,80,100,105,-111,80,105,185
+East Coast Classic,2013-05-04,Open Women's 58 kg,Rizelyx Rivera,57.7,-80,80,-85,95,100,0,80,100,180
+East Coast Classic,2013-05-04,Open Women's +75 Kg,Allison Bradshaw,83.7,78,82,0,-98,-98,98,82,98,180
+East Coast Classic,2013-05-04,Open Men's 105 kg,Ricardo Fernandez,102.03,70,-75,75,100,105,-110,75,105,180
+East Coast Classic,2013-05-04,Open Men's 69 kg,Troy Nagel,67.7,-80,-80,80,85,95,100,80,100,180
+East Coast Classic,2013-05-04,Open Men's 77 kg,Corey Hadzick,74.4,-65,70,-77,110,-113,-116,70,110,180
+East Coast Classic,2013-05-04,Open Men's 69 kg,Aleksey Khomenko,68.96,75,-77,77,95,100,-102,77,100,177
+East Coast Classic,2013-05-04,Open Men's 77 kg,Rustico Mirasol,75.44,75,80,-85,95,-100,-100,80,95,175
+East Coast Classic,2013-05-04,Open Men's 85 kg,Christopher Taylor,81.78,-69,69,74,92,97,-102,74,97,171
+East Coast Classic,2013-05-04,Open Men's 85 kg,Gordon MacDonald,80.55,60,65,70,92,-97,100,70,100,170
+East Coast Classic,2013-05-04,Open Men's 62 kg,Tyler Maizels,57.87,72,-75,-75,92,-95,-95,72,92,164
+East Coast Classic,2013-05-04,Women's Masters (35-39) 69 kg,Patricia Maizels,67.66,70,72,-74,88,-95,-95,72,88,160
+East Coast Classic,2013-05-04,Open Men's+105 kg,David Sneberger,107.7,70,-75,-76,85,90,-95,70,90,160
+East Coast Classic,2013-05-04,Open Men's 105 kg,Gerard Finn,102.8,62,66,-68,82,86,90,66,90,156
+East Coast Classic,2013-05-04,Open Men's 77 kg,Bailey Druck,75.84,60,65,70,70,77,85,70,85,155
+East Coast Classic,2013-05-04,Open Men's 77 kg,Tommy Ferrari,74.1,65,69,-72,75,80,85,69,85,154
+East Coast Classic,2013-05-04,Open Men's 85 kg,Tyler Watkin,82.76,60,64,67,75,80,85,67,85,152
+East Coast Classic,2013-05-04,Open Women's 75 kg,Aubrie Luckenbaugh,73.13,63,66,68,78,81,83,68,83,151
+East Coast Classic,2013-05-04,Open Men's 94 kg,Ron Marine,85.59,60,63,66,75,80,85,66,85,151
+East Coast Classic,2013-05-04,Women's Masters (35-39) 69 kg,Angeline Brambley-Moyer,64.22,60,64,-68,76,81,86,64,86,150
+East Coast Classic,2013-05-04,Open Women's 75 kg,Cassie Haynes,74.87,59,62,65,79,82,85,65,85,150
+East Coast Classic,2013-05-04,Open Men's 85 kg,William Kang,84.4,60,63,-66,80,83,87,63,87,150
+East Coast Classic,2013-05-04,Open Men's 105 kg,Peter Hegeman,100.07,60,65,-67,70,-80,80,65,80,145
+East Coast Classic,2013-05-04,Open Men's 85 kg,Art Donahoe,78.5,57,59,-61,79,83,86,59,86,145
+East Coast Classic,2013-05-04,Open Women's 69 kg,Elizabeth Bartlett,68.83,-63,-63,63,80,-85,-89,63,80,143
+East Coast Classic,2013-05-04,Open Women's +75 Kg,Elisha Weckesser,91.01,55,59,-63,75,79,83,59,83,142
+East Coast Classic,2013-05-04,Open Men's 56 kg,Mustafa Moledina,55.7,52,57,60,75,80,-85,60,80,140
+East Coast Classic,2013-05-04,Open Women's 58 kg,Jennifer Varano,57.74,55,58,60,75,-79,79,60,79,139
+East Coast Classic,2013-05-04,Open Women's 58 kg,Dara May,58,54,57,60,75,79,-82,60,79,139
+East Coast Classic,2013-05-04,Open Women's 75 kg,Cait Finn,74.38,-62,62,-64,-77,77,-81,62,77,139
+East Coast Classic,2013-05-04,Open Men's 69 kg,Michael Stangis,68.76,51,55,57,70,75,78,57,78,135
+East Coast Classic,2013-05-04,Open Men's 77 kg,Rob Gueriera,73.6,55,-60,60,70,75,-80,60,75,135
+East Coast Classic,2013-05-04,Open Women's 69 kg,Lauren Fiske,69,56,59,-62,75,-78,-79,59,75,134
+East Coast Classic,2013-05-04,Open Men's 62 kg,Joshua Giorgio,60.76,52,60,-65,65,72,-77,60,72,132
+East Coast Classic,2013-05-04,Open Men's 62 kg,Sam Wootten,61.25,55,-60,-60,70,75,-80,55,75,130
+East Coast Classic,2013-05-04,Open Men's 85 kg,Koby Conz,81.37,50,55,60,60,65,70,60,70,130
+East Coast Classic,2013-05-04,Open Women's +75 Kg,Kelsey Rebert,82.3,49,53,55,65,70,75,55,75,130
+East Coast Classic,2013-05-04,Open Men's 77 kg,Michael Snyder,70.55,44,48,54,70,73,-80,54,73,127
+East Coast Classic,2013-05-04,Open Women's +75 Kg,Katherine Goodrich,78.43,48,52,-56,68,72,-75,52,72,124
+East Coast Classic,2013-05-04,Men's 13 Under Age Group 56 Kg,Matthew Stevens,54.35,48,51,53,63,67,70,53,70,123
+East Coast Classic,2013-05-04,Open Women's 58 kg,Sarah Henderson,57.83,50,53,56,60,64,67,56,67,123
+East Coast Classic,2013-05-04,Open Women's +75 Kg,stephanie Vincent,112.51,-55,55,-60,63,68,-73,55,68,123
+East Coast Classic,2013-05-04,Open Men's 77 kg,David Benson,69.5,52,55,-58,65,-68,68,55,68,123
+East Coast Classic,2013-05-04,Women's Masters (35-39) 63 kg,Tasha Christie,62.88,50,53,56,66,-70,-72,56,66,122
+East Coast Classic,2013-05-04,Open Men's 94 kg,David Bravo,93.65,-52,52,-55,65,67,70,52,70,122
+East Coast Classic,2013-05-04,Women's Masters (35-39) 63 kg,Dianna Scotece,59.09,53,56,-59,65,-69,-70,56,65,121
+East Coast Classic,2013-05-04,Open Women's 69 kg,Samantha Slaff,68.04,-50,50,-52,62,65,68,50,68,118
+East Coast Classic,2013-05-04,Open Women's 63 kg,Kimberly Magrini,62.69,-47,47,50,58,62,66,50,66,116
+East Coast Classic,2013-05-04,Women's Masters (40-44) +75 kg,Jeannine Robinson,98.44,48,50,52,59,62,63,52,63,115
+East Coast Classic,2013-05-04,Women's Masters (35-39) 58 kg,Sharon Moran,57.86,47,-49,50,60,62,-65,50,62,112
+East Coast Classic,2013-05-04,Open Women's 58 kg,Emily Avener,57.49,47,-49,50,59,-61,61,50,61,111
+East Coast Classic,2013-05-04,Men's 13 Under Age Group 50 Kg,Jakub Vogel,47.44,44,47,50,54,57,60,50,60,110
+East Coast Classic,2013-05-04,Open Men's+105 kg,Benjamin McCool,130.9,42,45,-50,57,60,65,45,65,110
+East Coast Classic,2013-05-04,Open Men's+105 kg,Christian Schilling,109.24,45,48,-52,-60,60,-65,48,60,108
+East Coast Classic,2013-05-04,Women's Masters (35-39) 53 kg,Lesha Vozobule,51.82,39,42,-45,58,61,-65,42,61,103
+East Coast Classic,2013-05-04,Open Men's 62 kg,Sean Gleason,59.96,40,43,46,50,53,56,46,56,102
+East Coast Classic,2013-05-04,Open Men's 56 kg,Jack Kearns,53.28,42,-45,45,57,-60,-62,45,57,102
+East Coast Classic,2013-05-04,Open Women's 58 kg,Monica Meese,56.64,39,42,-45,53,56,59,42,59,101
+East Coast Classic,2013-05-04,Open Women's 69 kg,Amanda Jo Brensinger,67.63,39,41,44,51,-54,57,44,57,101
+East Coast Classic,2013-05-04,Open Men's 56 kg,John Capper,55.08,40,-43,43,50,54,56,43,56,99
+East Coast Classic,2013-05-04,Women's Masters (50-54) 53 kg,JoAnne Sutkin,52.26,39,41,43,48,51,54,43,54,97
+East Coast Classic,2013-05-04,Open Women's 69 kg,Kat Madamba,65.21,-39,39,42,51,54,-57,42,54,96
+East Coast Classic,2013-05-04,Open Women's 75 kg,Meghan Ramos,74.78,40,-43,43,50,-53,53,43,53,96
+East Coast Classic,2013-05-04,Open Men's 56 kg,Devin Errico,48.87,34,37,40,43,46,50,40,50,90
+East Coast Classic,2013-05-04,Men's 14-15 Age Group 50 Kg,Hayden Du Pont,47.86,35,40,-42,42,46,50,40,50,90
+East Coast Classic,2013-05-04,Open Men's 94 kg,Tanner Geesey,93.46,32,36,40,40,45,50,40,50,90
+East Coast Classic,2013-05-04,Women's Masters (35-39) 63 kg,Madeline Mirasol,58.88,30,35,-40,50,55,-58,35,55,90
+East Coast Classic,2013-05-04,Open Women's 58 kg,Deborah Gorth,56.66,-39,39,-41,46,49,-52,39,49,88
+East Coast Classic,2013-05-04,Women's Masters (45-49) 69 kg,Lisa Mott,65.02,36,-39,-39,52,-54,-54,36,52,88
+East Coast Classic,2013-05-04,Open Women's 63 kg,Ashley Cooper,60.91,32,36,39,43,47,-50,39,47,86
+East Coast Classic,2013-05-04,Open Women's 53 kg,Stephanie Beaver,52.85,25,28,30,-41,41,45,30,45,75
+East Coast Classic,2013-05-04,Open Men's 56 kg,Ted Holleran,48.48,25,28,31,35,38,41,31,41,72
+East Coast Classic,2013-05-04,Women's 16-17 Age Group 75 kg,Cara Cramer,73.63,23,27,32,35,-39,40,32,40,72
+East Coast Classic,2013-05-04,Men's 13 Under Age Group 39kg,Grant Wertz,36.63,23,28,-35,35,40,42,28,42,70
+East Coast Classic,2013-05-04,Women's 16-17 Age Group 63 kg,Xuan Truong,58.4,25,28,-35,38,-41,-41,28,38,66
+East Coast Classic,2013-05-04,Men's 13 Under Age Group 35 Kg,Max Wootten,34.9,23,25,-27,28,31,35,25,35,60
+East Coast Classic,2013-05-04,Men's 13 Under Age Group 31 Kg,Brixton Maizels,21.95,12,14,15,12,14,-15,15,14,29
+East Coast Classic,2013-05-04,Open Men's 85 kg,Michael Tirrito,84.49,-140,140,-145,-180,-182,-182,140,0,0
+East Coast Classic,2013-05-04,Open Men's 94 kg,Harrison Wolff,92.96,-95,-98,-98,-110,110,-115,0,110,0
+East Coast Classic,2013-05-04,Open Men's 94 kg,Donald Simcox,91.7,-85,-85,85,-105,-105,-105,85,0,0
+East Coast Classic,2013-05-04,Open Men's 105 kg,Jeremy King,94,-105,-105,-105,-127,127,132,0,132,0
+East Coast Classic,2013-05-04,Open Men's 94 kg,Daniel Roderick,92.9,-110,-110,-110,150,-157,-157,0,150,0

--- a/event_data/US/79.csv
+++ b/event_data/US/79.csv
@@ -1,0 +1,9 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Dumbarton Invitational 2015-1,2015-01-17,Open Men's 105 kg,Ryan Stambaugh,104.9,100,104,104,130,135,141,104,141,245
+Dumbarton Invitational 2015-1,2015-01-17,Open Men's+105 kg,Dietrich Homer,131,98,102,106,127,132,0,106,132,238
+Dumbarton Invitational 2015-1,2015-01-17,Open Men's 94 kg,Eric Winter,85.5,75,81,83,84,88,88,83,88,171
+Dumbarton Invitational 2015-1,2015-01-17,Open Men's 85 kg,Henry Deimel,82.1,65,70,72,90,95,97,72,97,169
+Dumbarton Invitational 2015-1,2015-01-17,Open Men's 62 kg,Gabe Perman,61.1,52,52,56,65,70,75,56,75,131
+Dumbarton Invitational 2015-1,2015-01-17,Open Men's 69 kg,Michael Foley,68,34,36,39,50,53,55,39,55,94
+Dumbarton Invitational 2015-1,2015-01-17,Men's 13 Under Age Group 31 Kg,Brixton Maizels,26.1,19,21,21,23,25,25,21,25,46
+Dumbarton Invitational 2015-1,2015-01-17,Women's 13 Under Age Group 31kg,Parker Maizels,17.5,6,7,8,7,8,9,8,9,17

--- a/event_data/US/921.csv
+++ b/event_data/US/921.csv
@@ -1,0 +1,86 @@
+meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatch_lift_3,c&j_lift_1,c&j_lift_2,c&j_lift_3,best_snatch,best_c&j,total
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,William Carter,104.2,105,110,0,145,152,0,110,152,262
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Aaron Armstrong,77,108,113,117,135,140,145,117,145,262
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's+105 kg,John Durmon,114.2,100,105,107,140,145,154,107,154,261
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 85 kg,Juan Carlos Bassi Rodriguez,78.5,105,0,0,140,145,150,105,150,255
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Nathan Damron,76.6,0,105,0,132,137,141,105,141,246
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 94 kg,Doug Loden,92,0,0,105,135,0,0,105,135,240
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's+105 kg,Ian Gordy,122.6,99,103,105,132,0,0,105,132,237
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 69 kg,Luis Ortiz,67.6,0,101,0,130,135,0,101,135,236
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,Dan Ammon,94.8,95,100,105,120,125,131,105,131,236
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 94 kg,Jordan Jacobs,93.4,95,0,0,130,135,140,95,140,235
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 85 kg,Kevin Baribeau,84.1,89,93,98,125,0,0,98,125,223
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's+105 kg,Andrew Nichols,140.7,90,0,96,120,125,0,96,125,221
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Christian Hobbs,75.6,88,91,0,120,125,0,91,125,216
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 94 kg,John McGrady,85.9,91,96,0,110,115,120,96,120,216
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Trenton Clausen,70.3,88,98,0,106,0,0,98,106,204
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,Michael Stratton,102.4,80,85,0,100,110,117,85,117,202
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Robert Masson,75.1,0,81,90,92,100,110,90,110,200
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 85 kg,Mark Johnson,81.6,82,88,0,101,107,110,88,110,198
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's+105 kg,Clay Oliver,112.5,80,82,84,90,96,100,84,100,184
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,Brian Petroff,103.6,72,0,0,95,105,110,72,110,182
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Geoffrey Steinbrenner,73.9,73,0,77,100,103,0,77,103,180
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's+105 kg,Cortland Enriquez,105.1,0,73,77,90,98,0,77,98,175
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,Walter Warren,95.3,70,75,0,90,95,100,75,100,175
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,Patrick Lowe,98.7,70,77,0,80,88,90,77,90,167
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 94 kg,Jonathan May,91.5,65,70,75,80,87,92,75,92,167
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 62 kg,Jon Mance,59.3,65,71,0,80,90,0,71,90,161
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 62 kg,Jeffery Chestnut,61.7,65,70,0,83,0,88,70,88,158
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 69 kg,Mark Hummel,63.5,62,67,72,85,0,0,72,85,157
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 69 kg,Tyler Bridson,64.2,65,0,0,85,0,90,65,90,155
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Adim Chukwurah,75.3,55,65,0,70,80,86,65,86,151
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 62 kg,Aaron Powell,61.5,60,65,0,80,0,85,65,85,150
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Shane Thideman,75.7,61,64,67,79,82,0,67,82,149
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's+105 kg,Tyler Tillery,127.6,55,60,65,75,0,80,65,80,145
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 85 kg,Rene Rodriguez,78.4,61,64,67,70,73,75,67,75,142
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Greg Hilario,76.4,0,0,62,0,78,79,62,79,141
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Ryan Cunningham,72.4,50,56,0,76,80,83,56,83,139
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Celestino Perez,75.4,45,50,55,65,70,78,55,78,133
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 94 kg,Clymer Law,93.3,54,58,0,75,0,0,58,75,133
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 94 kg,Curtis Hilkemann,90.3,50,55,57,65,70,74,57,74,131
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 69 Kg,Dean Scicchitano,68.5,50,55,0,70,0,75,55,75,130
+Onaga Brick Road Junior & Open,2013-05-04,Open Women's 53 kg,Margaret Lee,50.5,50,53,55,65,68,70,55,70,125
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,Eli Rhoades,73.1,45,50,54,65,70,0,54,70,124
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group 69 kg,Rapulu Okolo,64.2,48,52,55,63,67,0,55,67,122
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 69 kg,Seth Smith,67.5,45,50,0,65,70,0,50,70,120
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 77 kg,James Mashburn,74.6,45,0,50,60,64,66,50,66,116
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group 48 kg,Olivia Perez,48,46,49,50,60,63,65,50,65,115
+Onaga Brick Road Junior & Open,2013-05-04,Open Women's 63 kg,Leslie Shafer,61.8,50,53,0,61,0,0,53,61,114
+Onaga Brick Road Junior & Open,2013-05-04,Open Women's 69 kg,Anna Clayton,64.3,42,45,48,59,62,65,48,65,113
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group 53 kg,Hannah Damron,53,47,50,0,61,0,0,50,61,111
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group 58 kg,Macy Pilgrim,56.8,45,0,0,62,0,65,45,65,110
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group 69 kg,Isabelle Jennings,65.2,50,0,0,60,0,0,50,60,110
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 56 kg,Braxton Duran,53.6,40,0,45,55,60,0,45,60,105
+Onaga Brick Road Junior & Open,2013-05-04,Women's Masters (35-39) 58 kg,Kym Van Zanten,57.2,0,41,0,55,60,63,41,63,104
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 62 kg,Andrew Schovanec,60.6,40,0,0,55,62,0,40,62,102
+Onaga Brick Road Junior & Open,2013-05-04,Women's 13 Under Age Group +58 Kg,Malanna Boyd,68.7,0,41,0,54,58,60,41,60,101
+Onaga Brick Road Junior & Open,2013-05-04,Women's 16-17 Age Group 75 kg,Brittany Ollenborger,74.9,40,42,0,0,55,56,42,56,98
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 105 kg,Chris Huckabay,101.3,0,40,43,45,50,55,43,55,98
+Onaga Brick Road Junior & Open,2013-05-04,Open Women's 63 kg,Jenna Tretyak,63,0,40,42,0,0,53,42,53,95
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group +69 kg,Madison Estopare,77.8,0,38,40,48,51,0,40,51,91
+Onaga Brick Road Junior & Open,2013-05-04,Women's 16-17 Age Group 53 kg,Adrian Sanders,53,36,39,0,44,48,51,39,51,90
+Onaga Brick Road Junior & Open,2013-05-04,Women's 16-17 Age Group 63 kg,Heather White,61.8,36,38,41,45,47,49,41,49,90
+Onaga Brick Road Junior & Open,2013-05-04,Open Women's 69 kg,Amy Deluca,67.1,32,36,0,45,50,0,36,50,86
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 44kg,Ian Estopare,41.8,35,0,0,42,45,47,35,47,82
+Onaga Brick Road Junior & Open,2013-05-04,Women's 16-17 Age Group 53 kg,Sydnie Lundy,53,30,31,32,40,42,45,32,45,77
+Onaga Brick Road Junior & Open,2013-05-04,Men's 14-15 Age Group 62 kg,Douglas Bassi Rodriguez,61,25,30,0,40,45,0,30,45,75
+Onaga Brick Road Junior & Open,2013-05-04,Open Women's 53 kg,Alyssa Soto,52.9,30,0,32,0,37,40,32,40,72
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 50 Kg,Currin Harp,45.2,25,30,32,34,40,0,32,40,72
+Onaga Brick Road Junior & Open,2013-05-04,Men's 14-15 Age Group 50 Kg,Celestino Perez,47.9,25,0,30,35,40,0,30,40,70
+Onaga Brick Road Junior & Open,2013-05-04,Men's 14-15 Age Group 44kg,MaLieke Wright,42.6,20,23,28,25,30,35,28,35,63
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 69 Kg,Jared Boatwright,64.1,20,25,26,35,0,0,26,35,61
+Onaga Brick Road Junior & Open,2013-05-04,Men's 14-15 Age Group 69 kg,James Hartley,67.2,20,0,25,25,30,35,25,35,60
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 50 Kg,Spencer Carr,44.7,20,22,0,30,34,35,22,35,57
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 62 kg,Kevin Moppin,59.3,15,20,25,20,25,30,25,30,55
+Onaga Brick Road Junior & Open,2013-05-04,Men's 14-15 Age Group 50 Kg,Dominique Riggins,45.4,0,20,23,25,29,0,23,29,52
+Onaga Brick Road Junior & Open,2013-05-04,Men's 14-15 Age Group 77 kg,Justin Mohr,72.6,15,20,0,20,25,30,20,30,50
+Onaga Brick Road Junior & Open,2013-05-04,Women's 13 Under Age Group 31kg,Abigail Flickner,26.2,16,18,0,0,25,27,18,27,45
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group +69 Kg,Nate Carmichael,77.5,15,17,20,20,23,25,20,25,45
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 62 kg,Isaac Ruble,60.4,15,18,20,20,23,25,20,25,45
+Onaga Brick Road Junior & Open,2013-05-04,Women's 13 Under Age Group 35kg,Sidnee Carr,34.3,17,18,0,23,24,26,18,26,44
+Onaga Brick Road Junior & Open,2013-05-04,Women's 13 Under Age Group 35kg,Jessica Bridson,32.6,16,18,0,24,26,0,18,26,44
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 44kg,Lester Jennings,42.6,12,17,20,17,20,23,20,23,43
+Onaga Brick Road Junior & Open,2013-05-04,Women's 14-15 Age Group 53 kg,Jayda Lowe,48.4,15,17,18,20,22,24,18,24,42
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 31 Kg,Connor Gunderson,29,14,0,0,20,0,0,14,20,34
+Onaga Brick Road Junior & Open,2013-05-04,Men's 13 Under Age Group 31 Kg,Xavier Perez,20.6,5,7,0,7,9,10,7,10,17
+Onaga Brick Road Junior & Open,2013-05-04,Open Men's 85 kg,Christian Hannah,83.7,80,87,91,0,0,0,91,0,0


### PR DESCRIPTION

Follow-up to #536. This adds every US event that has results published on Sport80 but no CSV in event_data/US, minus five test events.

## The event listing endpoint has an issue

It seems that /api/events/table/data paginates without a deterministic sort, so rows move between pages while you navigate them. Some events come back on two pages and others never show up at all.

Two consecutive full sweeps of 2012 through 2026 gave me 7,118 and 7,099 event IDs. Both runs matched the API's own total on every page, so neither looked broken at first glance.

Asking for one big page per year (l=3000) skips pagination and is stable. Two runs in this method returned an identical 7,441 events, about 300 more than the paginated walk was finding. The scraper may want the same change, since that drift drops events on any run, not just the December ones. (Fun Fact--Indeed.com and some other job aggregator sites have this same issue)

## 97 files, 3,064 results

They run from 2013 to 2026. December is heavy again (21 from 2024, 15 from 2019), which fits the pattern in #536, but the gaps reach back a lot further than I expected.

Six of the 97 are from this month and the most recent is dated yesterday, so the next scheduled run may pick those up on its own. 

## Five Test Events

| id | name |
|----|------|
| 2497 | AIGROUP TESTING - DISREGARD |
| 2897 | test |
| 3540 | Test Meet |
| 3541 | TEST** 2018 American Open Finals |
| 4033 | Test LWC Event2 |

## Some Later-Added Results

Ten of these hold one result each, and a few reuse the name of an event already in the database, so I checked before including them. Jamie Hegg (event 4942, "The Nike 2021 North American Open Series 2") does not appear in 4736.csv, and Jose Cruz Richardson (event 5794, "2022 North American Open Finals (b)") does not appear in 5611.csv. They look like results added after the fact, same as 6477.csv, which is already in the repo.

## Same method as #536

Pulled from /api/events/{id}/table/data, one page per event, with a check that the row count matches the reported total.

I also went back and re-pulled 6172 and 6656 from #536 without pagination to make sure the shuffle above hadn't corrupted them. Both match the committed files exactly. The per-event results endpoint orders consistently, it's only the listing that moves around.

scripts/check_db.py US passes.
