### PR TITLE
Change Jun Yu to Zhen (Jun) Yu

### DIFF
--- a/event_data/US/7327.csv
+++ b/event_data/US/7327.csv
@@ -89,7 +89,7 @@ meet,date,age_category,lifter,body_weight_(kg),snatch_lift_1,snatch_lift_2,snatc
 2026 Cap City Open,2026-04-26,Junior Women's 69kg,Shania warmzyary,63.55,40,-45,-47,49,52,-55,40,52,92
 2026 Cap City Open,2026-04-26,Women's Masters (40-44) 63kg,Jillian Humphreys,62.25,37,40,-43,50,-53,-54,40,50,90
 2026 Cap City Open,2026-04-26,Open Women's 86+kg,Riley Benecke,121.15,38,41,-44,-48,49,-54,41,49,90
-2026 Cap City Open,2026-04-26,Open Women's 58kg,Jun Yu,53.95,31,33,35,42,-45,-45,35,42,77
+2026 Cap City Open,2026-04-26,Open Women's 58kg,Zhen (Jun) Yu,53.95,31,33,35,42,-45,-45,35,42,77
 2026 Cap City Open,2026-04-26,Open Women's 53kg,Caitlin Strong,51.35,29,31,-33,35,38,41,31,41,72
 2026 Cap City Open,2026-04-26,Open Women's 77kg,Miquela Apicella,70.65,22,25,28,32,36,40,28,40,68
 2026 Cap City Open,2026-04-26,Men's 13 Under Age Group 40kg,Adam Sowayan,36.5,25,27,-29,-30,30,33,27,33,60


### PR DESCRIPTION
Lifter name updated in USAW system, manually correct old record to use new name (new name used in https://github.com/euanwm/OpenWeightlifting/blob/a0146758ff31b759c141956d73c243de26c90545/event_data/US/7448.csv#L45 )